### PR TITLE
Add isEnabled to IScriptReloadable, clarifying some NPE errors

### DIFF
--- a/src/main/java/com/cleanroommc/groovyscript/api/IScriptReloadable.java
+++ b/src/main/java/com/cleanroommc/groovyscript/api/IScriptReloadable.java
@@ -2,8 +2,6 @@ package com.cleanroommc.groovyscript.api;
 
 import org.jetbrains.annotations.ApiStatus;
 
-import java.util.Collection;
-
 public interface IScriptReloadable extends INamed {
 
     @GroovyBlacklist
@@ -13,4 +11,10 @@ public interface IScriptReloadable extends INamed {
     @GroovyBlacklist
     @ApiStatus.OverrideOnly
     void afterScriptLoad();
+
+    @GroovyBlacklist
+    default boolean isEnabled() {
+        return true;
+    }
+
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ModPropertyContainer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ModPropertyContainer.java
@@ -1,9 +1,6 @@
 package com.cleanroommc.groovyscript.compat.mods;
 
-import com.cleanroommc.groovyscript.api.GroovyBlacklist;
-import com.cleanroommc.groovyscript.api.IDynamicGroovyProperty;
-import com.cleanroommc.groovyscript.api.IScriptReloadable;
-import com.cleanroommc.groovyscript.api.IVirtualizedRegistrar;
+import com.cleanroommc.groovyscript.api.*;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
@@ -32,7 +29,16 @@ public class ModPropertyContainer implements IDynamicGroovyProperty {
 
     @Override
     public @Nullable Object getProperty(String name) {
-        return registries.get(name);
+        IScriptReloadable registry = registries.get(name);
+        if (registry == null) {
+            GroovyLog.get().error("Attempted to access registry {}, but could not find a registry with that name", name);
+            return null;
+        }
+        if (!registry.isEnabled()) {
+            GroovyLog.get().error("Attempted to access registry {}, but that registry was disabled", registry.getName());
+            return null;
+        }
+        return registry;
     }
 
     /**

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/evilcraft/BloodInfuser.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/evilcraft/BloodInfuser.java
@@ -12,6 +12,8 @@ import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 import org.cyclops.cyclopscore.recipe.custom.api.IRecipe;
 import org.cyclops.cyclopscore.recipe.custom.component.IngredientRecipeComponent;
+import org.cyclops.evilcraft.Configs;
+import org.cyclops.evilcraft.block.BloodInfuserConfig;
 import org.cyclops.evilcraft.core.recipe.custom.DurationXpRecipeProperties;
 import org.cyclops.evilcraft.core.recipe.custom.IngredientFluidStackAndTierRecipeComponent;
 import org.jetbrains.annotations.Nullable;
@@ -21,6 +23,11 @@ public class BloodInfuser extends VirtualizedRegistry<IRecipe<IngredientFluidSta
 
     public BloodInfuser() {
         super();
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return Configs.isEnabled(BloodInfuserConfig.class);
     }
 
     @RecipeBuilderDescription(example = {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/evilcraft/EnvironmentalAccumulator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/evilcraft/EnvironmentalAccumulator.java
@@ -8,6 +8,7 @@ import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
 import net.minecraft.item.ItemStack;
 import org.cyclops.cyclopscore.recipe.custom.api.IRecipe;
+import org.cyclops.evilcraft.Configs;
 import org.cyclops.evilcraft.block.EnvironmentalAccumulatorConfig;
 import org.cyclops.evilcraft.core.recipe.custom.EnvironmentalAccumulatorRecipeComponent;
 import org.cyclops.evilcraft.core.recipe.custom.EnvironmentalAccumulatorRecipeProperties;
@@ -21,6 +22,11 @@ public class EnvironmentalAccumulator extends VirtualizedRegistry<IRecipe<Enviro
 
     public EnvironmentalAccumulator() {
         super();
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return Configs.isEnabled(EnvironmentalAccumulatorConfig.class);
     }
 
     @RecipeBuilderDescription(example = {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/forestry/Forestry.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/forestry/Forestry.java
@@ -8,7 +8,6 @@ import forestry.api.core.ForestryAPI;
 import forestry.api.genetics.AlleleManager;
 import forestry.apiculture.genetics.alleles.AlleleBeeSpecies;
 import forestry.modules.ForestryModuleUids;
-import org.jetbrains.annotations.Nullable;
 
 public class Forestry extends ModPropertyContainer {
 
@@ -39,18 +38,6 @@ public class Forestry extends ModPropertyContainer {
         addRegistry(beeMutations);
     }
 
-    @Override
-    public void initialize() {
-        GameObjectHandlerManager.registerGameObjectHandler("forestry", "species", Forestry::parseSpecies);
-    }
-
-    @Override
-    public @Nullable Object getProperty(String name) {
-        Object registry = super.getProperty(name);
-        if (registry instanceof ForestryRegistry<?> && !((ForestryRegistry<?>) registry).isEnabled()) return null;
-        return registry;
-    }
-
     public static Result<AlleleBeeSpecies> parseSpecies(String mainArg, Object... args) {
         if (!ForestryAPI.moduleManager.isModuleEnabled("forestry", ForestryModuleUids.APICULTURE)) {
             return Result.error("Can't get bee species while apiculture is disabled.");
@@ -70,5 +57,10 @@ public class Forestry extends ModPropertyContainer {
     protected static String getNormalName(String name) {
         String capital = name.substring(0, 1).toUpperCase() + name.substring(1);
         return "species" + capital;
+    }
+
+    @Override
+    public void initialize() {
+        GameObjectHandlerManager.registerGameObjectHandler("forestry", "species", Forestry::parseSpecies);
     }
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/integrateddynamics/MechanicalDryingBasin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/integrateddynamics/MechanicalDryingBasin.java
@@ -7,12 +7,20 @@ import net.minecraft.item.ItemStack;
 import org.cyclops.cyclopscore.recipe.custom.api.IRecipe;
 import org.cyclops.cyclopscore.recipe.custom.component.DurationRecipeProperties;
 import org.cyclops.cyclopscore.recipe.custom.component.IngredientAndFluidStackRecipeComponent;
+import org.cyclops.integrateddynamics.Configs;
+import org.cyclops.integrateddynamics.block.BlockMechanicalDryingBasin;
+import org.cyclops.integrateddynamics.block.BlockMechanicalDryingBasinConfig;
 
 @RegistryDescription
 public class MechanicalDryingBasin extends VirtualizedRegistry<IRecipe<IngredientAndFluidStackRecipeComponent, IngredientAndFluidStackRecipeComponent, DurationRecipeProperties>> {
 
     public MechanicalDryingBasin() {
         super();
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return Configs.isEnabled(BlockMechanicalDryingBasinConfig.class);
     }
 
     @RecipeBuilderDescription(example = @Example(".input(item('minecraft:diamond')).fluidInput(fluid('water') * 50).fluidOutput(fluid('lava') * 20000).duration(300)"), requirement = @Property(property = "mechanical", defaultValue = "true"))
@@ -22,8 +30,8 @@ public class MechanicalDryingBasin extends VirtualizedRegistry<IRecipe<Ingredien
 
     @Override
     public void onReload() {
-        removeScripted().forEach(org.cyclops.integrateddynamics.block.BlockMechanicalDryingBasin.getInstance().getRecipeRegistry().allRecipes()::remove);
-        restoreFromBackup().forEach(org.cyclops.integrateddynamics.block.BlockMechanicalDryingBasin.getInstance().getRecipeRegistry().allRecipes()::add);
+        removeScripted().forEach(BlockMechanicalDryingBasin.getInstance().getRecipeRegistry().allRecipes()::remove);
+        restoreFromBackup().forEach(BlockMechanicalDryingBasin.getInstance().getRecipeRegistry().allRecipes()::add);
     }
 
     public void add(IRecipe<IngredientAndFluidStackRecipeComponent, IngredientAndFluidStackRecipeComponent, DurationRecipeProperties> recipe) {
@@ -33,19 +41,19 @@ public class MechanicalDryingBasin extends VirtualizedRegistry<IRecipe<Ingredien
     public void add(IRecipe<IngredientAndFluidStackRecipeComponent, IngredientAndFluidStackRecipeComponent, DurationRecipeProperties> recipe, boolean add) {
         if (recipe == null) return;
         addScripted(recipe);
-        if (add) org.cyclops.integrateddynamics.block.BlockMechanicalDryingBasin.getInstance().getRecipeRegistry().allRecipes().add(recipe);
+        if (add) BlockMechanicalDryingBasin.getInstance().getRecipeRegistry().allRecipes().add(recipe);
     }
 
     public boolean remove(IRecipe<IngredientAndFluidStackRecipeComponent, IngredientAndFluidStackRecipeComponent, DurationRecipeProperties> recipe) {
         if (recipe == null) return false;
         addBackup(recipe);
-        org.cyclops.integrateddynamics.block.BlockMechanicalDryingBasin.getInstance().getRecipeRegistry().allRecipes().remove(recipe);
+        BlockMechanicalDryingBasin.getInstance().getRecipeRegistry().allRecipes().remove(recipe);
         return true;
     }
 
     @MethodDescription(description = "groovyscript.wiki.removeByInput")
     public boolean removeByInput(ItemStack input) {
-        return org.cyclops.integrateddynamics.block.BlockMechanicalDryingBasin.getInstance().getRecipeRegistry().allRecipes().removeIf(r -> {
+        return BlockMechanicalDryingBasin.getInstance().getRecipeRegistry().allRecipes().removeIf(r -> {
             if (r.getInput().getIngredient().test(input)) {
                 addBackup(r);
                 return true;
@@ -56,7 +64,7 @@ public class MechanicalDryingBasin extends VirtualizedRegistry<IRecipe<Ingredien
 
     @MethodDescription(description = "groovyscript.wiki.removeByOutput")
     public boolean removeByOutput(ItemStack input) {
-        return org.cyclops.integrateddynamics.block.BlockMechanicalDryingBasin.getInstance().getRecipeRegistry().allRecipes().removeIf(r -> {
+        return BlockMechanicalDryingBasin.getInstance().getRecipeRegistry().allRecipes().removeIf(r -> {
             if (r.getOutput().getIngredient().test(input)) {
                 addBackup(r);
                 return true;
@@ -67,13 +75,13 @@ public class MechanicalDryingBasin extends VirtualizedRegistry<IRecipe<Ingredien
 
     @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
     public void removeAll() {
-        org.cyclops.integrateddynamics.block.BlockMechanicalDryingBasin.getInstance().getRecipeRegistry().allRecipes().forEach(this::addBackup);
-        org.cyclops.integrateddynamics.block.BlockMechanicalDryingBasin.getInstance().getRecipeRegistry().allRecipes().clear();
+        BlockMechanicalDryingBasin.getInstance().getRecipeRegistry().allRecipes().forEach(this::addBackup);
+        BlockMechanicalDryingBasin.getInstance().getRecipeRegistry().allRecipes().clear();
     }
 
     @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<IRecipe<IngredientAndFluidStackRecipeComponent, IngredientAndFluidStackRecipeComponent, DurationRecipeProperties>> streamRecipes() {
-        return new SimpleObjectStream<>(org.cyclops.integrateddynamics.block.BlockMechanicalDryingBasin.getInstance().getRecipeRegistry().allRecipes())
+        return new SimpleObjectStream<>(BlockMechanicalDryingBasin.getInstance().getRecipeRegistry().allRecipes())
                 .setRemover(this::remove);
     }
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/integrateddynamics/MechanicalSqueezer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/integrateddynamics/MechanicalSqueezer.java
@@ -8,12 +8,20 @@ import org.cyclops.cyclopscore.recipe.custom.api.IRecipe;
 import org.cyclops.cyclopscore.recipe.custom.component.DurationRecipeProperties;
 import org.cyclops.cyclopscore.recipe.custom.component.IngredientRecipeComponent;
 import org.cyclops.cyclopscore.recipe.custom.component.IngredientsAndFluidStackRecipeComponent;
+import org.cyclops.integrateddynamics.Configs;
+import org.cyclops.integrateddynamics.block.BlockMechanicalSqueezer;
+import org.cyclops.integrateddynamics.block.BlockMechanicalSqueezerConfig;
 
 @RegistryDescription
 public class MechanicalSqueezer extends VirtualizedRegistry<IRecipe<IngredientRecipeComponent, IngredientsAndFluidStackRecipeComponent, DurationRecipeProperties>> {
 
     public MechanicalSqueezer() {
         super();
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return Configs.isEnabled(BlockMechanicalSqueezerConfig.class);
     }
 
     @RecipeBuilderDescription(example = @Example(".input(item('minecraft:diamond')).output(item('minecraft:clay') * 16, 0.9F)"), requirement = @Property(property = "mechanical", defaultValue = "true"))
@@ -23,8 +31,8 @@ public class MechanicalSqueezer extends VirtualizedRegistry<IRecipe<IngredientRe
 
     @Override
     public void onReload() {
-        removeScripted().forEach(org.cyclops.integrateddynamics.block.BlockMechanicalSqueezer.getInstance().getRecipeRegistry().allRecipes()::remove);
-        restoreFromBackup().forEach(org.cyclops.integrateddynamics.block.BlockMechanicalSqueezer.getInstance().getRecipeRegistry().allRecipes()::add);
+        removeScripted().forEach(BlockMechanicalSqueezer.getInstance().getRecipeRegistry().allRecipes()::remove);
+        restoreFromBackup().forEach(BlockMechanicalSqueezer.getInstance().getRecipeRegistry().allRecipes()::add);
     }
 
     public void add(IRecipe<IngredientRecipeComponent, IngredientsAndFluidStackRecipeComponent, DurationRecipeProperties> recipe) {
@@ -34,19 +42,19 @@ public class MechanicalSqueezer extends VirtualizedRegistry<IRecipe<IngredientRe
     public void add(IRecipe<IngredientRecipeComponent, IngredientsAndFluidStackRecipeComponent, DurationRecipeProperties> recipe, boolean add) {
         if (recipe == null) return;
         addScripted(recipe);
-        if (add) org.cyclops.integrateddynamics.block.BlockMechanicalSqueezer.getInstance().getRecipeRegistry().allRecipes().add(recipe);
+        if (add) BlockMechanicalSqueezer.getInstance().getRecipeRegistry().allRecipes().add(recipe);
     }
 
     public boolean remove(IRecipe<IngredientRecipeComponent, IngredientsAndFluidStackRecipeComponent, DurationRecipeProperties> recipe) {
         if (recipe == null) return false;
         addBackup(recipe);
-        org.cyclops.integrateddynamics.block.BlockMechanicalSqueezer.getInstance().getRecipeRegistry().allRecipes().remove(recipe);
+        BlockMechanicalSqueezer.getInstance().getRecipeRegistry().allRecipes().remove(recipe);
         return true;
     }
 
     @MethodDescription(description = "groovyscript.wiki.removeByInput")
     public boolean removeByInput(ItemStack input) {
-        return org.cyclops.integrateddynamics.block.BlockMechanicalSqueezer.getInstance().getRecipeRegistry().allRecipes().removeIf(r -> {
+        return BlockMechanicalSqueezer.getInstance().getRecipeRegistry().allRecipes().removeIf(r -> {
             if (r.getInput().getIngredient().test(input)) {
                 addBackup(r);
                 return true;
@@ -57,13 +65,13 @@ public class MechanicalSqueezer extends VirtualizedRegistry<IRecipe<IngredientRe
 
     @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
     public void removeAll() {
-        org.cyclops.integrateddynamics.block.BlockMechanicalSqueezer.getInstance().getRecipeRegistry().allRecipes().forEach(this::addBackup);
-        org.cyclops.integrateddynamics.block.BlockMechanicalSqueezer.getInstance().getRecipeRegistry().allRecipes().clear();
+        BlockMechanicalSqueezer.getInstance().getRecipeRegistry().allRecipes().forEach(this::addBackup);
+        BlockMechanicalSqueezer.getInstance().getRecipeRegistry().allRecipes().clear();
     }
 
     @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<IRecipe<IngredientRecipeComponent, IngredientsAndFluidStackRecipeComponent, DurationRecipeProperties>> streamRecipes() {
-        return new SimpleObjectStream<>(org.cyclops.integrateddynamics.block.BlockMechanicalSqueezer.getInstance().getRecipeRegistry().allRecipes())
+        return new SimpleObjectStream<>(BlockMechanicalSqueezer.getInstance().getRecipeRegistry().allRecipes())
                 .setRemover(this::remove);
     }
 }

--- a/src/main/java/com/cleanroommc/groovyscript/registry/ReloadableRegistryManager.java
+++ b/src/main/java/com/cleanroommc/groovyscript/registry/ReloadableRegistryManager.java
@@ -82,6 +82,7 @@ public class ReloadableRegistryManager {
                 .map(GroovyContainer::get)
                 .map(ModPropertyContainer::getRegistries)
                 .flatMap(Collection::stream)
+                .filter(IScriptReloadable::isEnabled)
                 .forEach(IScriptReloadable::onReload);
         if (ModSupport.JEI.isLoaded()) {
             JeiPlugin.reload();
@@ -95,6 +96,7 @@ public class ReloadableRegistryManager {
                 .map(GroovyContainer::get)
                 .map(ModPropertyContainer::getRegistries)
                 .flatMap(Collection::stream)
+                .filter(IScriptReloadable::isEnabled)
                 .forEach(IScriptReloadable::afterScriptLoad);
         VanillaModule.INSTANCE.afterScriptLoad();
         unfreezeForgeRegistries();


### PR DESCRIPTION
Forestry already had a similar system in place, but applied exclusively to its own compat and didn't provide any error logging.
Now individual registries can override the `isEnabled` method to ensure the registry actually exists. Only applied this to Integrated Dynamics (resolving #125), Blood Magic (uses same internals), and Forestry (pre-existing).


now, when loading into the world you will be presented with a much more helpful error message of "that registry is disabled" instead of just "Null Pointer Exception".
![image](https://github.com/CleanroomMC/GroovyScript/assets/25394029/24195056-8a0f-4209-94fc-147d0b2654b0)

don't know what appends the `Possible solutions:` line, which in this context provides incorrect information.