### PR TITLE
Modifications to addBackup() behaviour

### DIFF
--- a/src/main/java/com/cleanroommc/groovyscript/registry/VirtualizedRegistry.java
+++ b/src/main/java/com/cleanroommc/groovyscript/registry/VirtualizedRegistry.java
@@ -83,6 +83,7 @@ public abstract class VirtualizedRegistry<R> {
 
     @GroovyBlacklist
     public void addBackup(R recipe) {
+        if (this.scripted.stream().anyMatch(r -> r == recipe)) return;
         this.backup.add(recipe);
     }
 
@@ -104,5 +105,4 @@ public abstract class VirtualizedRegistry<R> {
         initScripted();
         return scripted;
     }
-
 }

--- a/src/main/java/com/cleanroommc/groovyscript/registry/VirtualizedRegistry.java
+++ b/src/main/java/com/cleanroommc/groovyscript/registry/VirtualizedRegistry.java
@@ -84,7 +84,7 @@ public abstract class VirtualizedRegistry<R> {
 
     @GroovyBlacklist
     public void addBackup(R recipe) {
-        if (this.scripted.stream().anyMatch(this.recipeComparator(recipe))) return;
+        if (this.scripted.stream().anyMatch(r -> compareRecipe(r, recipe))) return;
         this.backup.add(recipe);
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/registry/VirtualizedRegistry.java
+++ b/src/main/java/com/cleanroommc/groovyscript/registry/VirtualizedRegistry.java
@@ -108,7 +108,7 @@ public abstract class VirtualizedRegistry<R> {
     }
 
     @GroovyBlacklist
-    protected Predicate<R> recipeComparator(R recipe) {
-        return r -> r == recipe;
+    protected boolean compareRecipe(R recipe, R recipe2) {
+        return recipe == recipe2;
     }
 }

--- a/src/main/java/com/cleanroommc/groovyscript/registry/VirtualizedRegistry.java
+++ b/src/main/java/com/cleanroommc/groovyscript/registry/VirtualizedRegistry.java
@@ -5,6 +5,7 @@ import com.google.common.base.CaseFormat;
 import org.jetbrains.annotations.ApiStatus;
 
 import java.util.*;
+import java.util.function.Predicate;
 
 public abstract class VirtualizedRegistry<R> {
 
@@ -83,7 +84,7 @@ public abstract class VirtualizedRegistry<R> {
 
     @GroovyBlacklist
     public void addBackup(R recipe) {
-        if (this.scripted.stream().anyMatch(r -> r == recipe)) return;
+        if (this.scripted.stream().anyMatch(this.recipeComparator(recipe))) return;
         this.backup.add(recipe);
     }
 
@@ -104,5 +105,10 @@ public abstract class VirtualizedRegistry<R> {
         Collection<R> scripted = this.scripted;
         initScripted();
         return scripted;
+    }
+
+    @GroovyBlacklist
+    protected Predicate<R> recipeComparator(R recipe) {
+        return r -> r == recipe;
     }
 }


### PR DESCRIPTION
### Motivation:
The `VirtualizedRegistry<R>` class allows for convenience storing and retrieving of recipes thanks to the `scripted` and `backup` collections. These collections would be in charge of storing script-generated recipes and saving existing recipes that have been deleted by scripts, respectively. For this purpose, the `addScripted` and `addBackup` methods are used whenever the script calls any of the mod compatibility recipe functions like `addRecipe(...)` or `removeRecipe(...)`. When reloading the script, recipes from the `scripted` collection would get purged from the mod, while recipes in the `backup` collection would be restored to the mod.

During testing, I happened to notice that adding and removing the same user-generated recipe through GroovyScript would cause both `addScripted` and `addBackup` to be called with said recipe as their parameter. This essentially meant that the user-generated recipe was being treated as a "pre-existing" mod recipe that had to be saved in case of deletion, to be restored later when the script was reloaded. The consequence of this was that **the user was able to generate "persistent" recipes that could not be purged unless the game was restarted** (or explicitly deleted through the script).

### How to replicate
As an example, the following GroovyScript script is provided:
```groovy
mods.immersiveengineering.blastfurnace.add(item('minecraft:diamond'), item('minecraft:coal'), 1000, item('minecraft:dirt'))
mods.immersiveengineering.blastfurnace.removeByOutput(item('minecraft:diamond'))
```
This script, when executed, will cause the recipe to enter the `backup` collection. This behaviour could be reproduced with any other mod whose compatibility relied on the `VirtualizedRegistry<R>` collections.

### Pull request contents
This pull request, during time of writing, contains two commits. 
- The first commit introduces the "fix", which is a simple check inside the `addBackup` method that ignores the insertion request if the recipe is found inside the `scripted` collection.
- The second commit adds a new method to the `VirtualizedRegistry<R>` class called `recipeComparator`, which returns a `Predicate<R>` whose purpose is to compare recipe objects for equality. This commit also modifies the default `r -> r == recipe` comparison inside the `addBackup` check, and uses instead the newly defined `recipeComparator` method. The purpose of this commit is to allow for implementations of `VirtualizedRegistry<R>` to choose exactly when two recipes should be seen as equal, by way of overriding this new method.