### PR TITLE
Make recipe registry names and aliases auto-generate

### DIFF
--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/draconicevolution/Fusion.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/draconicevolution/Fusion.java
@@ -15,7 +15,7 @@ import org.jetbrains.annotations.Nullable;
 public class Fusion extends VirtualizedRegistry<IFusionRecipe> {
 
     public Fusion() {
-        super("Fusion", "fusion");
+        super();
     }
 
     @Override

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/AlloySmelter.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/AlloySmelter.java
@@ -33,7 +33,7 @@ public class AlloySmelter extends VirtualizedRegistry<IManyToOneRecipe> {
     private Set<IManyToOneRecipe> removalQueue;
 
     public AlloySmelter() {
-        super("AlloySmelter", "alloysmelter", "alloy_smelter", "Alloying", "alloying");
+        super(VirtualizedRegistry.generateAliases("Alloying"));
     }
 
     public RecipeBuilder recipeBuilder() {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/Enchanter.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/Enchanter.java
@@ -23,7 +23,7 @@ import java.util.List;
 public class Enchanter extends VirtualizedRegistry<EnchanterRecipe> {
 
     public Enchanter() {
-        super("Enchanter", "enchanter");
+        super();
     }
 
     public void add(EnchanterRecipe recipe) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/FluidCoolant.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/FluidCoolant.java
@@ -13,7 +13,7 @@ import org.jetbrains.annotations.Nullable;
 public class FluidCoolant extends VirtualizedRegistry<IFluidCoolant> {
 
     public FluidCoolant() {
-        super("FluidCoolant", "fluidcoolant", "fluid_coolant", "CombustionCoolant", "combustion_coolant");
+        super(VirtualizedRegistry.generateAliases("CombustionCoolant"));
     }
 
     public void addCoolant(FluidStack fluidStack, float degreesPerMb) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/FluidFuel.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/FluidFuel.java
@@ -13,7 +13,7 @@ import org.jetbrains.annotations.Nullable;
 public class FluidFuel extends VirtualizedRegistry<IFluidFuel> {
 
     public FluidFuel() {
-        super("FluidFuel", "fluidfuel", "fluid_fuel", "CombustionFuel", "combustion_fuel");
+        super(VirtualizedRegistry.generateAliases("CombustionFuel"));
     }
 
     public void addFuel(FluidStack fluidStack, int rfPerCycle, int totalBurnTime) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/SagMill.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/SagMill.java
@@ -21,7 +21,7 @@ import org.jetbrains.annotations.Nullable;
 public class SagMill extends VirtualizedRegistry<Recipe> {
 
     public SagMill() {
-        super("SagMill", "sagmill", "sag_mill", "SAGMill", "Sag", "sag");
+        super("SAGMill", "Sag", "sag");
     }
 
     public RecipeBuilder recipeBuilder() {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/SliceNSplice.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/SliceNSplice.java
@@ -23,7 +23,7 @@ import java.util.List;
 public class SliceNSplice extends VirtualizedRegistry<IManyToOneRecipe> {
 
     public SliceNSplice() {
-        super("SliceNSplice", "slice_n_splice", "SliceAndSplice", "slice_and_splice");
+        super(VirtualizedRegistry.generateAliases("SliceAndSplice"));
     }
 
     public RecipeBuilder recipeBuilder() {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/SoulBinder.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/SoulBinder.java
@@ -24,7 +24,7 @@ import java.util.List;
 public class SoulBinder extends VirtualizedRegistry<ISoulBinderRecipe> {
 
     public SoulBinder() {
-        super("SoulBinder", "soulbinder", "soul_binder");
+        super();
     }
 
     public RecipeBuilder recipeBuilder() {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/Tank.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/Tank.java
@@ -21,7 +21,7 @@ import java.util.List;
 public class Tank extends VirtualizedRegistry<TankMachineRecipe> {
 
     public Tank() {
-        super("Tank", "tank");
+        super();
     }
 
     public void addFill(IIngredient input, FluidStack inputFluid, ItemStack output) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/Vat.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/Vat.java
@@ -24,7 +24,7 @@ import java.util.List;
 public class Vat extends VirtualizedRegistry<VatRecipe> {
 
     public Vat() {
-        super("Vat", "vat");
+        super();
     }
 
     public RecipeBuilder recipeBuilder() {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/Centrifuge.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/Centrifuge.java
@@ -19,7 +19,7 @@ import java.util.List;
 public class Centrifuge extends VirtualizedRegistry<MachineRecipe<IRecipeInput, Collection<ItemStack>>> {
 
     public Centrifuge() {
-        super("ThermalCentrifuge", "thermalcentrifuge", "Centrifuge", "centrifuge");
+        super(VirtualizedRegistry.generateAliases("ThermalCentrifuge"));
     }
 
     @Override

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/MetalFormer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/MetalFormer.java
@@ -17,7 +17,7 @@ import java.util.*;
 public class MetalFormer extends VirtualizedRegistry<MetalFormer.MetalFormerRecipe> {
 
     public MetalFormer() {
-        super("MetalFormer", "metalformer");
+        super();
     }
 
     @Override

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/OreWasher.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/OreWasher.java
@@ -19,7 +19,7 @@ import java.util.List;
 public class OreWasher extends VirtualizedRegistry<MachineRecipe<IRecipeInput, Collection<ItemStack>>> {
 
     public OreWasher() {
-        super("OreWasher", "orewasher", "OreWashingPlant", "orewashingplant");
+        super(VirtualizedRegistry.generateAliases("OreWashingPlant"));
     }
 
     @Override

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/classic/Canner.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/classic/Canner.java
@@ -27,7 +27,7 @@ public class Canner extends VirtualizedRegistry<Canner.CanningRecipe> {
     private static Map<Integer, List<ItemWithMeta>> idToItems;
 
     public Canner() {
-        super("Canner", "canner");
+        super();
         idToItems = ((ClassicCanningMachineRegistryAccessor) ClassicRecipes.canningMachine).getIdToItems();
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/classic/ClassicElectrolyzer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/classic/ClassicElectrolyzer.java
@@ -12,7 +12,7 @@ import net.minecraft.item.ItemStack;
 public class ClassicElectrolyzer extends VirtualizedRegistry<ClassicElectrolyzer.ElectrolyzerRecipe> {
 
     public ClassicElectrolyzer() {
-        super("Electrolyzer", "electrolyzer");
+        super(false, VirtualizedRegistry.generateAliases("Electrolyzer"));
     }
 
     @Override

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/classic/LiquidFuelGenerator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/classic/LiquidFuelGenerator.java
@@ -14,7 +14,7 @@ import java.util.Map;
 public class LiquidFuelGenerator extends VirtualizedRegistry<LiquidFuelGenerator.LFGRecipe> {
 
     public LiquidFuelGenerator() {
-        super("FluidGenerator", "fluidgenerator");
+        super(VirtualizedRegistry.generateAliases("FluidGenerator"));
     }
 
     @Override

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/classic/RareEarthExtractor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/classic/RareEarthExtractor.java
@@ -12,7 +12,7 @@ import net.minecraft.item.ItemStack;
 public class RareEarthExtractor extends VirtualizedRegistry<IRareEarthExtractorRecipeList.EarthEntry> {
 
     public RareEarthExtractor() {
-        super("RareEarthExtractor", "rareearthextractor");
+        super();
     }
 
     @Override

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/classic/Sawmill.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/classic/Sawmill.java
@@ -15,7 +15,7 @@ import net.minecraft.item.ItemStack;
 public class Sawmill extends VirtualizedRegistry<IMachineRecipeList.RecipeEntry> {
 
     public Sawmill() {
-        super("Sawmill", "sawmill");
+        super();
     }
 
     @Override

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/exp/BlastFurnace.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/exp/BlastFurnace.java
@@ -21,7 +21,7 @@ import java.util.List;
 public class BlastFurnace extends VirtualizedRegistry<MachineRecipe<IRecipeInput, Collection<ItemStack>>> {
 
     public BlastFurnace() {
-        super("BlastFurnace", "blastfurnace");
+        super();
     }
 
     @Override

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/exp/BlockCutter.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/exp/BlockCutter.java
@@ -16,7 +16,7 @@ import java.util.*;
 public class BlockCutter extends VirtualizedRegistry<MachineRecipe<IRecipeInput, Collection<ItemStack>>> {
 
     public BlockCutter() {
-        super("BlockCutter", "blockcutter", "cutter");
+        super(VirtualizedRegistry.generateAliases("Cutter"));
     }
 
     @Override

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/exp/Compressor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/exp/Compressor.java
@@ -17,7 +17,7 @@ import java.util.*;
 public class Compressor extends VirtualizedRegistry<MachineRecipe<IRecipeInput, Collection<ItemStack>>> {
 
     public Compressor() {
-        super("Compressor", "compressor");
+        super();
     }
 
     @Override

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/exp/Electrolyzer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/exp/Electrolyzer.java
@@ -21,7 +21,7 @@ public class Electrolyzer extends VirtualizedRegistry<Pair<String, IElectrolyzer
     private static final Map<String, IElectrolyzerRecipeManager.ElectrolyzerRecipe> fluidMap = ((ElectrolyzerRecipeManagerAccessor) Recipes.electrolyzer).getFluidMap();
 
     public Electrolyzer() {
-        super("Electrolyzer", "electrolyzer");
+        super();
     }
 
     @Override

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/exp/Extractor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/exp/Extractor.java
@@ -17,7 +17,7 @@ import java.util.*;
 public class Extractor extends VirtualizedRegistry<MachineRecipe<IRecipeInput, Collection<ItemStack>>> {
 
     public Extractor() {
-        super("Extractor", "extractor");
+        super();
     }
 
     @Override

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/exp/Fermenter.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/exp/Fermenter.java
@@ -18,7 +18,7 @@ public class Fermenter extends VirtualizedRegistry<Pair<String, IFermenterRecipe
     private static final Map<String, IFermenterRecipeManager.FermentationProperty> fluidMap = ((FermenterRecipeManagerAccessor) Recipes.fermenter).getFluidMap();
 
     public Fermenter() {
-        super("Fermenter", "fermenter");
+        super();
     }
 
     @Override

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/exp/FluidCanner.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/exp/FluidCanner.java
@@ -20,7 +20,7 @@ import java.util.List;
 public class FluidCanner extends VirtualizedRegistry<MachineRecipe<ICannerEnrichRecipeManager.Input, FluidStack>> {
 
     public FluidCanner() {
-        super("FluidCanner", "fluidcanner");
+        super();
     }
 
     @Override

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/exp/FluidGenerator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/exp/FluidGenerator.java
@@ -17,7 +17,7 @@ public class FluidGenerator extends VirtualizedRegistry<Pair<String, ISemiFluidF
     private static final Map<String, ISemiFluidFuelManager.FuelProperty> fluidMap = ((SemiFluidFuelManagerAccessor) Recipes.semiFluidGenerator).getFuelProperties();
 
     public FluidGenerator() {
-        super("SemiFluidGenerator", "FluidGenerator", "semifluidgenerator", "fluidgenerator");
+        super(VirtualizedRegistry.generateAliases("SemiFluidGenerator"));
     }
 
     @Override

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/exp/FluidHeater.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/exp/FluidHeater.java
@@ -16,7 +16,7 @@ import java.util.Map;
 public class FluidHeater extends VirtualizedRegistry<Pair<String, IFluidHeatManager.BurnProperty>> {
 
     public FluidHeater() {
-        super("FluidHeater", "Firebox", "fluidheater", "firebox");
+        super(VirtualizedRegistry.generateAliases("Firebox"));
     }
 
     @Override

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/exp/LiquidHeatExchanger.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/exp/LiquidHeatExchanger.java
@@ -19,7 +19,7 @@ public class LiquidHeatExchanger extends VirtualizedRegistry<LiquidHeatExchanger
     private static final Map<String, ILiquidHeatExchangerManager.HeatExchangeProperty> cooldownMap = Recipes.liquidCooldownManager.getHeatExchangeProperties();
 
     public LiquidHeatExchanger() {
-        super("LiquidHeatExchanger", "liquidheatexchanger", "HeatExchanger", "heatexchanger");
+        super(VirtualizedRegistry.generateAliases("HeatExchanger"));
     }
 
     @Override

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/exp/Macerator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/exp/Macerator.java
@@ -17,7 +17,7 @@ import java.util.*;
 public class Macerator extends VirtualizedRegistry<MachineRecipe<IRecipeInput, Collection<ItemStack>>> {
 
     public Macerator() {
-        super("Macerator", "macerator");
+        super();
     }
 
     @Override

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/exp/Recycler.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/exp/Recycler.java
@@ -18,7 +18,7 @@ public class Recycler extends VirtualizedRegistry<IRecipeInput> {
     private static final Object dummy = new Object();
 
     public Recycler() {
-        super("Recycler", "recycler");
+        super();
     }
 
     @Override

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/exp/Scrapbox.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/exp/Scrapbox.java
@@ -13,7 +13,7 @@ import java.util.List;
 public class Scrapbox extends VirtualizedRegistry<Object> {
 
     public Scrapbox() {
-        super("Scrapbox", "scrapbox");
+        super();
     }
 
     @SuppressWarnings("all")

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/exp/SolidCanner.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/exp/SolidCanner.java
@@ -19,7 +19,7 @@ import java.util.List;
 public class SolidCanner extends VirtualizedRegistry<MachineRecipe<ICannerBottleRecipeManager.Input, ItemStack>> {
 
     public SolidCanner() {
-        super("SolidCanner", "solidcanner");
+        super();
     }
 
     @Override

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/AlloyKiln.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/AlloyKiln.java
@@ -17,7 +17,7 @@ import java.util.List;
 public class AlloyKiln extends VirtualizedRegistry<AlloyRecipe> {
 
     public AlloyKiln() {
-        super("AlloyKiln", "alloykiln");
+        super();
     }
 
     public RecipeBuilder recipeBuilder() {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/ArcFurnace.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/ArcFurnace.java
@@ -21,7 +21,7 @@ import java.util.List;
 public class ArcFurnace extends VirtualizedRegistry<ArcFurnaceRecipe> {
 
     public ArcFurnace() {
-        super("ArcFurnace", "arcfurnace", "arc_furnace");
+        super();
     }
 
     public RecipeBuilder recipeBuilder() {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/BlastFurnace.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/BlastFurnace.java
@@ -16,7 +16,7 @@ import java.util.List;
 public class BlastFurnace extends VirtualizedRegistry<BlastFurnaceRecipe> {
 
     public BlastFurnace() {
-        super("BlastFurnace", "blastfurnace", "blast_furnace");
+        super();
     }
 
     public static RecipeBuilder recipeBuilder() {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/BlueprintCrafting.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/BlueprintCrafting.java
@@ -21,7 +21,7 @@ import java.util.List;
 public class BlueprintCrafting extends VirtualizedRegistry<BlueprintCraftingRecipe> {
 
     public BlueprintCrafting() {
-        super("Blueprint", "blueprint");
+        super(VirtualizedRegistry.generateAliases("Blueprint"));
     }
 
     public static RecipeBuilder recipeBuilder() {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/BottlingMachine.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/BottlingMachine.java
@@ -16,7 +16,7 @@ import org.jetbrains.annotations.Nullable;
 public class BottlingMachine extends VirtualizedRegistry<BottlingMachineRecipe> {
 
     public BottlingMachine() {
-        super("Bottling", "bottling");
+        super(VirtualizedRegistry.generateAliases("Bottling"));
     }
 
     public static RecipeBuilder recipeBuilder() {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/CokeOven.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/CokeOven.java
@@ -16,7 +16,7 @@ import java.util.List;
 public class CokeOven extends VirtualizedRegistry<CokeOvenRecipe> {
 
     public CokeOven() {
-        super("CokeOven", "cokeoven");
+        super();
     }
 
     public static RecipeBuilder recipeBuilder() {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/Crusher.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/Crusher.java
@@ -16,7 +16,7 @@ import java.util.List;
 public class Crusher extends VirtualizedRegistry<CrusherRecipe> {
 
     public Crusher() {
-        super("Crusher", "crusher");
+        super();
     }
 
     public static RecipeBuilder recipeBuilder() {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/Fermenter.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/Fermenter.java
@@ -17,7 +17,7 @@ import javax.annotation.Nonnull;
 public class Fermenter extends VirtualizedRegistry<FermenterRecipe> {
 
     public Fermenter() {
-        super("Fermenter", "fermenter");
+        super();
     }
 
     public static RecipeBuilder recipeBuilder() {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/MetalPress.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/MetalPress.java
@@ -19,7 +19,7 @@ import java.util.List;
 public class MetalPress extends VirtualizedRegistry<MetalPressRecipe> {
 
     public MetalPress() {
-        super("MetalPress", "metalpress");
+        super();
     }
 
     @Override

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/Mixer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/Mixer.java
@@ -22,7 +22,7 @@ import java.util.List;
 public class Mixer extends VirtualizedRegistry<MixerRecipe> {
 
     public Mixer() {
-        super("Mixer", "mixer");
+        super();
     }
 
     public static RecipeBuilder recipeBuilder() {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/Refinery.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/Refinery.java
@@ -13,7 +13,7 @@ import org.jetbrains.annotations.Nullable;
 public class Refinery extends VirtualizedRegistry<RefineryRecipe> {
 
     public Refinery() {
-        super("Refinery", "refinery");
+        super();
     }
 
     public static RecipeBuilder recipeBuilder() {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/Squeezer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/Squeezer.java
@@ -17,7 +17,7 @@ import javax.annotation.Nonnull;
 public class Squeezer extends VirtualizedRegistry<SqueezerRecipe> {
 
     public Squeezer() {
-        super("Squeezer", "squeezer");
+        super();
     }
 
     public static RecipeBuilder recipeBuilder() {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/ChemicalInfuser.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/ChemicalInfuser.java
@@ -11,7 +11,7 @@ import mekanism.common.recipe.machines.ChemicalInfuserRecipe;
 public class ChemicalInfuser extends VirtualizedMekanismRegistry<ChemicalInfuserRecipe> {
 
     public ChemicalInfuser() {
-        super(RecipeHandler.Recipe.CHEMICAL_INFUSER, "ChemicalInfuser", "chemical_infuser");
+        super(RecipeHandler.Recipe.CHEMICAL_INFUSER);
     }
 
     public ChemicalInfuserRecipe add(GasStack leftInput, GasStack rightInput, GasStack output) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/ChemicalOxidizer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/ChemicalOxidizer.java
@@ -4,6 +4,7 @@ import com.cleanroommc.groovyscript.api.IIngredient;
 import com.cleanroommc.groovyscript.compat.mods.mekanism.recipe.VirtualizedMekanismRegistry;
 import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
 import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
 import mekanism.api.gas.GasStack;
 import mekanism.common.recipe.RecipeHandler;
 import mekanism.common.recipe.inputs.ItemStackInput;
@@ -13,7 +14,7 @@ import net.minecraft.item.ItemStack;
 public class ChemicalOxidizer extends VirtualizedMekanismRegistry<OxidationRecipe> {
 
     public ChemicalOxidizer() {
-        super(RecipeHandler.Recipe.CHEMICAL_OXIDIZER, "ChemicalOxidizer", "Oxidizer", "chemical_oxidizer", "oxidizer");
+        super(RecipeHandler.Recipe.CHEMICAL_OXIDIZER, VirtualizedRegistry.generateAliases("Oxidizer"));
     }
 
     public OxidationRecipe add(IIngredient ingredient, GasStack output) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Combiner.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Combiner.java
@@ -12,7 +12,7 @@ import net.minecraft.item.ItemStack;
 public class Combiner extends VirtualizedMekanismRegistry<CombinerRecipe> {
 
     public Combiner() {
-        super(RecipeHandler.Recipe.COMBINER, "Combiner", "combiner");
+        super(RecipeHandler.Recipe.COMBINER);
     }
 
     public CombinerRecipe add(IIngredient ingredient, ItemStack extra, ItemStack output) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Crusher.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Crusher.java
@@ -12,7 +12,7 @@ import net.minecraft.item.ItemStack;
 public class Crusher extends VirtualizedMekanismRegistry<CrusherRecipe> {
 
     public Crusher() {
-        super(RecipeHandler.Recipe.CRUSHER, "Crusher", "crusher");
+        super(RecipeHandler.Recipe.CRUSHER);
     }
 
     public CrusherRecipe add(IIngredient ingredient, ItemStack output) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Crystallizer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Crystallizer.java
@@ -12,7 +12,7 @@ import net.minecraft.item.ItemStack;
 public class Crystallizer extends VirtualizedMekanismRegistry<CrystallizerRecipe> {
 
     public Crystallizer() {
-        super(RecipeHandler.Recipe.CHEMICAL_CRYSTALLIZER, "Crystallizer", "crystallizer");
+        super(RecipeHandler.Recipe.CHEMICAL_CRYSTALLIZER);
     }
 
     public CrystallizerRecipe add(GasStack input, ItemStack output) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/DissolutionChamber.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/DissolutionChamber.java
@@ -4,6 +4,7 @@ import com.cleanroommc.groovyscript.api.IIngredient;
 import com.cleanroommc.groovyscript.compat.mods.mekanism.recipe.VirtualizedMekanismRegistry;
 import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
 import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
 import mekanism.api.gas.GasStack;
 import mekanism.common.recipe.RecipeHandler;
 import mekanism.common.recipe.inputs.ItemStackInput;
@@ -13,7 +14,7 @@ import net.minecraft.item.ItemStack;
 public class DissolutionChamber extends VirtualizedMekanismRegistry<DissolutionRecipe> {
 
     public DissolutionChamber() {
-        super(RecipeHandler.Recipe.CHEMICAL_DISSOLUTION_CHAMBER, "DissolutionChamber", "Dissolver", "dissolution_chamber", "dissolver");
+        super(RecipeHandler.Recipe.CHEMICAL_DISSOLUTION_CHAMBER, VirtualizedRegistry.generateAliases("Dissolver"));
     }
 
     public DissolutionRecipe add(IIngredient ingredient, GasStack output) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/EnrichmentChamber.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/EnrichmentChamber.java
@@ -4,6 +4,7 @@ import com.cleanroommc.groovyscript.api.IIngredient;
 import com.cleanroommc.groovyscript.compat.mods.mekanism.recipe.VirtualizedMekanismRegistry;
 import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
 import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
 import mekanism.common.recipe.RecipeHandler;
 import mekanism.common.recipe.inputs.ItemStackInput;
 import mekanism.common.recipe.machines.EnrichmentRecipe;
@@ -12,7 +13,7 @@ import net.minecraft.item.ItemStack;
 public class EnrichmentChamber extends VirtualizedMekanismRegistry<EnrichmentRecipe> {
 
     public EnrichmentChamber() {
-        super(RecipeHandler.Recipe.ENRICHMENT_CHAMBER, "EnrichmentChamber", "Enricher", "enrichment_chamber", "enricher");
+        super(RecipeHandler.Recipe.ENRICHMENT_CHAMBER, VirtualizedRegistry.generateAliases("Enricher"));
     }
 
     public EnrichmentRecipe add(IIngredient ingredient, ItemStack output) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/InjectionChamber.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/InjectionChamber.java
@@ -4,6 +4,7 @@ import com.cleanroommc.groovyscript.api.IIngredient;
 import com.cleanroommc.groovyscript.compat.mods.mekanism.recipe.VirtualizedMekanismRegistry;
 import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
 import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
 import mekanism.api.gas.GasStack;
 import mekanism.common.recipe.RecipeHandler;
 import mekanism.common.recipe.inputs.AdvancedMachineInput;
@@ -13,7 +14,7 @@ import net.minecraft.item.ItemStack;
 public class InjectionChamber extends VirtualizedMekanismRegistry<InjectionRecipe> {
 
     public InjectionChamber() {
-        super(RecipeHandler.Recipe.CHEMICAL_INJECTION_CHAMBER, "InjectionChamber", "injection_chamber", "Injector", "injector");
+        super(RecipeHandler.Recipe.CHEMICAL_INJECTION_CHAMBER, VirtualizedRegistry.generateAliases("Injector"));
     }
 
     public InjectionRecipe add(IIngredient ingredient, GasStack gasInput, ItemStack output) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/MetallurgicInfuser.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/MetallurgicInfuser.java
@@ -14,7 +14,7 @@ import net.minecraft.item.ItemStack;
 public class MetallurgicInfuser extends VirtualizedMekanismRegistry<MetallurgicInfuserRecipe> {
 
     public MetallurgicInfuser() {
-        super(RecipeHandler.Recipe.METALLURGIC_INFUSER, "MetallurgicInfuser", "metallurgic_infuser");
+        super(RecipeHandler.Recipe.METALLURGIC_INFUSER);
     }
 
     public MetallurgicInfuserRecipe add(IIngredient ingredient, String infuseType, int infuseAmount, ItemStack output) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/OsmiumCompressor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/OsmiumCompressor.java
@@ -14,7 +14,7 @@ import net.minecraft.item.ItemStack;
 public class OsmiumCompressor extends VirtualizedMekanismRegistry<OsmiumCompressorRecipe> {
 
     public OsmiumCompressor() {
-        super(RecipeHandler.Recipe.OSMIUM_COMPRESSOR, "OsmiumCompressor", "osmium_compressor");
+        super(RecipeHandler.Recipe.OSMIUM_COMPRESSOR);
     }
 
     public OsmiumCompressorRecipe add(IIngredient ingredient, GasStack gasInput, ItemStack output) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/PressurizedReactionChamber.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/PressurizedReactionChamber.java
@@ -21,7 +21,7 @@ import java.util.List;
 public class PressurizedReactionChamber extends VirtualizedMekanismRegistry<PressurizedRecipe> {
 
     public PressurizedReactionChamber() {
-        super(RecipeHandler.Recipe.PRESSURIZED_REACTION_CHAMBER, "PressurizedReactionChamber", "pressurize_reaction_chamber", "PRC");
+        super(RecipeHandler.Recipe.PRESSURIZED_REACTION_CHAMBER, "PRC");
     }
 
     public RecipeBuilder recipeBuilder() {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/PurificationChamber.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/PurificationChamber.java
@@ -4,6 +4,7 @@ import com.cleanroommc.groovyscript.api.IIngredient;
 import com.cleanroommc.groovyscript.compat.mods.mekanism.recipe.VirtualizedMekanismRegistry;
 import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
 import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
 import mekanism.api.gas.GasStack;
 import mekanism.common.recipe.RecipeHandler;
 import mekanism.common.recipe.inputs.AdvancedMachineInput;
@@ -14,7 +15,7 @@ import net.minecraft.item.ItemStack;
 public class PurificationChamber extends VirtualizedMekanismRegistry<PurificationRecipe> {
 
     public PurificationChamber() {
-        super(RecipeHandler.Recipe.PURIFICATION_CHAMBER, "PurificationChamber", "purification_chamber", "Purifier", "purifier");
+        super(RecipeHandler.Recipe.PURIFICATION_CHAMBER, VirtualizedRegistry.generateAliases("Purifier"));
     }
 
     public PurificationRecipe add(IIngredient ingredient, GasStack gasInput, ItemStack output) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Sawmill.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Sawmill.java
@@ -13,7 +13,7 @@ import net.minecraft.item.ItemStack;
 public class Sawmill extends VirtualizedMekanismRegistry<SawmillRecipe> {
 
     public Sawmill() {
-        super(RecipeHandler.Recipe.PRECISION_SAWMILL, "Sawmill", "sawmill");
+        super(RecipeHandler.Recipe.PRECISION_SAWMILL);
     }
 
     public SawmillRecipe add(IIngredient ingredient, ItemStack output) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Separator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Separator.java
@@ -3,6 +3,7 @@ package com.cleanroommc.groovyscript.compat.mods.mekanism;
 import com.cleanroommc.groovyscript.compat.mods.mekanism.recipe.VirtualizedMekanismRegistry;
 import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
 import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
 import mekanism.api.gas.GasStack;
 import mekanism.common.recipe.RecipeHandler;
 import mekanism.common.recipe.inputs.FluidInput;
@@ -12,7 +13,7 @@ import net.minecraftforge.fluids.FluidStack;
 public class Separator extends VirtualizedMekanismRegistry<SeparatorRecipe> {
 
     public Separator() {
-        super(RecipeHandler.Recipe.ELECTROLYTIC_SEPARATOR, "ElectrolyticSeparator", "Separator", "electrolytic_separator", "separator");
+        super(RecipeHandler.Recipe.ELECTROLYTIC_SEPARATOR, VirtualizedRegistry.generateAliases("ElectrolyticSeparator"));
     }
 
     public SeparatorRecipe add(FluidStack input, GasStack leftOutput, GasStack rightOutput, double energy) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/SolarNeutronActivator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/SolarNeutronActivator.java
@@ -11,7 +11,7 @@ import mekanism.common.recipe.machines.SolarNeutronRecipe;
 public class SolarNeutronActivator extends VirtualizedMekanismRegistry<SolarNeutronRecipe> {
 
     public SolarNeutronActivator() {
-        super(RecipeHandler.Recipe.SOLAR_NEUTRON_ACTIVATOR, "SolarNeutronActivator", "solar_neutron_activator", "SNA");
+        super(RecipeHandler.Recipe.SOLAR_NEUTRON_ACTIVATOR, "SNA");
     }
 
     public SolarNeutronRecipe add(GasStack input, GasStack output) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/ThermalEvaporation.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/ThermalEvaporation.java
@@ -11,7 +11,7 @@ import net.minecraftforge.fluids.FluidStack;
 public class ThermalEvaporation extends VirtualizedMekanismRegistry<ThermalEvaporationRecipe> {
 
     public ThermalEvaporation() {
-        super(RecipeHandler.Recipe.THERMAL_EVAPORATION_PLANT, "ThermalEvaporationPlant", "thermal_evaporation_plant", "TEP");
+        super(RecipeHandler.Recipe.THERMAL_EVAPORATION_PLANT, "TEP");
     }
 
     public ThermalEvaporationRecipe add(FluidStack input, FluidStack output) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Washer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Washer.java
@@ -11,7 +11,7 @@ import mekanism.common.recipe.machines.WasherRecipe;
 public class Washer extends VirtualizedMekanismRegistry<WasherRecipe> {
 
     public Washer() {
-        super(RecipeHandler.Recipe.CHEMICAL_WASHER, "Washer", "washer");
+        super(RecipeHandler.Recipe.CHEMICAL_WASHER);
     }
 
     public WasherRecipe add(GasStack input, GasStack output) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/recipe/VirtualizedMekanismRegistry.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/recipe/VirtualizedMekanismRegistry.java
@@ -12,8 +12,8 @@ public abstract class VirtualizedMekanismRegistry<R extends MachineRecipe<?, ?, 
 
     protected final RecipeHandler.Recipe<?, ?, R> recipeRegistry;
 
-    public VirtualizedMekanismRegistry(RecipeHandler.Recipe<?, ?, R> recipeRegistry, String name, String... aliases) {
-        super(name, aliases);
+    public VirtualizedMekanismRegistry(RecipeHandler.Recipe<?, ?, R> recipeRegistry, String... aliases) {
+        super(aliases);
         this.recipeRegistry = recipeRegistry;
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/Brewer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/Brewer.java
@@ -29,7 +29,7 @@ public class Brewer extends VirtualizedRegistry<BrewerManager.BrewerRecipe> {
     private final List<String> validationFluidsBackup = new ArrayList<>();
 
     public Brewer() {
-        super("Brewer", "brewer", "Imbuer");
+        super(VirtualizedRegistry.generateAliases("Imbuer"));
     }
 
     public RecipeBuilder recipeBuilder() {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/Crucible.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/Crucible.java
@@ -25,7 +25,7 @@ public class Crucible extends VirtualizedRegistry<CrucibleManager.CrucibleRecipe
     private final List<ComparableItemStackValidatedNBT> lavaSetBackup = new ArrayList<>();
 
     public Crucible() {
-        super("Crucible", "crucible");
+        super();
     }
 
     @Override

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/Pulverizer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/Pulverizer.java
@@ -21,7 +21,7 @@ import java.util.Map;
 public class Pulverizer extends VirtualizedRegistry<PulverizerRecipe> {
 
     public Pulverizer() {
-        super("Pulverizer", "pulverizer");
+        super();
     }
 
     public RecipeBuilder recipeBuilder() {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/Furnace.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/Furnace.java
@@ -15,7 +15,7 @@ import java.util.List;
 public class Furnace extends VirtualizedRegistry<Furnace.Recipe> {
 
     public Furnace() {
-        super("Furnace", "furnace");
+        super();
     }
 
     public void add(IIngredient input, ItemStack output) {

--- a/src/main/java/com/cleanroommc/groovyscript/registry/VirtualizedRegistry.java
+++ b/src/main/java/com/cleanroommc/groovyscript/registry/VirtualizedRegistry.java
@@ -21,7 +21,6 @@ public abstract class VirtualizedRegistry<R> {
             Collections.addAll(this.aliases, VirtualizedRegistry.generateAliases(this.getClass().getSimpleName()));
         }
         Collections.addAll(this.aliases, aliases);
-        GroovyLog.get().info("Alias: {}", this.aliases);
         initBackup();
         initScripted();
     }

--- a/src/main/java/com/cleanroommc/groovyscript/registry/VirtualizedRegistry.java
+++ b/src/main/java/com/cleanroommc/groovyscript/registry/VirtualizedRegistry.java
@@ -1,12 +1,11 @@
 package com.cleanroommc.groovyscript.registry;
 
 import com.cleanroommc.groovyscript.api.GroovyBlacklist;
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.google.common.base.CaseFormat;
 import org.jetbrains.annotations.ApiStatus;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 public abstract class VirtualizedRegistry<R> {
 
@@ -14,12 +13,30 @@ public abstract class VirtualizedRegistry<R> {
 
     protected Collection<R> backup, scripted;
 
-    public VirtualizedRegistry(String name, String... aliases) {
+    public VirtualizedRegistry(String... aliases) { this(true, aliases); }
+
+    public VirtualizedRegistry(Boolean generate, String... aliases) {
         this.aliases = new ArrayList<>();
-        this.aliases.add(name);
-        addAlias(aliases);
+        if (generate) {
+            Collections.addAll(this.aliases, VirtualizedRegistry.generateAliases(this.getClass().getSimpleName()));
+        }
+        Collections.addAll(this.aliases, aliases);
+        GroovyLog.get().info("Alias: {}", this.aliases);
         initBackup();
         initScripted();
+    }
+
+    public static String[] generateAliases(String name) {
+        ArrayList<String> aliases = new ArrayList<>();
+        aliases.add(name);
+        aliases.add(name.toLowerCase(Locale.ROOT));
+
+        if (name.split("[A-Z]").length > 2) {
+            aliases.add(CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, name));
+            aliases.add(CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, name));
+        }
+
+        return aliases.toArray(new String[0]);
     }
 
     @GroovyBlacklist
@@ -30,10 +47,6 @@ public abstract class VirtualizedRegistry<R> {
     @ApiStatus.OverrideOnly
     public void afterScriptLoad() {
 
-    }
-
-    public void addAlias(String... aliases) {
-        Collections.addAll(this.aliases, aliases);
     }
 
     public List<String> getAliases() {

--- a/src/main/java/com/cleanroommc/groovyscript/registry/VirtualizedRegistry.java
+++ b/src/main/java/com/cleanroommc/groovyscript/registry/VirtualizedRegistry.java
@@ -15,7 +15,7 @@ public abstract class VirtualizedRegistry<R> {
 
     public VirtualizedRegistry(String... aliases) { this(true, aliases); }
 
-    public VirtualizedRegistry(Boolean generate, String... aliases) {
+    public VirtualizedRegistry(boolean generate, String... aliases) {
         this.aliases = new ArrayList<>();
         if (generate) {
             Collections.addAll(this.aliases, VirtualizedRegistry.generateAliases(this.getClass().getSimpleName()));


### PR DESCRIPTION
automatically generates the `PascalCase` name and aliases in the form of `lowercase`, `underscore_case`, and `camelCase` (if relevant) based off the class name. obtained via `this.getClass().getSimpleName()`.

a few quick examples of the syntax change:
```diff
// generates `Fusion` and `fusion`
-super("Fusion", "fusion");
+super();

// generates `BlastFurnace`, `blastfurnace`, `blastFurnace`, and `blast_furnace`
-super("BlastFurnace", "blastfurnace", "blast_furnace");
+super();

// generates `SliceNSplice`, `slicensplice`, `sliceNSplice`, `slice_n_splice`, `SliceAndSplice`, `sliceandsplice`, `sliceandSplice`, and `slice_and_splice`
-super("SliceNSplice", "slice_n_splice", "SliceAndSplice", "slice_and_splice");
+super(VirtualizedRegistry.generateAliases("SliceAndSplice")); 

// if the auto-generation is undesired, just pass in false as the first param. generates `Electrolyzer` and `electrolyzer` (class name is `ClassicElectrolyzer`)
-super("Electrolyzer", "electrolyzer");
+super(false, VirtualizedRegistry.generateAliases("Electrolyzer"));
```
