### PR TITLE
Additional Removal Options

### DIFF
--- a/src/main/java/com/cleanroommc/groovyscript/helper/SimpleObjectStream.java
+++ b/src/main/java/com/cleanroommc/groovyscript/helper/SimpleObjectStream.java
@@ -77,6 +77,15 @@ public class SimpleObjectStream<T> extends AbstractList<T> {
         return new ObjectOpenHashSet<>(this.recipes);
     }
 
+    @Override
+    public boolean removeIf(Predicate<? super T> filter) {
+        Objects.requireNonNull(this.remover);
+        return this.recipes.removeIf(t -> {
+            if (filter.test(t)) return this.remover.test(t);
+            return false;
+        });
+    }
+
     public SimpleObjectStream<T> removeAll() {
         Objects.requireNonNull(this.remover);
         this.recipes.removeIf(this.remover);

--- a/src/main/java/com/cleanroommc/groovyscript/helper/SimpleObjectStream.java
+++ b/src/main/java/com/cleanroommc/groovyscript/helper/SimpleObjectStream.java
@@ -80,10 +80,7 @@ public class SimpleObjectStream<T> extends AbstractList<T> {
     @Override
     public boolean removeIf(Predicate<? super T> filter) {
         Objects.requireNonNull(this.remover);
-        return this.recipes.removeIf(t -> {
-            if (filter.test(t)) return this.remover.test(t);
-            return false;
-        });
+        return this.recipes.removeIf(t -> filter.test(t) && this.remover.test(t));
     }
 
     public SimpleObjectStream<T> removeAll() {


### PR DESCRIPTION
Adds more methods for recipe removal.

- SimpleObjectStream now has an implementation for `removeIf`
- Crafting and Furnace recipe removals can now optionally have their error logs disabled
- You can now get a stream of Crafting recipes
- You can now remove Crafting recipes based on their inputs
- You can now remove Furnace recipes based on their output