### PR TITLE
Run PostInit scripts on LoadComplete

### DIFF
--- a/src/main/java/com/cleanroommc/groovyscript/GroovyScript.java
+++ b/src/main/java/com/cleanroommc/groovyscript/GroovyScript.java
@@ -136,7 +136,9 @@ public class GroovyScript {
             Loader.instance().setActiveModContainer(Loader.instance().getIndexedModList().get(ID));
         }
 
+        long time = System.currentTimeMillis();
         getSandbox().run(LoadStage.PRE_INIT);
+        LOGGER.info("Running early Groovy scripts took " + (System.currentTimeMillis() - time) + " ms");
 
         if (wasNull) {
             Loader.instance().setActiveModContainer(null);
@@ -145,7 +147,9 @@ public class GroovyScript {
 
     @Mod.EventHandler
     public void onLoadComplete(FMLLoadCompleteEvent event) {
+        long time = System.currentTimeMillis();
         getSandbox().run(LoadStage.POST_INIT);
+        LOGGER.info("Running Groovy scripts took " + (System.currentTimeMillis() - time) + " ms");
     }
 
     @Mod.EventHandler

--- a/src/main/java/com/cleanroommc/groovyscript/GroovyScript.java
+++ b/src/main/java/com/cleanroommc/groovyscript/GroovyScript.java
@@ -41,10 +41,7 @@ import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.fml.client.registry.ClientRegistry;
 import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fml.common.event.FMLConstructionEvent;
-import net.minecraftforge.fml.common.event.FMLInitializationEvent;
-import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
-import net.minecraftforge.fml.common.event.FMLServerStartingEvent;
+import net.minecraftforge.fml.common.event.*;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.InputEvent;
@@ -63,7 +60,7 @@ import java.nio.file.StandardOpenOption;
 import java.util.List;
 
 @GroovyBlacklist
-@Mod(modid = GroovyScript.ID, name = GroovyScript.NAME, version = GroovyScript.VERSION)
+@Mod(modid = GroovyScript.ID, name = GroovyScript.NAME, version = GroovyScript.VERSION, dependencies = "before:jei;")
 @Mod.EventBusSubscriber(modid = GroovyScript.ID)
 public class GroovyScript {
 
@@ -147,9 +144,12 @@ public class GroovyScript {
     }
 
     @Mod.EventHandler
-    public void onPostInit(FMLPostInitializationEvent event) {
+    public void onLoadComplete(FMLLoadCompleteEvent event) {
         getSandbox().run(LoadStage.POST_INIT);
+    }
 
+    @Mod.EventHandler
+    public void onPostInit(FMLPostInitializationEvent event) {
         CustomClickAction.registerAction("copy", value -> {
             GuiScreen.setClipboardString(value);
             Minecraft.getMinecraft().player.sendMessage(new TextComponentTranslation("groovyscript.command.copy.copied_start")

--- a/src/main/java/com/cleanroommc/groovyscript/GroovyScript.java
+++ b/src/main/java/com/cleanroommc/groovyscript/GroovyScript.java
@@ -60,7 +60,7 @@ import java.nio.file.StandardOpenOption;
 import java.util.List;
 
 @GroovyBlacklist
-@Mod(modid = GroovyScript.ID, name = GroovyScript.NAME, version = GroovyScript.VERSION, dependencies = "before:jei;")
+@Mod(modid = GroovyScript.ID, name = GroovyScript.NAME, version = GroovyScript.VERSION)
 @Mod.EventBusSubscriber(modid = GroovyScript.ID)
 public class GroovyScript {
 
@@ -145,8 +145,9 @@ public class GroovyScript {
         }
     }
 
-    @Mod.EventHandler
-    public void onLoadComplete(FMLLoadCompleteEvent event) {
+    @ApiStatus.Internal
+    public static void initializeGroovyPostInit() {
+        // called via mixin between fml post init and load complete
         long time = System.currentTimeMillis();
         getSandbox().run(LoadStage.POST_INIT);
         LOGGER.info("Running Groovy scripts took " + (System.currentTimeMillis() - time) + " ms");

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/LoaderControllerMixin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/LoaderControllerMixin.java
@@ -16,11 +16,7 @@ public class LoaderControllerMixin {
         if (state == LoaderState.PREINITIALIZATION) {
             GroovyScript.initializeGroovyPreInit();
         }
-    }
-
-    @Inject(method = "distributeStateMessage(Lnet/minecraftforge/fml/common/LoaderState;[Ljava/lang/Object;)V", at = @At("RETURN"))
-    public void postInit(LoaderState state, Object[] eventData, CallbackInfo ci) {
-        if (state == LoaderState.POSTINITIALIZATION) {
+        if (state == LoaderState.AVAILABLE) {
             GroovyScript.initializeGroovyPostInit();
         }
     }

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/LoaderControllerMixin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/LoaderControllerMixin.java
@@ -17,4 +17,11 @@ public class LoaderControllerMixin {
             GroovyScript.initializeGroovyPreInit();
         }
     }
+
+    @Inject(method = "distributeStateMessage(Lnet/minecraftforge/fml/common/LoaderState;[Ljava/lang/Object;)V", at = @At("RETURN"))
+    public void postInit(LoaderState state, Object[] eventData, CallbackInfo ci) {
+        if (state == LoaderState.POSTINITIALIZATION) {
+            GroovyScript.initializeGroovyPostInit();
+        }
+    }
 }


### PR DESCRIPTION
Runs the `POST_INIT` loader on `FMLLoadComplete` instead of `FMLPostInitialization`. (while making sure run before JEI loads)

This solves any issues with scripts being run before a mod loads required recipes or other things, including an existing issue where Tinkers' registers melting recipes after scripts are run.

Also added logs that say how long the first script loads took.