### PR TITLE
Fix several warnings about remapping mixins

### DIFF
--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/InventoryCraftingAccess.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/InventoryCraftingAccess.java
@@ -5,7 +5,7 @@ import net.minecraft.inventory.InventoryCrafting;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
-@Mixin(InventoryCrafting.class)
+@Mixin(value = InventoryCrafting.class, remap = false)
 public interface InventoryCraftingAccess {
 
     @Accessor

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/OreDictionaryAccessor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/OreDictionaryAccessor.java
@@ -9,7 +9,7 @@ import org.spongepowered.asm.mixin.gen.Accessor;
 import java.util.List;
 import java.util.Map;
 
-@Mixin(OreDictionary.class)
+@Mixin(value = OreDictionary.class, remap = false)
 public interface OreDictionaryAccessor {
 
     @Accessor

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/SlotCraftingAccess.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/SlotCraftingAccess.java
@@ -5,7 +5,7 @@ import net.minecraft.inventory.SlotCrafting;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
-@Mixin(SlotCrafting.class)
+@Mixin(value = SlotCrafting.class, remap = false)
 public interface SlotCraftingAccess {
 
     @Accessor

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/draconicevolution/FusionRegistryAccessor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/draconicevolution/FusionRegistryAccessor.java
@@ -7,7 +7,7 @@ import org.spongepowered.asm.mixin.gen.Accessor;
 
 import java.util.List;
 
-@Mixin(FusionRecipeRegistry.class)
+@Mixin(value = FusionRecipeRegistry.class, remap = false)
 public interface FusionRegistryAccessor {
 
     @Accessor

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/ic2/ClassicCanningMachineRegistryAccessor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/ic2/ClassicCanningMachineRegistryAccessor.java
@@ -8,7 +8,7 @@ import org.spongepowered.asm.mixin.gen.Accessor;
 import java.util.List;
 import java.util.Map;
 
-@Mixin(CanningMachineRegistry.class)
+@Mixin(value = CanningMachineRegistry.class, remap = false)
 public interface ClassicCanningMachineRegistryAccessor {
 
     @Accessor("IdToItems")

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/ic2/ElectrolyzerRecipeManagerAccessor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/ic2/ElectrolyzerRecipeManagerAccessor.java
@@ -7,7 +7,7 @@ import org.spongepowered.asm.mixin.gen.Accessor;
 
 import java.util.Map;
 
-@Mixin(ElectrolyzerRecipeManager.class)
+@Mixin(value = ElectrolyzerRecipeManager.class, remap = false)
 public interface ElectrolyzerRecipeManagerAccessor {
 
     @Accessor

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/ic2/FermenterRecipeManagerAccessor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/ic2/FermenterRecipeManagerAccessor.java
@@ -7,7 +7,7 @@ import org.spongepowered.asm.mixin.gen.Accessor;
 
 import java.util.Map;
 
-@Mixin(FermenterRecipeManager.class)
+@Mixin(value = FermenterRecipeManager.class, remap = false)
 public interface FermenterRecipeManagerAccessor {
 
     @Accessor

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/ic2/ScrapboxRecipeManagerAccessor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/ic2/ScrapboxRecipeManagerAccessor.java
@@ -6,7 +6,7 @@ import org.spongepowered.asm.mixin.gen.Accessor;
 
 import java.util.List;
 
-@Mixin(ScrapboxRecipeManager.class)
+@Mixin(value = ScrapboxRecipeManager.class, remap = false)
 public interface ScrapboxRecipeManagerAccessor {
 
     @Accessor

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/ic2/SemiFluidFuelManagerAccessor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/ic2/SemiFluidFuelManagerAccessor.java
@@ -7,7 +7,7 @@ import org.spongepowered.asm.mixin.gen.Accessor;
 
 import java.util.Map;
 
-@Mixin(SemiFluidFuelManager.class)
+@Mixin(value = SemiFluidFuelManager.class, remap = false)
 public interface SemiFluidFuelManagerAccessor {
 
     @Accessor

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/thermalexpansion/BrewerManagerAccessor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/thermalexpansion/BrewerManagerAccessor.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-@Mixin(BrewerManager.class)
+@Mixin(value = BrewerManager.class, remap = false)
 public interface BrewerManagerAccessor {
 
     @Accessor

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/thermalexpansion/CrucibleManagerAccessor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/thermalexpansion/CrucibleManagerAccessor.java
@@ -8,7 +8,7 @@ import org.spongepowered.asm.mixin.gen.Accessor;
 import java.util.Map;
 import java.util.Set;
 
-@Mixin(CrucibleManager.class)
+@Mixin(value = CrucibleManager.class, remap = false)
 public interface CrucibleManagerAccessor {
 
     @Accessor


### PR DESCRIPTION
Fixes several warnings about no remapping targets when building the project, namely:

```
Note: Writing refmap to /home/alongstringofnumbers/IdeaProjects/GroovyScript/build/tmp/compileJava/compileJava-refmap.json
/home/alongstringofnumbers/IdeaProjects/GroovyScript/build/sources/main/java/com/cleanroommc/groovyscript/core/mixin/draconicevolution/FusionRegistryAccessor.java:13: warning: Unable to locate obfuscation mapping for @Accessor target REGISTRY
    @Accessor
    ^
/home/alongstringofnumbers/IdeaProjects/GroovyScript/build/sources/main/java/com/cleanroommc/groovyscript/core/mixin/ic2/ScrapboxRecipeManagerAccessor.java:12: warning: Unable to locate obfuscation mapping for @Accessor target drops
    @Accessor
    ^
/home/alongstringofnumbers/IdeaProjects/GroovyScript/build/sources/main/java/com/cleanroommc/groovyscript/core/mixin/ic2/SemiFluidFuelManagerAccessor.java:13: warning: Unable to locate obfuscation mapping for @Accessor target fuelProperties
    @Accessor
    ^
/home/alongstringofnumbers/IdeaProjects/GroovyScript/build/sources/main/java/com/cleanroommc/groovyscript/core/mixin/ic2/ElectrolyzerRecipeManagerAccessor.java:13: warning: Unable to locate obfuscation mapping for @Accessor target fluidMap
    @Accessor
    ^
/home/alongstringofnumbers/IdeaProjects/GroovyScript/build/sources/main/java/com/cleanroommc/groovyscript/core/mixin/ic2/ClassicCanningMachineRegistryAccessor.java:14: warning: Unable to locate obfuscation mapping for @Accessor target IdToItems
    @Accessor("IdToItems")
    ^
/home/alongstringofnumbers/IdeaProjects/GroovyScript/build/sources/main/java/com/cleanroommc/groovyscript/core/mixin/ic2/FermenterRecipeManagerAccessor.java:13: warning: Unable to locate obfuscation mapping for @Accessor target fluidMap
    @Accessor
    ^
/home/alongstringofnumbers/IdeaProjects/GroovyScript/build/sources/main/java/com/cleanroommc/groovyscript/core/mixin/thermalexpansion/CrucibleManagerAccessor.java:14: warning: Unable to locate obfuscation mapping for @Accessor target recipeMap
    @Accessor
    ^
/home/alongstringofnumbers/IdeaProjects/GroovyScript/build/sources/main/java/com/cleanroommc/groovyscript/core/mixin/thermalexpansion/CrucibleManagerAccessor.java:19: warning: Unable to locate obfuscation mapping for @Accessor target lavaSet
    @Accessor
    ^
/home/alongstringofnumbers/IdeaProjects/GroovyScript/build/sources/main/java/com/cleanroommc/groovyscript/core/mixin/thermalexpansion/BrewerManagerAccessor.java:15: warning: Unable to locate obfuscation mapping for @Accessor target recipeMap
    @Accessor
    ^
/home/alongstringofnumbers/IdeaProjects/GroovyScript/build/sources/main/java/com/cleanroommc/groovyscript/core/mixin/thermalexpansion/BrewerManagerAccessor.java:20: warning: Unable to locate obfuscation mapping for @Accessor target validationSet
    @Accessor
    ^
/home/alongstringofnumbers/IdeaProjects/GroovyScript/build/sources/main/java/com/cleanroommc/groovyscript/core/mixin/thermalexpansion/BrewerManagerAccessor.java:25: warning: Unable to locate obfuscation mapping for @Accessor target validationFluids
    @Accessor
    ^
/home/alongstringofnumbers/IdeaProjects/GroovyScript/build/sources/main/java/com/cleanroommc/groovyscript/core/mixin/OreDictionaryAccessor.java:15: warning: Unable to locate obfuscation mapping for @Accessor target idToName
    @Accessor
    ^
/home/alongstringofnumbers/IdeaProjects/GroovyScript/build/sources/main/java/com/cleanroommc/groovyscript/core/mixin/OreDictionaryAccessor.java:20: warning: Unable to locate obfuscation mapping for @Accessor target nameToId
    @Accessor
    ^
/home/alongstringofnumbers/IdeaProjects/GroovyScript/build/sources/main/java/com/cleanroommc/groovyscript/core/mixin/OreDictionaryAccessor.java:25: warning: Unable to locate obfuscation mapping for @Accessor target idToStack
    @Accessor
    ^
/home/alongstringofnumbers/IdeaProjects/GroovyScript/build/sources/main/java/com/cleanroommc/groovyscript/core/mixin/OreDictionaryAccessor.java:30: warning: Unable to locate obfuscation mapping for @Accessor target idToStackUn
    @Accessor
    ^
/home/alongstringofnumbers/IdeaProjects/GroovyScript/build/sources/main/java/com/cleanroommc/groovyscript/core/mixin/OreDictionaryAccessor.java:35: warning: Unable to locate obfuscation mapping for @Accessor target stackToId
    @Accessor
    ^
```

For things that are not obfuscated, like other mods. 

In addition, changes a few accessors to remap= false that were causing issues in CEu dev environment where Groovyscript mixins were failing because they were targetting obfuscated names