### PR TITLE
Fixes #84 + Fixes #110

### DIFF
--- a/src/main/java/com/cleanroommc/groovyscript/core/GroovyScriptCore.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/GroovyScriptCore.java
@@ -6,12 +6,15 @@ import net.minecraftforge.fml.relauncher.IFMLLoadingPlugin;
 import zone.rong.mixinbooter.IEarlyMixinLoader;
 
 import javax.annotation.Nullable;
+import java.io.File;
 import java.util.List;
 import java.util.Map;
 
 @IFMLLoadingPlugin.Name("GroovyScript-Core")
 @IFMLLoadingPlugin.MCVersion(ForgeVersion.mcVersion)
 public class GroovyScriptCore implements IFMLLoadingPlugin, IEarlyMixinLoader {
+
+    public static File source;
 
     @Override
     public String[] getASMTransformerClass() {
@@ -31,6 +34,7 @@ public class GroovyScriptCore implements IFMLLoadingPlugin, IEarlyMixinLoader {
 
     @Override
     public void injectData(Map<String, Object> data) {
+        source = (File) data.getOrDefault("coremodLocation", null);
     }
 
     @Override

--- a/src/main/java/com/cleanroommc/groovyscript/sandbox/ScriptModContainer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/sandbox/ScriptModContainer.java
@@ -1,6 +1,7 @@
 package com.cleanroommc.groovyscript.sandbox;
 
 import com.cleanroommc.groovyscript.GroovyScript;
+import com.cleanroommc.groovyscript.core.GroovyScriptCore;
 import com.google.common.eventbus.EventBus;
 import net.minecraftforge.fml.common.DummyModContainer;
 import net.minecraftforge.fml.common.LoadController;
@@ -10,17 +11,14 @@ import java.io.File;
 
 public class ScriptModContainer extends DummyModContainer {
 
-    private final File source;
-
     public ScriptModContainer() {
         super(RunConfig.modMetadata);
-        this.source = (File) FMLInjectionData.data()[6];
-        GroovyScript.initializeRunConfig(this.source);
+        GroovyScript.initializeRunConfig((File) FMLInjectionData.data()[6]);
     }
 
     @Override
     public File getSource() {
-        return source;
+        return GroovyScriptCore.source;
     }
 
     @Override


### PR DESCRIPTION
The run folder was being set as the source for the `ScriptModContainer::source`, which introduced the `.minecraft` folder as a classpath for the class loader.

AgriCraft uses the `org.reflections` library which compiles all the paths and searches resources through all of them, the source that GroovyScript puts in comes up first, leading to a relative path of `config/agricraft/json/defaults` when AgriCraft *always* expects it in its own jar which is just `json/defaults`, hence every time the path is being resolved, it appends `config/agricraft/` before it.