### PR TITLE
Item addition support for JEI

### DIFF
--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/JeiPlugin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/JeiPlugin.java
@@ -34,6 +34,8 @@ public class JeiPlugin implements IModPlugin {
 
     public static final List<ItemStack> HIDDEN = new ArrayList<>();
     public static final List<FluidStack> HIDDEN_FLUIDS = new ArrayList<>();
+    public static final List<ItemStack> ADDED = new ArrayList<>();
+    public static final List<FluidStack> ADDED_FLUIDS = new ArrayList<>();
     public static final List<String> HIDDEN_CATEGORY = new ArrayList<>();
 
     public static boolean isLoaded() {
@@ -42,11 +44,18 @@ public class JeiPlugin implements IModPlugin {
 
     public static void reload() {
         HIDDEN.clear();
+        HIDDEN_FLUIDS.clear();
         HIDDEN_CATEGORY.clear();
+        ADDED.clear();
+        ADDED_FLUIDS.clear();
     }
 
     public static void hideItem(ItemStack... stack) {
         Collections.addAll(HIDDEN, stack);
+    }
+
+    public static void addItem(ItemStack... stack) {
+        Collections.addAll(ADDED, stack);
     }
 
     @Override
@@ -71,6 +80,12 @@ public class JeiPlugin implements IModPlugin {
         }
         if (!HIDDEN_FLUIDS.isEmpty()) {
             itemRegistry.removeIngredientsAtRuntime(VanillaTypes.FLUID, HIDDEN_FLUIDS);
+        }
+        if (!ADDED.isEmpty()) {
+            itemRegistry.addIngredientsAtRuntime(VanillaTypes.ITEM, ingredientHelper.expandSubtypes(ADDED));
+        }
+        if (!ADDED_FLUIDS.isEmpty()) {
+            itemRegistry.addIngredientsAtRuntime(VanillaTypes.FLUID, ADDED_FLUIDS);
         }
         for (String category : HIDDEN_CATEGORY) {
             recipeRegistry.hideRecipeCategory(category);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/JustEnoughItems.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/JustEnoughItems.java
@@ -5,6 +5,7 @@ import com.cleanroommc.groovyscript.api.IIngredient;
 import com.cleanroommc.groovyscript.compat.mods.ModPropertyContainer;
 import com.cleanroommc.groovyscript.compat.vanilla.VanillaModule;
 import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
+import net.minecraftforge.fluids.FluidStack;
 
 public class JustEnoughItems extends ModPropertyContainer {
 
@@ -16,11 +17,18 @@ public class JustEnoughItems extends ModPropertyContainer {
                     .post();
             return;
         }
-        if (IngredientHelper.isFluid(ingredient)) {
-            JeiPlugin.HIDDEN_FLUIDS.add(IngredientHelper.toFluidStack(ingredient));
-        } else {
-            JeiPlugin.hideItem(ingredient.getMatchingStacks());
+        JeiPlugin.hideItem(ingredient.getMatchingStacks());
+    }
+
+    public void hide(FluidStack stack) {
+        if (IngredientHelper.isEmpty(stack)) {
+            GroovyLog.msg("Error hiding items {}", stack)
+                    .add("Items must not be empty")
+                    .error()
+                    .post();
+            return;
         }
+        JeiPlugin.HIDDEN_FLUIDS.add(stack);
     }
 
     public void removeAndHide(IIngredient ingredient) {
@@ -48,5 +56,27 @@ public class JustEnoughItems extends ModPropertyContainer {
             return;
         }
         JeiPlugin.HIDDEN_CATEGORY.add(category);
+    }
+
+    public void add(IIngredient ingredient) {
+        if (IngredientHelper.isEmpty(ingredient)) {
+            GroovyLog.msg("Error adding items {}", ingredient)
+                    .add("Items must not be empty")
+                    .error()
+                    .post();
+            return;
+        }
+        JeiPlugin.addItem(ingredient.getMatchingStacks());
+    }
+
+    public void add(FluidStack stack) {
+        if (IngredientHelper.isEmpty(stack)) {
+            GroovyLog.msg("Error adding items {}", stack)
+                    .add("Items must not be empty")
+                    .error()
+                    .post();
+            return;
+        }
+        JeiPlugin.ADDED_FLUIDS.add(stack);
     }
 }


### PR DESCRIPTION
Adds a `.add()` method to GrS's JEI support that adds the given item or fluid to JEI.

Also fixes a bug that prevents you from hiding a fluid from JEI.