### PR TITLE
Minor Fixes

### DIFF
--- a/src/main/java/com/cleanroommc/groovyscript/api/IIngredient.java
+++ b/src/main/java/com/cleanroommc/groovyscript/api/IIngredient.java
@@ -21,6 +21,10 @@ public interface IIngredient extends IResourceStack, Predicate<ItemStack> {
 
     ItemStack[] getMatchingStacks();
 
+    default boolean isEmpty() {
+        return getAmount() <= 0 || getMatchingStacks().length == 0;
+    }
+
     default ItemStack applyTransform(ItemStack matchedInput) {
         return ForgeHooks.getContainerItem(matchedInput);
     }
@@ -54,6 +58,11 @@ public interface IIngredient extends IResourceStack, Predicate<ItemStack> {
 
         @Override
         public void setAmount(int amount) {
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return true;
         }
 
         @Override
@@ -100,6 +109,11 @@ public interface IIngredient extends IResourceStack, Predicate<ItemStack> {
         @Override
         public ItemStack[] getMatchingStacks() {
             return new ItemStack[0];
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return false;
         }
 
         @Override

--- a/src/main/java/com/cleanroommc/groovyscript/brackets/BlockStateBracketHandler.java
+++ b/src/main/java/com/cleanroommc/groovyscript/brackets/BlockStateBracketHandler.java
@@ -37,7 +37,7 @@ public class BlockStateBracketHandler implements IBracketHandler<IBlockState> {
                     return blockState;
                 }
             }
-            String[] stringArgs = (String[]) Arrays.copyOfRange(args, 1, args.length);
+            String[] stringArgs = Arrays.stream(args).map(Object::toString).toArray(String[]::new);
             return parseBlockStates(blockState, Iterators.forArray(stringArgs));
         }
         return blockState;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/tcomplement/HighOven.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/tcomplement/HighOven.java
@@ -68,7 +68,7 @@ public class HighOven extends MeltingRecipeRegistry {
         })) return true;
 
         GroovyLog.msg("Error removing Tinkers Complement High Oven override")
-                .add("could not find override with output %s", output)
+                .add("could not find override with output {}", output)
                 .error()
                 .post();
         return false;
@@ -85,7 +85,7 @@ public class HighOven extends MeltingRecipeRegistry {
 
         list.clear();
         GroovyLog.msg("Error removing Tinkers Complement High Oven override")
-                .add("could not find override with input %s", input)
+                .add("could not find override with input {}", input)
                 .error()
                 .post();
         return false;
@@ -102,7 +102,7 @@ public class HighOven extends MeltingRecipeRegistry {
 
         list.clear();
         GroovyLog.msg("Error removing Tinkers Complement High Oven override")
-                .add("could not find override with input %s and output %s", input, output)
+                .add("could not find override with input {} and output {]", input, output)
                 .error()
                 .post();
         return false;
@@ -150,7 +150,7 @@ public class HighOven extends MeltingRecipeRegistry {
             })) return true;
 
             GroovyLog.msg("Error removing Tinkers Complement High Oven Mixing recipe")
-                    .add("could not find recipe with output %s", output)
+                    .add("could not find recipe with output {}", output)
                     .error()
                     .post();
             return false;
@@ -165,7 +165,7 @@ public class HighOven extends MeltingRecipeRegistry {
             })) return true;
 
             GroovyLog.msg("Error removing Tinkers Complement High Oven Mixing recipe")
-                    .add("could not find recipe with input %s", input)
+                    .add("could not find recipe with input {}", input)
                     .error()
                     .post();
             return false;
@@ -180,7 +180,7 @@ public class HighOven extends MeltingRecipeRegistry {
             })) return true;
 
             GroovyLog.msg("Error removing Tinkers Complement High Oven Mixing recipe")
-                    .add("could not find recipe with input %s and output %s", input, output)
+                    .add("could not find recipe with input {} and output {}", input, output)
                     .error()
                     .post();
             return false;
@@ -201,7 +201,7 @@ public class HighOven extends MeltingRecipeRegistry {
             })) return true;
 
             GroovyLog.msg("Error removing Tinkers Complement High Oven Mixing recipe")
-                    .add("could not find override with additives %s", additives.values())
+                    .add("could not find override with additives {}", additives.values())
                     .error()
                     .post();
             return false;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/tcomplement/Melter.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/tcomplement/Melter.java
@@ -113,7 +113,7 @@ public class Melter extends MeltingRecipeRegistry {
         })) return true;
 
         GroovyLog.msg("Error removing Tinkers Complement Melter blacklist")
-                .add("could not find a blacklist for item %s", item)
+                .add("could not find a blacklist for item {}", item)
                 .error()
                 .post();
         return false;
@@ -130,7 +130,7 @@ public class Melter extends MeltingRecipeRegistry {
 
         list.clear();
         GroovyLog.msg("Error removing Tinkers Complement Melter override")
-                .add("could not find a override for input %s", input)
+                .add("could not find a override for input {}", input)
                 .error()
                 .post();
         return false;
@@ -144,7 +144,7 @@ public class Melter extends MeltingRecipeRegistry {
         })) return true;
 
         GroovyLog.msg("Error removing Tinkers Complement Melter override")
-                .add("could not find a override for output %s", stack)
+                .add("could not find a override for output {}", stack)
                 .error()
                 .post();
         return false;
@@ -161,7 +161,7 @@ public class Melter extends MeltingRecipeRegistry {
 
         list.clear();
         GroovyLog.msg("Error removing Tinkers Complement Melter override")
-                .add("could not find a override for input %s and output %s", input, output)
+                .add("could not find a override for input {} and output {}", input, output)
                 .error()
                 .post();
         return false;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/tinkersconstruct/Alloying.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/tinkersconstruct/Alloying.java
@@ -52,7 +52,7 @@ public class Alloying extends VirtualizedRegistry<AlloyRecipe> {
         })) return true;
 
         GroovyLog.msg("Error removing Tinkers Construct Alloying recipe")
-                .add("could not find recipe with output %s", output)
+                .add("could not find recipe with output {}", output)
                 .error()
                 .post();
         return false;
@@ -66,7 +66,7 @@ public class Alloying extends VirtualizedRegistry<AlloyRecipe> {
         })) return true;
 
         GroovyLog.msg("Error removing Tinkers Construct Alloying recipe")
-                .add("could not find recipe with inputs %s", Arrays.asList(inputs))
+                .add("could not find recipe with inputs {}", Arrays.asList(inputs))
                 .error()
                 .post();
         return false;
@@ -80,7 +80,7 @@ public class Alloying extends VirtualizedRegistry<AlloyRecipe> {
         })) return true;
 
         GroovyLog.msg("Error removing Tinkers Construct Alloying recipe")
-                .add("could not find recipe with inputs %s and output %s", Arrays.asList(inputs), output)
+                .add("could not find recipe with inputs %s and output {}", Arrays.asList(inputs), output)
                 .error()
                 .post();
         return false;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/tinkersconstruct/Casting.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/tinkersconstruct/Casting.java
@@ -171,13 +171,13 @@ public class Casting {
 
         public boolean removeByOutput(ItemStack output){
             if (TinkerRegistryAccessor.getBasinCastRegistry().removeIf(recipe -> {
-                boolean found = recipe.getResult(ItemStack.EMPTY, FluidRegistry.WATER).isItemEqual(output);
+                boolean found = ItemStack.areItemStacksEqual(recipe.getResult(ItemStack.EMPTY, FluidRegistry.WATER), output);
                 if (found) addBackup(recipe);
                 return found;
             })) return true;
 
             GroovyLog.msg("Error removing Tinkers Construct Casting Basin recipe")
-                    .add("could not find recipe with output %s", output)
+                    .add("could not find recipe with output {}", output)
                     .error()
                     .post();
             return false;
@@ -191,21 +191,22 @@ public class Casting {
             })) return true;
 
             GroovyLog.msg("Error removing Tinkers Construct Casting Basin recipe")
-                    .add("could not find recipe with input %s", input)
+                    .add("could not find recipe with input {}", input)
                     .error()
                     .post();
             return false;
         }
 
         public boolean removeByCast(IIngredient cast) {
+            ItemStack castStack = cast.getMatchingStacks()[0];
             if (TinkerRegistryAccessor.getBasinCastRegistry().removeIf(recipe -> {
-                boolean found = recipe.matches(cast.getMatchingStacks()[0], recipe.getFluid(cast.getMatchingStacks()[0], FluidRegistry.WATER).getFluid());
+                boolean found = recipe.matches(castStack, recipe.getFluid(castStack, FluidRegistry.WATER).getFluid());
                 if (found) addBackup(recipe);
                 return found;
             })) return true;
 
             GroovyLog.msg("Error removing Tinkers Construct Casting Basin recipe")
-                    .add("could not find recipe with cast %s", cast)
+                    .add("could not find recipe with cast {}", cast)
                     .error()
                     .post();
             return false;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/tinkersconstruct/Drying.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/tinkersconstruct/Drying.java
@@ -9,6 +9,7 @@ import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
 import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.NonNullList;
 import org.jetbrains.annotations.Nullable;
 import slimeknights.tconstruct.library.DryingRecipe;
 
@@ -45,14 +46,15 @@ public class Drying extends VirtualizedRegistry<DryingRecipe> {
     }
 
     public boolean removeByInput(IIngredient input) {
+        NonNullList<ItemStack> matching = NonNullList.from(ItemStack.EMPTY, input.getMatchingStacks());
         if (TinkerRegistryAccessor.getDryingRegistry().removeIf(recipe -> {
-            boolean found = input.test(recipe.input.getInputs().get(0));
+            boolean found = recipe.input.matches(matching).isPresent();
             if (found) addBackup(recipe);
             return found;
         })) return true;
 
         GroovyLog.msg("Error removing Tinkers Construct Drying recipe")
-                .add("could not find recipe with input %s", input)
+                .add("could not find recipe with input {}", input)
                 .error()
                 .post();
         return false;
@@ -60,27 +62,28 @@ public class Drying extends VirtualizedRegistry<DryingRecipe> {
 
     public boolean removeByOutput(ItemStack output) {
         if (TinkerRegistryAccessor.getDryingRegistry().removeIf(recipe -> {
-            boolean found = recipe.output.isItemEqual(output);
+            boolean found = ItemStack.areItemStacksEqual(recipe.output, output);
             if (found) addBackup(recipe);
             return found;
         })) return true;
 
         GroovyLog.msg("Error removing Tinkers Construct Drying recipe")
-                .add("could not find recipe with output %s", output)
+                .add("could not find recipe with output {}", output)
                 .error()
                 .post();
         return false;
     }
 
     public boolean removeByInputAndOutput(IIngredient input, ItemStack output) {
+        NonNullList<ItemStack> matching = NonNullList.from(ItemStack.EMPTY, input.getMatchingStacks());
         if (TinkerRegistryAccessor.getDryingRegistry().removeIf(recipe -> {
-            boolean found = input.test(recipe.input.getInputs().get(0)) && recipe.output.isItemEqual(output);
+            boolean found = recipe.input.matches(matching).isPresent() && ItemStack.areItemStacksEqual(recipe.output, output);
             if (found) addBackup(recipe);
             return found;
         })) return true;
 
         GroovyLog.msg("Error removing Tinkers Construct Drying recipe")
-                .add("could not find recipe with input %s and output %s", input, output)
+                .add("could not find recipe with input {} and output {}", input, output)
                 .error()
                 .post();
         return false;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/tinkersconstruct/Melting.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/tinkersconstruct/Melting.java
@@ -1,5 +1,6 @@
 package com.cleanroommc.groovyscript.compat.mods.tinkersconstruct;
 
+import com.cleanroommc.groovyscript.GroovyScript;
 import com.cleanroommc.groovyscript.api.GroovyBlacklist;
 import com.cleanroommc.groovyscript.api.GroovyLog;
 import com.cleanroommc.groovyscript.api.IIngredient;
@@ -11,6 +12,8 @@ import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
 import com.cleanroommc.groovyscript.helper.recipe.IRecipeBuilder;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
 import net.minecraft.entity.EntityList;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fml.common.registry.EntityEntry;
@@ -56,14 +59,15 @@ public class Melting extends MeltingRecipeRegistry {
     }
 
     public boolean removeByInput(IIngredient input) {
+        NonNullList<ItemStack> matching = NonNullList.from(ItemStack.EMPTY, input.getMatchingStacks());
         if (TinkerRegistryAccessor.getMeltingRegistry().removeIf(recipe -> {
-            boolean found = input.test(recipe.input.getInputs().get(0));
+            boolean found = recipe.input.matches(matching).isPresent();
             if (found) addBackup(recipe);
             return found;
         })) return true;
 
         GroovyLog.msg("Error removing Tinkers Construct Melting recipe")
-                .add("could not find recipe with input %s", input)
+                .add("could not find recipe with input {}", input)
                 .error()
                 .post();
         return false;
@@ -77,21 +81,22 @@ public class Melting extends MeltingRecipeRegistry {
         })) return true;
 
         GroovyLog.msg("Error removing Tinkers Construct Melting recipe")
-                .add("could not find recipe with output %s", output)
+                .add("could not find recipe with output {}", output)
                 .error()
                 .post();
         return false;
     }
 
     public boolean removeByInputAndOutput(IIngredient input, FluidStack output) {
+        NonNullList<ItemStack> matching = NonNullList.from(ItemStack.EMPTY, input.getMatchingStacks());
         if (TinkerRegistryAccessor.getMeltingRegistry().removeIf(recipe -> {
-            boolean found = input.test(recipe.input.getInputs().get(0)) && recipe.getResult().isFluidEqual(output);
+            boolean found = recipe.input.matches(matching).isPresent() && recipe.getResult().isFluidEqual(output);
             if (found) addBackup(recipe);
             return found;
         })) return true;
 
         GroovyLog.msg("Error removing Tinkers Construct Melting recipe")
-                .add("could not find recipe with input %s and output %s", input, output)
+                .add("could not find recipe with input {} and output {}", input, output)
                 .error()
                 .post();
         return false;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/tinkersconstruct/SmelteryFuel.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/tinkersconstruct/SmelteryFuel.java
@@ -38,7 +38,7 @@ public class SmelteryFuel extends VirtualizedRegistry<SmelteryFuelRecipe> {
         })) return true;
 
         GroovyLog.msg("Error removing Tinkers Construct Smeltery Fuel")
-                .add("could not find smeltery fuel entry for %s", fluid)
+                .add("could not find smeltery fuel entry for {}", fluid)
                 .error()
                 .post();
         return false;

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/FluidStackMixin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/FluidStackMixin.java
@@ -61,6 +61,11 @@ public abstract class FluidStackMixin implements IIngredient, INBTResourceStack 
     }
 
     @Override
+    public boolean isEmpty() {
+        return getAmount() <= 0;
+    }
+
+    @Override
     public boolean test(ItemStack stack) {
         if (matchCondition == null || ClosureHelper.call(true, matchCondition, stack)) {
             IFluidHandlerItem fluidHandler = stack.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);

--- a/src/main/java/com/cleanroommc/groovyscript/helper/ingredient/IngredientHelper.java
+++ b/src/main/java/com/cleanroommc/groovyscript/helper/ingredient/IngredientHelper.java
@@ -74,6 +74,7 @@ public class IngredientHelper {
     }
 
     public static boolean isEmpty(@Nullable IIngredient ingredient) {
+        if (ingredient instanceof FluidStack) return isEmpty(toFluidStack(ingredient));
         return ingredient == null || ingredient.getMatchingStacks().length == 0 || ingredient.getAmount() <= 0;
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/helper/ingredient/IngredientHelper.java
+++ b/src/main/java/com/cleanroommc/groovyscript/helper/ingredient/IngredientHelper.java
@@ -74,8 +74,7 @@ public class IngredientHelper {
     }
 
     public static boolean isEmpty(@Nullable IIngredient ingredient) {
-        if (ingredient instanceof FluidStack) return isEmpty(toFluidStack(ingredient));
-        return ingredient == null || ingredient.getMatchingStacks().length == 0 || ingredient.getAmount() <= 0;
+        return ingredient == null || ingredient.isEmpty();
     }
 
     public static boolean isEmpty(@Nullable ItemStack itemStack) {


### PR DESCRIPTION
- Add an `isEmpty()` method to `IIngredient` that can be overridden for ingredients that don't have any matching stacks. (Fixes `IngredientHelper.isEmpty()` always returning true for FluidStacks)
- Fixes the blockstate bracket handler causing a `ClassCastException` when using arguments.
- Changes `%s` to `{}` in the tinkers compat logs.
- Fixes some logic errors in the tinkers compat.