### PR TITLE
Add a varargs variant for yeeting items in JEI

### DIFF
--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/JustEnoughItems.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/JustEnoughItems.java
@@ -53,20 +53,14 @@ public class JustEnoughItems extends ModPropertyContainer {
             }
             JeiPlugin.hideItem(ingredient.getMatchingStacks());
         }
-        List<ResourceLocation> recipesToRemove = new ArrayList<>();
         for (IRecipe recipe : ForgeRegistries.RECIPES) {
             if (recipe.getRegistryName() != null) {
                 for (IIngredient ingredient : ingredients) {
                     if (ingredient.test(recipe.getRecipeOutput())) {
-                        recipesToRemove.add(recipe.getRegistryName());
+                        ReloadableRegistryManager.removeRegistryEntry(ForgeRegistries.RECIPES, recipe.getRegistryName());
                         break;
                     }
                 }
-            }
-        }
-        if (!recipesToRemove.isEmpty()) {
-            for (ResourceLocation loc : recipesToRemove) {
-                ReloadableRegistryManager.removeRegistryEntry(ForgeRegistries.RECIPES, loc);
             }
         }
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/JustEnoughItems.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/JustEnoughItems.java
@@ -5,6 +5,13 @@ import com.cleanroommc.groovyscript.api.IIngredient;
 import com.cleanroommc.groovyscript.compat.mods.ModPropertyContainer;
 import com.cleanroommc.groovyscript.compat.vanilla.VanillaModule;
 import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
+import com.cleanroommc.groovyscript.registry.ReloadableRegistryManager;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.common.registry.ForgeRegistries;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class JustEnoughItems extends ModPropertyContainer {
 
@@ -35,8 +42,41 @@ public class JustEnoughItems extends ModPropertyContainer {
         JeiPlugin.hideItem(ingredient.getMatchingStacks());
     }
 
+    public void removeAndHide(IIngredient... ingredients) {
+        for (IIngredient ingredient : ingredients) {
+            if (IngredientHelper.isEmpty(ingredient)) {
+                GroovyLog.msg("Error remove and hide items {}", ingredient)
+                        .add("Items must not be empty")
+                        .error()
+                        .post();
+                return;
+            }
+            JeiPlugin.hideItem(ingredient.getMatchingStacks());
+        }
+        List<ResourceLocation> recipesToRemove = new ArrayList<>();
+        for (IRecipe recipe : ForgeRegistries.RECIPES) {
+            if (recipe.getRegistryName() != null) {
+                for (IIngredient ingredient : ingredients) {
+                    if (ingredient.test(recipe.getRecipeOutput())) {
+                        recipesToRemove.add(recipe.getRegistryName());
+                        break;
+                    }
+                }
+            }
+        }
+        if (!recipesToRemove.isEmpty()) {
+            for (ResourceLocation loc : recipesToRemove) {
+                ReloadableRegistryManager.removeRegistryEntry(ForgeRegistries.RECIPES, loc);
+            }
+        }
+    }
+
     public void yeet(IIngredient ingredient) {
         removeAndHide(ingredient);
+    }
+
+    public void yeet(IIngredient... ingredients) {
+        removeAndHide(ingredients);
     }
 
     public void hideCategory(String category) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/JustEnoughItems.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/JustEnoughItems.java
@@ -7,12 +7,7 @@ import com.cleanroommc.groovyscript.compat.vanilla.VanillaModule;
 import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
 import com.cleanroommc.groovyscript.registry.ReloadableRegistryManager;
 import net.minecraft.item.crafting.IRecipe;
-import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
 
 public class JustEnoughItems extends ModPropertyContainer {
 
@@ -28,6 +23,18 @@ public class JustEnoughItems extends ModPropertyContainer {
             JeiPlugin.HIDDEN_FLUIDS.add(IngredientHelper.toFluidStack(ingredient));
         } else {
             JeiPlugin.hideItem(ingredient.getMatchingStacks());
+        }
+    }
+
+    public void hide(IIngredient... ingredients) {
+        for (IIngredient ingredient : ingredients) {
+            hide(ingredient);
+        }
+    }
+
+    public void hide(Iterable<IIngredient> ingredients) {
+        for (IIngredient ingredient : ingredients) {
+            hide(ingredient);
         }
     }
 
@@ -66,7 +73,7 @@ public class JustEnoughItems extends ModPropertyContainer {
         }
     }
 
-    public void removeAndHide(Collection<IIngredient> ingredients) {
+    public void removeAndHide(Iterable<IIngredient> ingredients) {
         for (IIngredient ingredient : ingredients) {
             if (IngredientHelper.isEmpty(ingredient)) {
                 GroovyLog.msg("Error remove and hide items {}", ingredient)
@@ -97,7 +104,7 @@ public class JustEnoughItems extends ModPropertyContainer {
         removeAndHide(ingredients);
     }
 
-    public void yeet(Collection<IIngredient> ingredients) {
+    public void yeet(Iterable<IIngredient> ingredients) {
         removeAndHide(ingredients);
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/JustEnoughItems.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/JustEnoughItems.java
@@ -11,6 +11,7 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 public class JustEnoughItems extends ModPropertyContainer {
@@ -65,11 +66,38 @@ public class JustEnoughItems extends ModPropertyContainer {
         }
     }
 
+    public void removeAndHide(Collection<IIngredient> ingredients) {
+        for (IIngredient ingredient : ingredients) {
+            if (IngredientHelper.isEmpty(ingredient)) {
+                GroovyLog.msg("Error remove and hide items {}", ingredient)
+                        .add("Items must not be empty")
+                        .error()
+                        .post();
+                return;
+            }
+            JeiPlugin.hideItem(ingredient.getMatchingStacks());
+        }
+        for (IRecipe recipe : ForgeRegistries.RECIPES) {
+            if (recipe.getRegistryName() != null) {
+                for (IIngredient ingredient : ingredients) {
+                    if (ingredient.test(recipe.getRecipeOutput())) {
+                        ReloadableRegistryManager.removeRegistryEntry(ForgeRegistries.RECIPES, recipe.getRegistryName());
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
     public void yeet(IIngredient ingredient) {
         removeAndHide(ingredient);
     }
 
     public void yeet(IIngredient... ingredients) {
+        removeAndHide(ingredients);
+    }
+
+    public void yeet(Collection<IIngredient> ingredients) {
         removeAndHide(ingredients);
     }
 


### PR DESCRIPTION
Allows you to yeet a ton of items at the same time via varargs, which is both more convenient and more performant.