### PR TITLE
add Better With Mods compat

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -43,6 +43,13 @@ dependencies {
         runtimeOnly rfg.deobf('curse.maven:chisel-235279:2915375')
     }
 
+    compileOnly rfg.deobf('curse.maven:bwm-suite-246760:3289033')
+    compileOnly rfg.deobf('curse.maven:bwm-core-294335:2624990')
+    if (project.debug_better_with_mods.toBoolean()) {
+        runtimeOnly rfg.deobf('curse.maven:bwm-suite-246760:3289033')
+        runtimeOnly rfg.deobf('curse.maven:bwm-core-294335:2624990')
+    }
+
     compileOnly rfg.deobf('curse.maven:mantle-74924:2713386')
     if (project.debug_inspirations.toBoolean() || project.debug_tinkers.toBoolean()) {
         runtimeOnly rfg.deobf('curse.maven:mantle-74924:2713386')

--- a/examples/postInit/betterwithmods.groovy
+++ b/examples/postInit/betterwithmods.groovy
@@ -1,0 +1,148 @@
+
+// Auto generated groovyscript example file
+// MODS_LOADED: betterwithmods
+
+println 'mod \'betterwithmods\' detected, running script'
+
+// Anvil Crafting:
+// Similar to a normal crafting table, but 4x4 instead.
+
+mods.betterwithmods.anvil_crafting.removeByInput(item('minecraft:redstone'))
+mods.betterwithmods.anvil_crafting.removeByOutput(item('betterwithmods:steel_block'))
+mods.betterwithmods.anvil_crafting.removeAll()
+
+mods.betterwithmods.anvil_crafting.shapedBuilder()
+    .output(item('minecraft:diamond') * 32)
+    .matrix([[item('minecraft:gold_ingot'),item('minecraft:gold_ingot'),item('minecraft:gold_ingot'),null],
+            [item('minecraft:gold_ingot'),item('minecraft:gold_ingot'),item('minecraft:gold_ingot'),null],
+            [item('minecraft:gold_ingot'),item('minecraft:gold_ingot'),item('minecraft:gold_ingot'),null],
+            [null,null,null,item('minecraft:gold_ingot').transform({ _ -> item('minecraft:diamond') })]])
+    .register()
+
+mods.betterwithmods.anvil_crafting.shapedBuilder()
+    .output(item('minecraft:diamond'))
+    .matrix('BXXX')
+    .mirrored()
+    .key('B', item('minecraft:stone'))
+    .key('X', item('minecraft:gold_ingot'))
+    .register()
+
+mods.betterwithmods.anvil_crafting.shapelessBuilder()
+    .name(resource('example:anvil_clay'))
+    .output(item('minecraft:clay'))
+    .input([item('minecraft:cobblestone'), item('minecraft:gold_ingot')])
+    .register()
+
+
+// Cauldron:
+// Converts a large number of items into other items, with the ability to require specific amounts of heat.
+
+mods.betterwithmods.cauldron.removeByInput(item('minecraft:gunpowder'))
+mods.betterwithmods.cauldron.removeByOutput(item('minecraft:gunpowder'))
+mods.betterwithmods.cauldron.removeAll()
+
+mods.betterwithmods.cauldron.recipeBuilder()
+    .input(item('minecraft:clay'))
+    .output(item('minecraft:diamond'))
+    .heat(2)
+    .register()
+
+mods.betterwithmods.cauldron.recipeBuilder()
+    .input(item('minecraft:diamond') * 2)
+    .output(item('minecraft:gold_ingot') * 16)
+    .ignoreHeat()
+    .register()
+
+
+// groovyscript.wiki.betterwithmods.crucible.title:
+// groovyscript.wiki.betterwithmods.crucible.description
+
+mods.betterwithmods.crucible.removeByInput(item('minecraft:gunpowder'))
+mods.betterwithmods.crucible.removeByOutput(item('minecraft:gunpowder'))
+mods.betterwithmods.crucible.removeAll()
+
+mods.betterwithmods.crucible.recipeBuilder()
+    .input(item('minecraft:clay'))
+    .output(item('minecraft:diamond'))
+    .heat(2)
+    .register()
+
+mods.betterwithmods.crucible.recipeBuilder()
+    .input(item('minecraft:diamond') * 2)
+    .output(item('minecraft:gold_ingot') * 16)
+    .ignoreHeat()
+    .register()
+
+
+// Kiln:
+// Converts a block into up to three output itemstacks, with the ability to require specific amounts of heat.
+
+mods.betterwithmods.kiln.removeByInput(item('minecraft:end_stone'))
+mods.betterwithmods.kiln.removeByOutput(item('minecraft:brick'))
+mods.betterwithmods.kiln.removeAll()
+
+mods.betterwithmods.kiln.recipeBuilder()
+    .input(item('minecraft:clay'))
+    .output(item('minecraft:diamond'))
+    .heat(2)
+    .register()
+
+mods.betterwithmods.kiln.recipeBuilder()
+    .input(item('minecraft:diamond_block'))
+    .output(item('minecraft:gold_ingot') * 16)
+    .ignoreHeat()
+    .register()
+
+
+// Mill Stone:
+// Converts input itemstacks into output itemstacks after being ground via rotation power for a given time.
+
+mods.betterwithmods.mill_stone.removeByInput(item('minecraft:netherrack'))
+mods.betterwithmods.mill_stone.removeByOutput(item('minecraft:blaze_powder'))
+mods.betterwithmods.mill_stone.removeAll()
+
+mods.betterwithmods.mill_stone.recipeBuilder()
+    .input(item('minecraft:diamond') * 2)
+    .output(item('minecraft:gold_ingot') * 16)
+    .register()
+
+mods.betterwithmods.mill_stone.recipeBuilder()
+    .input(item('minecraft:diamond_block'))
+    .output(item('minecraft:gold_ingot'), item('minecraft:gold_block'), item('minecraft:clay'))
+    .register()
+
+
+// Saw:
+// Converts a block into output itemstacks after being powered via rotation power.
+
+mods.betterwithmods.saw.removeByInput(item('minecraft:vine'))
+mods.betterwithmods.saw.removeByOutput(item('minecraft:pumpkin'))
+mods.betterwithmods.saw.removeAll()
+
+mods.betterwithmods.saw.recipeBuilder()
+    .input(item('minecraft:diamond_block'))
+    .output(item('minecraft:gold_ingot') * 16)
+    .register()
+
+
+// Turntable:
+// Converts a block into an output block and up to two itemstacks after being powered via rotation power.
+
+mods.betterwithmods.turntable.removeByInput(item('betterwithmods:unfired_pottery'))
+mods.betterwithmods.turntable.removeByOutput(item('minecraft:clay_ball'))
+mods.betterwithmods.turntable.removeAll()
+
+mods.betterwithmods.turntable.recipeBuilder()
+    .input(item('minecraft:gold_block'))
+    .outputBlock(blockstate('minecraft:clay'))
+    .output(item('minecraft:gold_ingot') * 5)
+    .rotations(5)
+    .register()
+
+mods.betterwithmods.turntable.recipeBuilder()
+    .input(item('minecraft:clay'))
+    .output(item('minecraft:gold_ingot'))
+    .rotations(2)
+    .register()
+
+

--- a/examples/postInit/betterwithmods.groovy
+++ b/examples/postInit/betterwithmods.groovy
@@ -9,7 +9,7 @@ println 'mod \'betterwithmods\' detected, running script'
 
 mods.betterwithmods.anvil_crafting.removeByInput(item('minecraft:redstone'))
 mods.betterwithmods.anvil_crafting.removeByOutput(item('betterwithmods:steel_block'))
-mods.betterwithmods.anvil_crafting.removeAll()
+// mods.betterwithmods.anvil_crafting.removeAll()
 
 mods.betterwithmods.anvil_crafting.shapedBuilder()
     .output(item('minecraft:diamond') * 32)
@@ -39,7 +39,7 @@ mods.betterwithmods.anvil_crafting.shapelessBuilder()
 
 mods.betterwithmods.cauldron.removeByInput(item('minecraft:gunpowder'))
 mods.betterwithmods.cauldron.removeByOutput(item('minecraft:gunpowder'))
-mods.betterwithmods.cauldron.removeAll()
+// mods.betterwithmods.cauldron.removeAll()
 
 mods.betterwithmods.cauldron.recipeBuilder()
     .input(item('minecraft:clay'))
@@ -54,12 +54,12 @@ mods.betterwithmods.cauldron.recipeBuilder()
     .register()
 
 
-// groovyscript.wiki.betterwithmods.crucible.title:
-// groovyscript.wiki.betterwithmods.crucible.description
+// Crucible:
+// Converts a large number of items into other items, with the ability to require specific amounts of heat.
 
 mods.betterwithmods.crucible.removeByInput(item('minecraft:gunpowder'))
 mods.betterwithmods.crucible.removeByOutput(item('minecraft:gunpowder'))
-mods.betterwithmods.crucible.removeAll()
+// mods.betterwithmods.crucible.removeAll()
 
 mods.betterwithmods.crucible.recipeBuilder()
     .input(item('minecraft:clay'))
@@ -79,7 +79,7 @@ mods.betterwithmods.crucible.recipeBuilder()
 
 mods.betterwithmods.kiln.removeByInput(item('minecraft:end_stone'))
 mods.betterwithmods.kiln.removeByOutput(item('minecraft:brick'))
-mods.betterwithmods.kiln.removeAll()
+// mods.betterwithmods.kiln.removeAll()
 
 mods.betterwithmods.kiln.recipeBuilder()
     .input(item('minecraft:clay'))
@@ -99,7 +99,7 @@ mods.betterwithmods.kiln.recipeBuilder()
 
 mods.betterwithmods.mill_stone.removeByInput(item('minecraft:netherrack'))
 mods.betterwithmods.mill_stone.removeByOutput(item('minecraft:blaze_powder'))
-mods.betterwithmods.mill_stone.removeAll()
+// mods.betterwithmods.mill_stone.removeAll()
 
 mods.betterwithmods.mill_stone.recipeBuilder()
     .input(item('minecraft:diamond') * 2)
@@ -117,7 +117,7 @@ mods.betterwithmods.mill_stone.recipeBuilder()
 
 mods.betterwithmods.saw.removeByInput(item('minecraft:vine'))
 mods.betterwithmods.saw.removeByOutput(item('minecraft:pumpkin'))
-mods.betterwithmods.saw.removeAll()
+// mods.betterwithmods.saw.removeAll()
 
 mods.betterwithmods.saw.recipeBuilder()
     .input(item('minecraft:diamond_block'))
@@ -130,7 +130,7 @@ mods.betterwithmods.saw.recipeBuilder()
 
 mods.betterwithmods.turntable.removeByInput(item('betterwithmods:unfired_pottery'))
 mods.betterwithmods.turntable.removeByOutput(item('minecraft:clay_ball'))
-mods.betterwithmods.turntable.removeAll()
+// mods.betterwithmods.turntable.removeAll()
 
 mods.betterwithmods.turntable.recipeBuilder()
     .input(item('minecraft:gold_block'))

--- a/examples/postInit/betterwithmods.groovy
+++ b/examples/postInit/betterwithmods.groovy
@@ -48,7 +48,7 @@ mods.betterwithmods.cauldron.recipeBuilder()
     .register()
 
 mods.betterwithmods.cauldron.recipeBuilder()
-    .input(item('minecraft:diamond') * 2)
+    .input(item('minecraft:diamond'))
     .output(item('minecraft:gold_ingot') * 16)
     .ignoreHeat()
     .register()
@@ -68,9 +68,55 @@ mods.betterwithmods.crucible.recipeBuilder()
     .register()
 
 mods.betterwithmods.crucible.recipeBuilder()
-    .input(item('minecraft:diamond') * 2)
+    .input(item('minecraft:diamond'))
     .output(item('minecraft:gold_ingot') * 16)
     .ignoreHeat()
+    .register()
+
+
+// Heat:
+// Creates new levels or adds new blocks to old heat levels.
+
+mods.betterwithmods.heat.add(4, item('minecraft:redstone_block'), item('minecraft:redstone_torch'))
+mods.betterwithmods.heat.add(3, 'torch')
+
+// Filtered Hopper:
+// Recipes for the Filtered Hopper to process. The filter targeted must allow the input item in to function.
+
+mods.betterwithmods.hopper.removeByInput(item('minecraft:gunpowder'))
+mods.betterwithmods.hopper.removeByOutput(item('minecraft:gunpowder'))
+// mods.betterwithmods.hopper.removeAll()
+
+mods.betterwithmods.hopper.recipeBuilder()
+    .name('betterwithmods:iron_bar')
+    .input(ore('sand'))
+    .output(item('minecraft:clay'))
+    .inWorldItemOutput(item('minecraft:gold_ingot'))
+    .register()
+
+mods.betterwithmods.hopper.recipeBuilder()
+    .name('betterwithmods:wicker')
+    .input(item('minecraft:clay'))
+    .inWorldItemOutput(item('minecraft:gold_ingot'))
+    .register()
+
+
+// Hopper Filters:
+// Items placed in the middle slot of the Filtered Hopper to restrict what is capable of passing through.
+
+mods.betterwithmods.hopper_filters.removeByFilter(item('minecraft:trapdoor'))
+mods.betterwithmods.hopper_filters.removeByName('betterwithmods:ladder')
+// mods.betterwithmods.hopper_filters.removeAll()
+
+mods.betterwithmods.hopper_filters.recipeBuilder()
+    .name('too_weak_to_stop')
+    .filter(item('minecraft:string'))
+    .register()
+
+mods.betterwithmods.hopper_filters.recipeBuilder()
+    .name('groovyscript:clay_only')
+    .filter(item('minecraft:clay'))
+    .input(item('minecraft:clay'))
     .register()
 
 
@@ -102,7 +148,7 @@ mods.betterwithmods.mill_stone.removeByOutput(item('minecraft:blaze_powder'))
 // mods.betterwithmods.mill_stone.removeAll()
 
 mods.betterwithmods.mill_stone.recipeBuilder()
-    .input(item('minecraft:diamond') * 2)
+    .input(item('minecraft:diamond'))
     .output(item('minecraft:gold_ingot') * 16)
     .register()
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,7 @@ debug_adv_mortars = false
 debug_applied_energistics_2 = false
 debug_astral = false
 debug_avaritia = false
+debug_better_with_mods = false
 debug_blood_magic = false
 debug_botania = false
 debug_chisel = false

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ModSupport.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ModSupport.java
@@ -9,6 +9,7 @@ import com.cleanroommc.groovyscript.compat.mods.advancedmortars.AdvancedMortars;
 import com.cleanroommc.groovyscript.compat.mods.appliedenergistics2.AppliedEnergistics2;
 import com.cleanroommc.groovyscript.compat.mods.astralsorcery.AstralSorcery;
 import com.cleanroommc.groovyscript.compat.mods.avaritia.Avaritia;
+import com.cleanroommc.groovyscript.compat.mods.betterwithmods.BetterWithMods;
 import com.cleanroommc.groovyscript.compat.mods.bloodmagic.BloodMagic;
 import com.cleanroommc.groovyscript.compat.mods.botania.Botania;
 import com.cleanroommc.groovyscript.compat.mods.chisel.Chisel;
@@ -55,6 +56,7 @@ public class ModSupport implements IDynamicGroovyProperty {
     public static final GroovyContainer<AppliedEnergistics2> APPLIED_ENERGISTICS_2 = new InternalModContainer<>("appliedenergistics2", "Applied Energistics 2", AppliedEnergistics2::new, "ae2");
     public static final GroovyContainer<AstralSorcery> ASTRAL_SORCERY = new InternalModContainer<>("astralsorcery", "Astral Sorcery", AstralSorcery::new, "astral");
     public static final GroovyContainer<Avaritia> AVARITIA = new InternalModContainer<>("avaritia", "Avaritia", Avaritia::new);
+    public static final GroovyContainer<BetterWithMods> BETTER_WITH_MODS = new InternalModContainer<>("betterwithmods", "Better With Mods", BetterWithMods::new);
     public static final GroovyContainer<BloodMagic> BLOOD_MAGIC = new InternalModContainer<>("bloodmagic", "Blood Magic: Alchemical Wizardry", BloodMagic::new, "bm");
     public static final GroovyContainer<Botania> BOTANIA = new InternalModContainer<>("botania", "Botania", Botania::new);
     public static final GroovyContainer<Chisel> CHISEL = new InternalModContainer<>("chisel", "Chisel", Chisel::new);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/AnvilCrafting.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/AnvilCrafting.java
@@ -1,0 +1,99 @@
+package com.cleanroommc.groovyscript.compat.mods.betterwithmods;
+
+import betterwithmods.common.registry.anvil.AnvilCraftingManager;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.Example;
+import com.cleanroommc.groovyscript.api.documentation.annotations.MethodDescription;
+import com.cleanroommc.groovyscript.api.documentation.annotations.RecipeBuilderDescription;
+import com.cleanroommc.groovyscript.api.documentation.annotations.RegistryDescription;
+import com.cleanroommc.groovyscript.helper.Alias;
+import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
+import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
+import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.item.crafting.Ingredient;
+
+@RegistryDescription
+public class AnvilCrafting extends VirtualizedRegistry<IRecipe> {
+
+    public AnvilCrafting() {
+        super(Alias.generateOfClass(AnvilCrafting.class).andGenerate("SoulforgedSteelAnvil"));
+    }
+
+    @RecipeBuilderDescription(example = {
+            @Example(".output(item('minecraft:diamond') * 32).matrix([[item('minecraft:gold_ingot'),item('minecraft:gold_ingot'),item('minecraft:gold_ingot'),null],[item('minecraft:gold_ingot'),item('minecraft:gold_ingot'),item('minecraft:gold_ingot'),null],[item('minecraft:gold_ingot'),item('minecraft:gold_ingot'),item('minecraft:gold_ingot'),null],[null,null,null,item('minecraft:gold_ingot').transform({ _ -> item('minecraft:diamond') })]])"),
+            @Example(".output(item('minecraft:diamond')).matrix('BXXX').mirrored().key('B', item('minecraft:stone')).key('X', item('minecraft:gold_ingot'))")
+    })
+    public AnvilRecipeBuilder.Shaped shapedBuilder() {
+        return new AnvilRecipeBuilder.Shaped();
+    }
+
+    @RecipeBuilderDescription(example = @Example(".name(resource('example:anvil_clay')).output(item('minecraft:clay')).input([item('minecraft:cobblestone'), item('minecraft:gold_ingot')])"))
+    public AnvilRecipeBuilder.Shapeless shapelessBuilder() {
+        return new AnvilRecipeBuilder.Shapeless();
+    }
+
+    @Override
+    public void onReload() {
+        removeScripted().forEach(recipe -> AnvilCraftingManager.ANVIL_CRAFTING.removeIf(r -> r == recipe));
+        AnvilCraftingManager.ANVIL_CRAFTING.addAll(restoreFromBackup());
+    }
+
+    public IRecipe add(IRecipe recipe) {
+        if (recipe != null) {
+            addScripted(recipe);
+            AnvilCraftingManager.ANVIL_CRAFTING.add(recipe);
+        }
+        return recipe;
+    }
+
+    public boolean remove(IRecipe recipe) {
+        if (AnvilCraftingManager.ANVIL_CRAFTING.removeIf(r -> r == recipe)) {
+            addBackup(recipe);
+            return true;
+        }
+        return false;
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('betterwithmods:steel_block')"))
+    public boolean removeByOutput(ItemStack output) {
+        return AnvilCraftingManager.ANVIL_CRAFTING.removeIf(r -> {
+            if (r.getRecipeOutput().equals(output)) {
+                addBackup(r);
+                return true;
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:redstone')"))
+    public boolean removeByInput(ItemStack input) {
+        return AnvilCraftingManager.ANVIL_CRAFTING.removeIf(r -> {
+            for (Ingredient ingredient : r.getIngredients()) {
+                if (ingredient.test(input)) {
+                    addBackup(r);
+                    return true;
+                }
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeByInput")
+    public boolean removeByInput(IIngredient input) {
+        return removeByInput(IngredientHelper.toItemStack(input));
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    public SimpleObjectStream<IRecipe> streamRecipes() {
+        return new SimpleObjectStream<>(AnvilCraftingManager.ANVIL_CRAFTING).setRemover(this::remove);
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    public void removeAll() {
+        AnvilCraftingManager.ANVIL_CRAFTING.forEach(this::addBackup);
+        AnvilCraftingManager.ANVIL_CRAFTING.clear();
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/AnvilCrafting.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/AnvilCrafting.java
@@ -57,9 +57,9 @@ public class AnvilCrafting extends VirtualizedRegistry<IRecipe> {
     }
 
     @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('betterwithmods:steel_block')"))
-    public boolean removeByOutput(ItemStack output) {
+    public boolean removeByOutput(IIngredient output) {
         return AnvilCraftingManager.ANVIL_CRAFTING.removeIf(r -> {
-            if (r.getRecipeOutput().equals(output)) {
+            if (output.test(r.getRecipeOutput())) {
                 addBackup(r);
                 return true;
             }
@@ -68,21 +68,18 @@ public class AnvilCrafting extends VirtualizedRegistry<IRecipe> {
     }
 
     @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:redstone')"))
-    public boolean removeByInput(ItemStack input) {
+    public boolean removeByInput(IIngredient input) {
         return AnvilCraftingManager.ANVIL_CRAFTING.removeIf(r -> {
             for (Ingredient ingredient : r.getIngredients()) {
-                if (ingredient.test(input)) {
-                    addBackup(r);
-                    return true;
+                for (ItemStack item : ingredient.getMatchingStacks()) {
+                    if (input.test(item)) {
+                        addBackup(r);
+                        return true;
+                    }
                 }
             }
             return false;
         });
-    }
-
-    @MethodDescription(description = "groovyscript.wiki.removeByInput")
-    public boolean removeByInput(IIngredient input) {
-        return removeByInput(IngredientHelper.toItemStack(input));
     }
 
     @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/AnvilRecipeBuilder.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/AnvilRecipeBuilder.java
@@ -1,0 +1,186 @@
+package com.cleanroommc.groovyscript.compat.mods.betterwithmods;
+
+import betterwithmods.common.registry.anvil.ShapedAnvilRecipe;
+import betterwithmods.common.registry.anvil.ShapelessAnvilRecipe;
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.Comp;
+import com.cleanroommc.groovyscript.api.documentation.annotations.Property;
+import com.cleanroommc.groovyscript.api.documentation.annotations.RecipeBuilderMethodDescription;
+import com.cleanroommc.groovyscript.api.documentation.annotations.RecipeBuilderRegistrationMethod;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.compat.vanilla.CraftingRecipeBuilder;
+import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
+import it.unimi.dsi.fastutil.chars.Char2ObjectOpenHashMap;
+import net.minecraft.item.crafting.IRecipe;
+import org.apache.commons.lang3.ArrayUtils;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+public abstract class AnvilRecipeBuilder extends CraftingRecipeBuilder {
+
+    public AnvilRecipeBuilder() {
+        super(4, 4);
+    }
+
+    public static class Shaped extends AnvilRecipeBuilder {
+
+        @Property(value = "groovyscript.wiki.craftingrecipe.keyMap.value", defaultValue = "' ' = IIngredient.EMPTY", priority = 200)
+        private final Char2ObjectOpenHashMap<IIngredient> keyMap = new Char2ObjectOpenHashMap<>();
+        private final List<String> errors = new ArrayList<>();
+        @Property("groovyscript.wiki.craftingrecipe.mirrored.value")
+        protected boolean mirrored = false;
+        @Property(value = "groovyscript.wiki.craftingrecipe.keyBasedMatrix.value", requirement = "groovyscript.wiki.craftingrecipe.matrix.required", priority = 210)
+        private String[] keyBasedMatrix;
+        @Property(value = "groovyscript.wiki.craftingrecipe.ingredientMatrix.value", requirement = "groovyscript.wiki.craftingrecipe.matrix.required", valid = {
+                @Comp(value = "1", type = Comp.Type.GTE), @Comp(value = "81", type = Comp.Type.LTE)}, priority = 250)
+        private List<List<IIngredient>> ingredientMatrix;
+
+        public Shaped() {
+            keyMap.put(' ', IIngredient.EMPTY);
+        }
+
+        @RecipeBuilderMethodDescription
+        public AnvilRecipeBuilder.Shaped mirrored(boolean mirrored) {
+            this.mirrored = mirrored;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public AnvilRecipeBuilder.Shaped mirrored() {
+            return mirrored(true);
+        }
+
+        @RecipeBuilderMethodDescription(field = "keyBasedMatrix")
+        public AnvilRecipeBuilder.Shaped matrix(String... matrix) {
+            this.keyBasedMatrix = matrix;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription(field = "keyBasedMatrix")
+        public AnvilRecipeBuilder.Shaped shape(String... matrix) {
+            this.keyBasedMatrix = matrix;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription(field = "keyBasedMatrix")
+        public AnvilRecipeBuilder.Shaped row(String row) {
+            if (this.keyBasedMatrix == null) {
+                this.keyBasedMatrix = new String[]{row};
+            } else {
+                this.keyBasedMatrix = ArrayUtils.add(this.keyBasedMatrix, row);
+            }
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription(field = "keyMap")
+        public AnvilRecipeBuilder.Shaped key(char c, IIngredient ingredient) {
+            this.keyMap.put(c, ingredient);
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription(field = "keyMap")
+        public AnvilRecipeBuilder.Shaped key(String c, IIngredient ingredient) {
+            if (c == null || c.length() != 1) {
+                errors.add("key must be a single char, but found '" + c + "'");
+                return this;
+            }
+            this.keyMap.put(c.charAt(0), ingredient);
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription(field = "keyMap")
+        public AnvilRecipeBuilder.Shaped key(Map<String, IIngredient> map) {
+            for (Map.Entry<String, IIngredient> x : map.entrySet()) {
+                key(x.getKey(), x.getValue());
+            }
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription(field = "ingredientMatrix")
+        public AnvilRecipeBuilder.Shaped matrix(List<List<IIngredient>> matrix) {
+            this.ingredientMatrix = matrix;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription(field = "ingredientMatrix")
+        public AnvilRecipeBuilder.Shaped shape(List<List<IIngredient>> matrix) {
+            this.ingredientMatrix = matrix;
+            return this;
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public IRecipe register() {
+            GroovyLog.Msg msg = GroovyLog.msg("Error adding shaped Better With Mods Anvil recipe").error()
+                    .add((keyBasedMatrix == null || keyBasedMatrix.length == 0) && (ingredientMatrix == null || ingredientMatrix.isEmpty()), () -> "No matrix was defined")
+                    .add(keyBasedMatrix != null && ingredientMatrix != null, () -> "A key based matrix AND a ingredient based matrix was defined. This is not allowed!");
+            if (msg.postIfNotEmpty()) return null;
+            msg.add(IngredientHelper.isEmpty(this.output), () -> "Output must not be empty");
+            ShapedAnvilRecipe recipe = null;
+            if (keyBasedMatrix != null) {
+                recipe = validateShape(msg, errors, keyBasedMatrix, keyMap, ((width1, height1, ingredients) -> AnvilShapedRecipe.make(name, output, ingredients, width1, height1, mirrored, recipeFunction, recipeAction)));
+            } else if (ingredientMatrix != null) {
+                recipe = validateShape(msg, ingredientMatrix, ((width1, height1, ingredients) -> AnvilShapedRecipe.make(name, output.copy(), ingredients, width1, height1, mirrored, recipeFunction, recipeAction)));
+            }
+            if (msg.postIfNotEmpty()) return null;
+            if (recipe != null) {
+                ModSupport.BETTER_WITH_MODS.get().anvilCrafting.add(recipe);
+            }
+            return recipe;
+        }
+    }
+
+    public static class Shapeless extends AnvilRecipeBuilder {
+
+        @Property(value = "groovyscript.wiki.craftingrecipe.ingredients.value", valid = {@Comp(value = "1", type = Comp.Type.GTE),
+                                                                                         @Comp(value = "81", type = Comp.Type.LTE)}, priority = 250)
+        private final List<IIngredient> ingredients = new ArrayList<>();
+
+        @RecipeBuilderMethodDescription(field = "ingredients")
+        public AnvilRecipeBuilder.Shapeless input(IIngredient ingredient) {
+            ingredients.add(ingredient);
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription(field = "ingredients")
+        public AnvilRecipeBuilder.Shapeless input(IIngredient... ingredients) {
+            if (ingredients != null) {
+                for (IIngredient ingredient : ingredients) {
+                    input(ingredient);
+                }
+            }
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription(field = "ingredients")
+        public AnvilRecipeBuilder.Shapeless input(Collection<IIngredient> ingredients) {
+            if (ingredients != null && !ingredients.isEmpty()) {
+                for (IIngredient ingredient : ingredients) {
+                    input(ingredient);
+                }
+            }
+            return this;
+        }
+
+        public boolean validate() {
+            GroovyLog.Msg msg = GroovyLog.msg("Error adding shapeless Better With Mods Anvil recipe").error();
+            msg.add(IngredientHelper.isEmpty(this.output), () -> "Output must not be empty");
+            msg.add(ingredients.isEmpty(), () -> "inputs must not be empty");
+            msg.add(ingredients.size() > width * height, () -> "maximum inputs are " + (width * height) + " but found " + ingredients.size());
+            return !msg.postIfNotEmpty();
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public IRecipe register() {
+            if (!validate()) return null;
+            ShapelessAnvilRecipe recipe = AnvilShapelessRecipe.make(name, output.copy(), ingredients, recipeFunction, recipeAction);
+            ModSupport.BETTER_WITH_MODS.get().anvilCrafting.add(recipe);
+            return recipe;
+        }
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/AnvilShapedRecipe.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/AnvilShapedRecipe.java
@@ -1,0 +1,56 @@
+package com.cleanroommc.groovyscript.compat.mods.betterwithmods;
+
+import betterwithmods.common.registry.anvil.ShapedAnvilRecipe;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.compat.vanilla.ShapedCraftingRecipe;
+import groovy.lang.Closure;
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.NonNullList;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.world.World;
+import net.minecraftforge.common.crafting.CraftingHelper;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+public class AnvilShapedRecipe extends ShapedAnvilRecipe {
+
+    private final ShapedCraftingRecipe groovyRecipe;
+
+    private AnvilShapedRecipe(ResourceLocation resourceLocation, ShapedCraftingRecipe groovyRecipe, CraftingHelper.ShapedPrimer primer) {
+        super(resourceLocation, groovyRecipe.getRecipeOutput(), primer);
+        this.groovyRecipe = groovyRecipe;
+        setMirrored(this.groovyRecipe.isMirrored());
+    }
+
+//    public static AnvilShapedRecipe make(ItemStack output, List<IIngredient> input, int width, int height, boolean mirrored, @Nullable Closure<ItemStack> recipeFunction, @Nullable Closure<Void> recipeAction) {
+//        return make(null, output, input, width, height, mirrored, recipeFunction, recipeAction);
+//    }
+
+    public static AnvilShapedRecipe make(ResourceLocation resourceLocation, ItemStack output, List<IIngredient> input, int width, int height, boolean mirrored, @Nullable Closure<ItemStack> recipeFunction, @Nullable Closure<Void> recipeAction) {
+        ShapedCraftingRecipe recipe = new ShapedCraftingRecipe(output, input, width, height, mirrored, recipeFunction, recipeAction);
+        CraftingHelper.ShapedPrimer primer = new CraftingHelper.ShapedPrimer();
+        primer.width = width;
+        primer.height = height;
+        primer.mirrored = mirrored;
+        primer.input = recipe.getIngredients();
+        return new AnvilShapedRecipe(resourceLocation, recipe, primer);
+    }
+
+    @Override
+    public @NotNull ItemStack getCraftingResult(@NotNull InventoryCrafting inv) {
+        return this.groovyRecipe.getCraftingResult(inv);
+    }
+
+    @Override
+    public boolean matches(@NotNull InventoryCrafting inv, @NotNull World world) {
+        return this.groovyRecipe.matches(inv, world);
+    }
+
+    @Override
+    public @NotNull NonNullList<ItemStack> getRemainingItems(@NotNull InventoryCrafting inv) {
+        return this.groovyRecipe.getRemainingItems(inv);
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/AnvilShapelessRecipe.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/AnvilShapelessRecipe.java
@@ -1,0 +1,49 @@
+package com.cleanroommc.groovyscript.compat.mods.betterwithmods;
+
+import betterwithmods.common.registry.anvil.ShapelessAnvilRecipe;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.compat.vanilla.ShapelessCraftingRecipe;
+import groovy.lang.Closure;
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.NonNullList;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.world.World;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+public class AnvilShapelessRecipe extends ShapelessAnvilRecipe {
+
+    private final ShapelessCraftingRecipe groovyRecipe;
+
+    public AnvilShapelessRecipe(ResourceLocation resourceLocation, ShapelessCraftingRecipe groovyRecipe) {
+        super(resourceLocation, groovyRecipe.getIngredients(), groovyRecipe.getRecipeOutput());
+        this.groovyRecipe = groovyRecipe;
+    }
+
+//    public static AnvilShapelessRecipe make(ItemStack output, List<IIngredient> input, @Nullable Closure<ItemStack> recipeFunction, @Nullable Closure<Void> recipeAction) {
+//        return make(null, output, input, recipeFunction, recipeAction);
+//    }
+
+    public static AnvilShapelessRecipe make(ResourceLocation resourceLocation, ItemStack output, List<IIngredient> input, @Nullable Closure<ItemStack> recipeFunction, @Nullable Closure<Void> recipeAction) {
+        ShapelessCraftingRecipe recipe = new ShapelessCraftingRecipe(output, input, recipeFunction, recipeAction);
+        return new AnvilShapelessRecipe(resourceLocation, recipe);
+    }
+
+    @Override
+    public @NotNull ItemStack getCraftingResult(@NotNull InventoryCrafting inv) {
+        return this.groovyRecipe.getCraftingResult(inv);
+    }
+
+    @Override
+    public boolean matches(@NotNull InventoryCrafting inv, @NotNull World world) {
+        return this.groovyRecipe.matches(inv, world);
+    }
+
+    @Override
+    public @NotNull NonNullList<ItemStack> getRemainingItems(@NotNull InventoryCrafting inv) {
+        return this.groovyRecipe.getRemainingItems(inv);
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/BetterWithMods.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/BetterWithMods.java
@@ -1,0 +1,24 @@
+package com.cleanroommc.groovyscript.compat.mods.betterwithmods;
+
+import com.cleanroommc.groovyscript.compat.mods.ModPropertyContainer;
+
+public class BetterWithMods extends ModPropertyContainer {
+
+    public final AnvilCrafting anvilCrafting = new AnvilCrafting();
+    public final Cauldron cauldron = new Cauldron();
+    public final Crucible crucible = new Crucible();
+    public final Kiln kiln = new Kiln();
+    public final MillStone millStone = new MillStone();
+    public final Saw saw = new Saw();
+    public final Turntable turntable = new Turntable();
+
+    public BetterWithMods() {
+        addRegistry(anvilCrafting);
+        addRegistry(cauldron);
+        addRegistry(crucible);
+        addRegistry(kiln);
+        addRegistry(millStone);
+        addRegistry(saw);
+        addRegistry(turntable);
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/BetterWithMods.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/BetterWithMods.java
@@ -11,6 +11,9 @@ public class BetterWithMods extends ModPropertyContainer {
     public final MillStone millStone = new MillStone();
     public final Saw saw = new Saw();
     public final Turntable turntable = new Turntable();
+    public final Heat heat = new Heat();
+    public final Hopper hopper = new Hopper();
+    public final HopperFilters hopperFilters = new HopperFilters();
 
     public BetterWithMods() {
         addRegistry(anvilCrafting);
@@ -20,5 +23,9 @@ public class BetterWithMods extends ModPropertyContainer {
         addRegistry(millStone);
         addRegistry(saw);
         addRegistry(turntable);
+        addRegistry(heat);
+        addRegistry(hopper);
+        addRegistry(hopperFilters);
     }
+
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/Cauldron.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/Cauldron.java
@@ -7,12 +7,10 @@ import com.cleanroommc.groovyscript.api.IIngredient;
 import com.cleanroommc.groovyscript.api.documentation.annotations.*;
 import com.cleanroommc.groovyscript.compat.mods.ModSupport;
 import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
-import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
 import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.Ingredient;
-import net.minecraftforge.items.ItemHandlerHelper;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.stream.Collectors;
@@ -51,10 +49,10 @@ public class Cauldron extends VirtualizedRegistry<CookingPotRecipe> {
     }
 
     @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('minecraft:gunpowder')"))
-    public boolean removeByOutput(ItemStack output) {
+    public boolean removeByOutput(IIngredient output) {
         return BWRegistry.CAULDRON.getRecipes().removeIf(r -> {
             for (ItemStack itemstack : r.getOutputs()) {
-                if (ItemHandlerHelper.canItemStacksStack(itemstack, output)) {
+                if (output.test(itemstack)) {
                     addBackup(r);
                     return true;
                 }
@@ -64,21 +62,18 @@ public class Cauldron extends VirtualizedRegistry<CookingPotRecipe> {
     }
 
     @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:gunpowder')"))
-    public boolean removeByInput(ItemStack input) {
+    public boolean removeByInput(IIngredient input) {
         return BWRegistry.CAULDRON.getRecipes().removeIf(r -> {
             for (Ingredient ingredient : r.getInputs()) {
-                if (ingredient.test(input)) {
-                    addBackup(r);
-                    return true;
+                for (ItemStack item : ingredient.getMatchingStacks()) {
+                    if (input.test(item)) {
+                        addBackup(r);
+                        return true;
+                    }
                 }
             }
             return false;
         });
-    }
-
-    @MethodDescription(description = "groovyscript.wiki.removeByInput")
-    public boolean removeByInput(IIngredient input) {
-        return removeByInput(IngredientHelper.toItemStack(input));
     }
 
     @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/Cauldron.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/Cauldron.java
@@ -1,0 +1,150 @@
+package com.cleanroommc.groovyscript.compat.mods.betterwithmods;
+
+import betterwithmods.common.BWRegistry;
+import betterwithmods.common.registry.bulk.recipes.CookingPotRecipe;
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
+import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.Ingredient;
+import net.minecraftforge.items.ItemHandlerHelper;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.stream.Collectors;
+
+@RegistryDescription
+public class Cauldron extends VirtualizedRegistry<CookingPotRecipe> {
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:clay')).output(item('minecraft:diamond')).heat(2)"),
+            @Example(".input(item('minecraft:diamond') * 2).output(item('minecraft:gold_ingot') * 16).ignoreHeat()")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @Override
+    public void onReload() {
+        removeScripted().forEach(recipe -> BWRegistry.CAULDRON.getRecipes().removeIf(r -> r == recipe));
+        BWRegistry.CAULDRON.getRecipes().addAll(restoreFromBackup());
+    }
+
+    public CookingPotRecipe add(CookingPotRecipe recipe) {
+        if (recipe != null) {
+            addScripted(recipe);
+            BWRegistry.CAULDRON.getRecipes().add(recipe);
+        }
+        return recipe;
+    }
+
+    public boolean remove(CookingPotRecipe recipe) {
+        if (BWRegistry.CAULDRON.getRecipes().removeIf(r -> r == recipe)) {
+            addBackup(recipe);
+            return true;
+        }
+        return false;
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('minecraft:gunpowder')"))
+    public boolean removeByOutput(ItemStack output) {
+        return BWRegistry.CAULDRON.getRecipes().removeIf(r -> {
+            for (ItemStack itemstack : r.getOutputs()) {
+                if (ItemHandlerHelper.canItemStacksStack(itemstack, output)) {
+                    addBackup(r);
+                    return true;
+                }
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:gunpowder')"))
+    public boolean removeByInput(ItemStack input) {
+        return BWRegistry.CAULDRON.getRecipes().removeIf(r -> {
+            for (Ingredient ingredient : r.getInputs()) {
+                if (ingredient.test(input)) {
+                    addBackup(r);
+                    return true;
+                }
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeByInput")
+    public boolean removeByInput(IIngredient input) {
+        return removeByInput(IngredientHelper.toItemStack(input));
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    public SimpleObjectStream<CookingPotRecipe> streamRecipes() {
+        return new SimpleObjectStream<>(BWRegistry.CAULDRON.getRecipes()).setRemover(this::remove);
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    public void removeAll() {
+        BWRegistry.CAULDRON.getRecipes().forEach(this::addBackup);
+        BWRegistry.CAULDRON.getRecipes().clear();
+    }
+
+    @Property(property = "input", valid = {@Comp(value = "1", type = Comp.Type.GTE), @Comp(value = "9", type = Comp.Type.LTE)})
+    @Property(property = "output", valid = {@Comp(value = "1", type = Comp.Type.GTE), @Comp(value = "9", type = Comp.Type.LTE)})
+    public static class RecipeBuilder extends AbstractRecipeBuilder<CookingPotRecipe> {
+
+        @Property(defaultValue = "1")
+        private int heat = 1;
+        @Property
+        private boolean ignoreHeat;
+        @Property(defaultValue = "1")
+        private int priority = 1;
+
+        public RecipeBuilder heat(int heat) {
+            this.heat = heat;
+            return this;
+        }
+
+        public RecipeBuilder ignoreHeat(boolean ignoreHeat) {
+            this.ignoreHeat = ignoreHeat;
+            return this;
+        }
+
+        public RecipeBuilder ignoreHeat() {
+            this.ignoreHeat = !ignoreHeat;
+            return this;
+        }
+
+        public RecipeBuilder priority(int priority) {
+            this.priority = priority;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Better With Mods Cauldron recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 1, 9, 1, 9);
+            validateFluids(msg);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable CookingPotRecipe register() {
+            if (!validate()) return null;
+
+            CookingPotRecipe recipe = new CookingPotRecipe(input.stream().map(IIngredient::toMcIngredient).collect(Collectors.toList()), output, heat);
+            recipe.setIgnoreHeat(ignoreHeat);
+            recipe.setPriority(priority);
+            ModSupport.BETTER_WITH_MODS.get().cauldron.add(recipe);
+            return recipe;
+        }
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/Cauldron.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/Cauldron.java
@@ -22,7 +22,7 @@ public class Cauldron extends VirtualizedRegistry<CookingPotRecipe> {
 
     @RecipeBuilderDescription(example = {
             @Example(".input(item('minecraft:clay')).output(item('minecraft:diamond')).heat(2)"),
-            @Example(".input(item('minecraft:diamond') * 2).output(item('minecraft:gold_ingot') * 16).ignoreHeat()")
+            @Example(".input(item('minecraft:diamond')).output(item('minecraft:gold_ingot') * 16).ignoreHeat()")
     })
     public RecipeBuilder recipeBuilder() {
         return new RecipeBuilder();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/Crucible.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/Crucible.java
@@ -1,0 +1,150 @@
+package com.cleanroommc.groovyscript.compat.mods.betterwithmods;
+
+import betterwithmods.common.BWRegistry;
+import betterwithmods.common.registry.bulk.recipes.CookingPotRecipe;
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
+import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.Ingredient;
+import net.minecraftforge.items.ItemHandlerHelper;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.stream.Collectors;
+
+@RegistryDescription
+public class Crucible extends VirtualizedRegistry<CookingPotRecipe> {
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:clay')).output(item('minecraft:diamond')).heat(2)"),
+            @Example(".input(item('minecraft:diamond') * 2).output(item('minecraft:gold_ingot') * 16).ignoreHeat()")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @Override
+    public void onReload() {
+        removeScripted().forEach(recipe -> BWRegistry.CRUCIBLE.getRecipes().removeIf(r -> r == recipe));
+        BWRegistry.CRUCIBLE.getRecipes().addAll(restoreFromBackup());
+    }
+
+    public CookingPotRecipe add(CookingPotRecipe recipe) {
+        if (recipe != null) {
+            addScripted(recipe);
+            BWRegistry.CRUCIBLE.getRecipes().add(recipe);
+        }
+        return recipe;
+    }
+
+    public boolean remove(CookingPotRecipe recipe) {
+        if (BWRegistry.CRUCIBLE.getRecipes().removeIf(r -> r == recipe)) {
+            addBackup(recipe);
+            return true;
+        }
+        return false;
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('minecraft:gunpowder')"))
+    public boolean removeByOutput(ItemStack output) {
+        return BWRegistry.CRUCIBLE.getRecipes().removeIf(r -> {
+            for (ItemStack itemstack : r.getOutputs()) {
+                if (ItemHandlerHelper.canItemStacksStack(itemstack, output)) {
+                    addBackup(r);
+                    return true;
+                }
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:gunpowder')"))
+    public boolean removeByInput(ItemStack input) {
+        return BWRegistry.CRUCIBLE.getRecipes().removeIf(r -> {
+            for (Ingredient ingredient : r.getInputs()) {
+                if (ingredient.test(input)) {
+                    addBackup(r);
+                    return true;
+                }
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeByInput")
+    public boolean removeByInput(IIngredient input) {
+        return removeByInput(IngredientHelper.toItemStack(input));
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    public SimpleObjectStream<CookingPotRecipe> streamRecipes() {
+        return new SimpleObjectStream<>(BWRegistry.CRUCIBLE.getRecipes()).setRemover(this::remove);
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    public void removeAll() {
+        BWRegistry.CRUCIBLE.getRecipes().forEach(this::addBackup);
+        BWRegistry.CRUCIBLE.getRecipes().clear();
+    }
+
+    @Property(property = "input", valid = {@Comp(value = "1", type = Comp.Type.GTE), @Comp(value = "9", type = Comp.Type.LTE)})
+    @Property(property = "output", valid = {@Comp(value = "1", type = Comp.Type.GTE), @Comp(value = "9", type = Comp.Type.LTE)})
+    public static class RecipeBuilder extends AbstractRecipeBuilder<CookingPotRecipe> {
+
+        @Property(defaultValue = "1")
+        private int heat = 1;
+        @Property
+        private boolean ignoreHeat;
+        @Property(defaultValue = "1")
+        private int priority = 1;
+
+        public RecipeBuilder heat(int heat) {
+            this.heat = heat;
+            return this;
+        }
+
+        public RecipeBuilder ignoreHeat(boolean ignoreHeat) {
+            this.ignoreHeat = ignoreHeat;
+            return this;
+        }
+
+        public RecipeBuilder ignoreHeat() {
+            this.ignoreHeat = !ignoreHeat;
+            return this;
+        }
+
+        public RecipeBuilder priority(int priority) {
+            this.priority = priority;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Better With Mods Cauldron recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 1, 9, 1, 9);
+            validateFluids(msg);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable CookingPotRecipe register() {
+            if (!validate()) return null;
+
+            CookingPotRecipe recipe = new CookingPotRecipe(input.stream().map(IIngredient::toMcIngredient).collect(Collectors.toList()), output, heat);
+            recipe.setIgnoreHeat(ignoreHeat);
+            recipe.setPriority(priority);
+            ModSupport.BETTER_WITH_MODS.get().crucible.add(recipe);
+            return recipe;
+        }
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/Crucible.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/Crucible.java
@@ -22,7 +22,7 @@ public class Crucible extends VirtualizedRegistry<CookingPotRecipe> {
 
     @RecipeBuilderDescription(example = {
             @Example(".input(item('minecraft:clay')).output(item('minecraft:diamond')).heat(2)"),
-            @Example(".input(item('minecraft:diamond') * 2).output(item('minecraft:gold_ingot') * 16).ignoreHeat()")
+            @Example(".input(item('minecraft:diamond')).output(item('minecraft:gold_ingot') * 16).ignoreHeat()")
     })
     public RecipeBuilder recipeBuilder() {
         return new RecipeBuilder();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/Heat.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/Heat.java
@@ -1,0 +1,64 @@
+package com.cleanroommc.groovyscript.compat.mods.betterwithmods;
+
+import betterwithmods.common.registry.block.recipe.BlockIngredient;
+import betterwithmods.common.registry.heat.BWMHeatRegistry;
+import com.cleanroommc.groovyscript.api.GroovyBlacklist;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.Admonition;
+import com.cleanroommc.groovyscript.api.documentation.annotations.Example;
+import com.cleanroommc.groovyscript.api.documentation.annotations.MethodDescription;
+import com.cleanroommc.groovyscript.api.documentation.annotations.RegistryDescription;
+import com.cleanroommc.groovyscript.core.mixin.betterwithmods.BWMHeatRegistryAccessor;
+import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import net.minecraft.item.ItemStack;
+
+import java.util.List;
+
+@RegistryDescription(
+        admonition = @Admonition("groovyscript.wiki.betterwithmods.heat.note0")
+)
+public class Heat extends VirtualizedRegistry<BWMHeatRegistry.HeatSource> {
+
+    @Override
+    @GroovyBlacklist
+    public void onReload() {
+        removeScripted().forEach(recipe -> BWMHeatRegistryAccessor.getHEAT_SOURCES().removeIf(r -> r == recipe));
+        BWMHeatRegistryAccessor.getHEAT_SOURCES().addAll(restoreFromBackup());
+    }
+
+    public void add(BWMHeatRegistry.HeatSource heatSource) {
+        BWMHeatRegistryAccessor.getHEAT_SOURCES().add(heatSource);
+        addScripted(heatSource);
+    }
+
+    public boolean remove(BWMHeatRegistry.HeatSource heatSource) {
+        if (!BWMHeatRegistryAccessor.getHEAT_SOURCES().remove(heatSource)) return false;
+        addBackup(heatSource);
+        return true;
+    }
+
+    @MethodDescription(type = MethodDescription.Type.VALUE)
+    public void add(int heat, BlockIngredient ingredient) {
+        add(new BWMHeatRegistry.HeatSource(ingredient, heat));
+    }
+
+    @MethodDescription(type = MethodDescription.Type.VALUE, example = @Example("3, 'torch'"))
+    public void add(int heat, String input) {
+        add(heat, new BlockIngredient(input));
+    }
+
+    @MethodDescription(type = MethodDescription.Type.VALUE)
+    public void add(int heat, List<ItemStack> input) {
+        add(heat, new BlockIngredient(input));
+    }
+
+    @MethodDescription(type = MethodDescription.Type.VALUE, example = @Example("4, item('minecraft:redstone_block'), item('minecraft:redstone_torch')"))
+    public void add(int heat, ItemStack... input) {
+        add(heat, new BlockIngredient(input));
+    }
+
+    @MethodDescription(type = MethodDescription.Type.VALUE)
+    public void add(int heat, IIngredient input) {
+        add(heat, new BlockIngredient(input.toMcIngredient()));
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/Hopper.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/Hopper.java
@@ -6,12 +6,10 @@ import com.cleanroommc.groovyscript.api.IIngredient;
 import com.cleanroommc.groovyscript.api.documentation.annotations.*;
 import com.cleanroommc.groovyscript.compat.mods.ModSupport;
 import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
-import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
 import com.cleanroommc.groovyscript.helper.ingredient.ItemStackList;
 import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
 import net.minecraft.item.ItemStack;
-import net.minecraftforge.items.ItemHandlerHelper;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
@@ -50,10 +48,10 @@ public class Hopper extends VirtualizedRegistry<HopperInteractions.HopperRecipe>
     }
 
     @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('minecraft:gunpowder')"))
-    public boolean removeByOutput(ItemStack output) {
+    public boolean removeByOutput(IIngredient output) {
         return HopperInteractions.RECIPES.removeIf(r -> {
             for (ItemStack itemstack : r.getOutputs()) {
-                if (ItemHandlerHelper.canItemStacksStack(itemstack, output)) {
+                if (output.test(itemstack)) {
                     addBackup(r);
                     return true;
                 }
@@ -63,19 +61,16 @@ public class Hopper extends VirtualizedRegistry<HopperInteractions.HopperRecipe>
     }
 
     @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:gunpowder')"))
-    public boolean removeByInput(ItemStack input) {
+    public boolean removeByInput(IIngredient input) {
         return HopperInteractions.RECIPES.removeIf(r -> {
-            if (r.getInputs().test(input)) {
-                addBackup(r);
-                return true;
+            for (ItemStack item : r.getInputs().getMatchingStacks()) {
+                if (input.test(item)) {
+                    addBackup(r);
+                    return true;
+                }
             }
             return false;
         });
-    }
-
-    @MethodDescription(description = "groovyscript.wiki.removeByInput")
-    public boolean removeByInput(IIngredient input) {
-        return removeByInput(IngredientHelper.toItemStack(input));
     }
 
     @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/Hopper.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/Hopper.java
@@ -1,0 +1,146 @@
+package com.cleanroommc.groovyscript.compat.mods.betterwithmods;
+
+import betterwithmods.common.registry.HopperInteractions;
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
+import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
+import com.cleanroommc.groovyscript.helper.ingredient.ItemStackList;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.items.ItemHandlerHelper;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+
+@RegistryDescription
+public class Hopper extends VirtualizedRegistry<HopperInteractions.HopperRecipe> {
+
+    @RecipeBuilderDescription(example = {
+            @Example(".name('betterwithmods:iron_bar').input(ore('sand')).output(item('minecraft:clay')).inWorldItemOutput(item('minecraft:gold_ingot'))"),
+            @Example(".name('betterwithmods:wicker').input(item('minecraft:clay')).inWorldItemOutput(item('minecraft:gold_ingot'))")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @Override
+    public void onReload() {
+        removeScripted().forEach(recipe -> HopperInteractions.RECIPES.removeIf(r -> r == recipe));
+        HopperInteractions.RECIPES.addAll(restoreFromBackup());
+    }
+
+    public HopperInteractions.HopperRecipe add(HopperInteractions.HopperRecipe recipe) {
+        if (recipe != null) {
+            addScripted(recipe);
+            HopperInteractions.RECIPES.add(recipe);
+        }
+        return recipe;
+    }
+
+    public boolean remove(HopperInteractions.HopperRecipe recipe) {
+        if (HopperInteractions.RECIPES.removeIf(r -> r == recipe)) {
+            addBackup(recipe);
+            return true;
+        }
+        return false;
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('minecraft:gunpowder')"))
+    public boolean removeByOutput(ItemStack output) {
+        return HopperInteractions.RECIPES.removeIf(r -> {
+            for (ItemStack itemstack : r.getOutputs()) {
+                if (ItemHandlerHelper.canItemStacksStack(itemstack, output)) {
+                    addBackup(r);
+                    return true;
+                }
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:gunpowder')"))
+    public boolean removeByInput(ItemStack input) {
+        return HopperInteractions.RECIPES.removeIf(r -> {
+            if (r.getInputs().test(input)) {
+                addBackup(r);
+                return true;
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeByInput")
+    public boolean removeByInput(IIngredient input) {
+        return removeByInput(IngredientHelper.toItemStack(input));
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    public SimpleObjectStream<HopperInteractions.HopperRecipe> streamRecipes() {
+        return new SimpleObjectStream<>(HopperInteractions.RECIPES).setRemover(this::remove);
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    public void removeAll() {
+        HopperInteractions.RECIPES.forEach(this::addBackup);
+        HopperInteractions.RECIPES.clear();
+    }
+
+    @Property(property = "name", value = "groovyscript.wiki.betterwithmods.hopper.name.value", valid = @Comp(value = "null", type = Comp.Type.NOT))
+    @Property(property = "input", valid = @Comp("1"))
+    @Property(property = "output", valid = {@Comp(value = "0", type = Comp.Type.GTE), @Comp(value = "2", type = Comp.Type.LTE)})
+    public static class RecipeBuilder extends AbstractRecipeBuilder<HopperInteractions.HopperRecipe> {
+
+        @Property(valid = {@Comp(value = "0", type = Comp.Type.GTE), @Comp(value = "2", type = Comp.Type.LTE)})
+        protected final ItemStackList inWorldItemOutput = new ItemStackList();
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder inWorldItemOutput(ItemStack inWorldItemOutput) {
+            this.inWorldItemOutput.add(inWorldItemOutput);
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder inWorldItemOutput(ItemStack... inWorldItemOutputs) {
+            for (ItemStack inWorldItemOutput : inWorldItemOutputs) {
+                inWorldItemOutput(inWorldItemOutput);
+            }
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder inWorldItemOutput(Collection<ItemStack> inWorldItemOutputs) {
+            for (ItemStack inWorldItemOutput : inWorldItemOutputs) {
+                inWorldItemOutput(inWorldItemOutput);
+            }
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Better With Mods Filtered Hopper recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            msg.add(name == null, "name cannot be null");
+            validateItems(msg, 1, 1, 0, 2);
+            validateCustom(msg, inWorldItemOutput, 0, 2, "item in world output");
+            validateFluids(msg);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable HopperInteractions.HopperRecipe register() {
+            if (!validate()) return null;
+
+            HopperInteractions.HopperRecipe recipe = new HopperInteractions.HopperRecipe(name.toString(), input.get(0).toMcIngredient(), output, inWorldItemOutput);
+            ModSupport.BETTER_WITH_MODS.get().hopper.add(recipe);
+            return recipe;
+        }
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/HopperFilters.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/HopperFilters.java
@@ -1,0 +1,137 @@
+package com.cleanroommc.groovyscript.compat.mods.betterwithmods;
+
+import betterwithmods.api.tile.IHopperFilter;
+import betterwithmods.common.BWRegistry;
+import betterwithmods.common.registry.HopperFilter;
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.core.mixin.betterwithmods.HopperFiltersAccessor;
+import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
+import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.Ingredient;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.stream.Collectors;
+
+@RegistryDescription
+public class HopperFilters extends VirtualizedRegistry<IHopperFilter> {
+
+    @RecipeBuilderDescription(example = {
+            @Example(".name('too_weak_to_stop').filter(item('minecraft:string'))"),
+            @Example(".name('groovyscript:clay_only').filter(item('minecraft:clay')).input(item('minecraft:clay'))")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @Override
+    public void onReload() {
+        removeScripted().forEach(recipe -> ((HopperFiltersAccessor) BWRegistry.HOPPER_FILTERS).getFILTERS().remove(recipe.getName()));
+        restoreFromBackup().forEach(recipe -> ((HopperFiltersAccessor) BWRegistry.HOPPER_FILTERS).getFILTERS().put(recipe.getName(), recipe));
+    }
+
+    public IHopperFilter add(IHopperFilter recipe) {
+        if (recipe != null) {
+            addScripted(recipe);
+            ((HopperFiltersAccessor) BWRegistry.HOPPER_FILTERS).getFILTERS().put(recipe.getName(), recipe);
+        }
+        return recipe;
+    }
+
+    public boolean remove(IHopperFilter recipe) {
+        if (((HopperFiltersAccessor) BWRegistry.HOPPER_FILTERS).getFILTERS().remove(recipe.getName(), recipe)) {
+            addBackup(recipe);
+            return true;
+        }
+        return false;
+    }
+
+    @MethodDescription(example = @Example("'betterwithmods:ladder'"))
+    public boolean removeByName(String name) {
+        return ((HopperFiltersAccessor) BWRegistry.HOPPER_FILTERS).getFILTERS().remove(name) != null;
+    }
+
+    @MethodDescription(example = @Example("item('minecraft:trapdoor')"))
+    public boolean removeByFilter(ItemStack input) {
+        return ((HopperFiltersAccessor) BWRegistry.HOPPER_FILTERS).getFILTERS().values().removeIf(r -> {
+            if (r.getFilter().test(input)) {
+                addBackup(r);
+                return true;
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription
+    public boolean removeByFiltered(ItemStack output) {
+        return ((HopperFiltersAccessor) BWRegistry.HOPPER_FILTERS).getFILTERS().values().removeIf(r -> {
+            if (!(r instanceof HopperFilter)) return false;
+            for (Ingredient ingredient : ((HopperFilter) r).getFiltered()) {
+                if (ingredient.test(output)) {
+                    addBackup(r);
+                    return true;
+                }
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    public SimpleObjectStream<IHopperFilter> streamRecipes() {
+        return new SimpleObjectStream<>(((HopperFiltersAccessor) BWRegistry.HOPPER_FILTERS).getFILTERS().values())
+                .setRemover(this::remove);
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    public void removeAll() {
+        ((HopperFiltersAccessor) BWRegistry.HOPPER_FILTERS).getFILTERS().values().forEach(this::addBackup);
+        ((HopperFiltersAccessor) BWRegistry.HOPPER_FILTERS).getFILTERS().values().clear();
+    }
+
+    @Property(property = "input", value = "groovyscript.wiki.betterwithmods.hopper_filters.filtered.value", valid = {@Comp(value = "0", type = Comp.Type.GTE), @Comp(value = "Integer.MAX_VALUE", type = Comp.Type.LTE)})
+    public static class RecipeBuilder extends AbstractRecipeBuilder<IHopperFilter> {
+
+        @Property(valid = @Comp(value = "null", type = Comp.Type.NOT))
+        private IIngredient filter;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder filter(IIngredient filter) {
+            this.filter = filter;
+            return this;
+        }
+
+        @Override
+        public String getRecipeNamePrefix() {
+            return "groovyscript_hopper_filter_";
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Better With Mods Hopper Filter recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateName();
+            validateItems(msg, 0, Integer.MAX_VALUE, 0, 0);
+            validateFluids(msg);
+            msg.add(IngredientHelper.isEmpty(filter), "filter must be defined");
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable IHopperFilter register() {
+            if (!validate()) return null;
+
+            IHopperFilter recipe = new HopperFilter(name.toString(), filter.toMcIngredient(), input.stream().map(IIngredient::toMcIngredient).collect(Collectors.toList()));
+            ModSupport.BETTER_WITH_MODS.get().hopperFilters.add(recipe);
+            return recipe;
+        }
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/HopperFilters.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/HopperFilters.java
@@ -57,24 +57,28 @@ public class HopperFilters extends VirtualizedRegistry<IHopperFilter> {
     }
 
     @MethodDescription(example = @Example("item('minecraft:trapdoor')"))
-    public boolean removeByFilter(ItemStack input) {
+    public boolean removeByFilter(IIngredient input) {
         return ((HopperFiltersAccessor) BWRegistry.HOPPER_FILTERS).getFILTERS().values().removeIf(r -> {
-            if (r.getFilter().test(input)) {
-                addBackup(r);
-                return true;
+            for (ItemStack item : r.getFilter().getMatchingStacks()) {
+                if (input.test(item)) {
+                    addBackup(r);
+                    return true;
+                }
             }
             return false;
         });
     }
 
     @MethodDescription
-    public boolean removeByFiltered(ItemStack output) {
+    public boolean removeByFiltered(IIngredient output) {
         return ((HopperFiltersAccessor) BWRegistry.HOPPER_FILTERS).getFILTERS().values().removeIf(r -> {
             if (!(r instanceof HopperFilter)) return false;
             for (Ingredient ingredient : ((HopperFilter) r).getFiltered()) {
-                if (ingredient.test(output)) {
-                    addBackup(r);
-                    return true;
+                for (ItemStack item : ingredient.getMatchingStacks()) {
+                    if (output.test(item)) {
+                        addBackup(r);
+                        return true;
+                    }
                 }
             }
             return false;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/Kiln.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/Kiln.java
@@ -8,11 +8,9 @@ import com.cleanroommc.groovyscript.api.IIngredient;
 import com.cleanroommc.groovyscript.api.documentation.annotations.*;
 import com.cleanroommc.groovyscript.compat.mods.ModSupport;
 import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
-import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
 import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
 import net.minecraft.item.ItemStack;
-import net.minecraftforge.items.ItemHandlerHelper;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
@@ -51,10 +49,10 @@ public class Kiln extends VirtualizedRegistry<KilnRecipe> {
     }
 
     @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('minecraft:brick')"))
-    public boolean removeByOutput(ItemStack output) {
+    public boolean removeByOutput(IIngredient output) {
         return BWRegistry.KILN.getRecipes().removeIf(r -> {
             for (ItemStack itemstack : r.getOutputs()) {
-                if (ItemHandlerHelper.canItemStacksStack(itemstack, output)) {
+                if (output.test(itemstack)) {
                     addBackup(r);
                     return true;
                 }
@@ -64,21 +62,16 @@ public class Kiln extends VirtualizedRegistry<KilnRecipe> {
     }
 
     @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:end_stone')"))
-    public boolean removeByInput(ItemStack input) {
+    public boolean removeByInput(IIngredient input) {
         return BWRegistry.KILN.getRecipes().removeIf(r -> {
             for (ItemStack itemstack : r.getInput().getMatchingStacks()) {
-                if (ItemHandlerHelper.canItemStacksStack(itemstack, input)) {
+                if (input.test(itemstack)) {
                     addBackup(r);
                     return true;
                 }
             }
             return false;
         });
-    }
-
-    @MethodDescription(description = "groovyscript.wiki.removeByInput")
-    public boolean removeByInput(IIngredient input) {
-        return removeByInput(IngredientHelper.toItemStack(input));
     }
 
     @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/Kiln.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/Kiln.java
@@ -1,0 +1,168 @@
+package com.cleanroommc.groovyscript.compat.mods.betterwithmods;
+
+import betterwithmods.common.BWRegistry;
+import betterwithmods.common.registry.block.recipe.BlockIngredient;
+import betterwithmods.common.registry.block.recipe.KilnRecipe;
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
+import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.items.ItemHandlerHelper;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+@RegistryDescription
+public class Kiln extends VirtualizedRegistry<KilnRecipe> {
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:clay')).output(item('minecraft:diamond')).heat(2)"),
+            @Example(".input(item('minecraft:diamond_block')).output(item('minecraft:gold_ingot') * 16).ignoreHeat()")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @Override
+    public void onReload() {
+        removeScripted().forEach(recipe -> BWRegistry.KILN.getRecipes().removeIf(r -> r == recipe));
+        BWRegistry.KILN.getRecipes().addAll(restoreFromBackup());
+    }
+
+    public KilnRecipe add(KilnRecipe recipe) {
+        if (recipe != null) {
+            addScripted(recipe);
+            BWRegistry.KILN.getRecipes().add(recipe);
+        }
+        return recipe;
+    }
+
+    public boolean remove(KilnRecipe recipe) {
+        if (BWRegistry.KILN.getRecipes().removeIf(r -> r == recipe)) {
+            addBackup(recipe);
+            return true;
+        }
+        return false;
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('minecraft:brick')"))
+    public boolean removeByOutput(ItemStack output) {
+        return BWRegistry.KILN.getRecipes().removeIf(r -> {
+            for (ItemStack itemstack : r.getOutputs()) {
+                if (ItemHandlerHelper.canItemStacksStack(itemstack, output)) {
+                    addBackup(r);
+                    return true;
+                }
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:end_stone')"))
+    public boolean removeByInput(ItemStack input) {
+        return BWRegistry.KILN.getRecipes().removeIf(r -> {
+            for (ItemStack itemstack : r.getInput().getMatchingStacks()) {
+                if (ItemHandlerHelper.canItemStacksStack(itemstack, input)) {
+                    addBackup(r);
+                    return true;
+                }
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeByInput")
+    public boolean removeByInput(IIngredient input) {
+        return removeByInput(IngredientHelper.toItemStack(input));
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    public SimpleObjectStream<KilnRecipe> streamRecipes() {
+        return new SimpleObjectStream<>(BWRegistry.KILN.getRecipes()).setRemover(this::remove);
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    public void removeAll() {
+        BWRegistry.KILN.getRecipes().forEach(this::addBackup);
+        BWRegistry.KILN.getRecipes().clear();
+    }
+
+    @Property(property = "output", valid = {@Comp(value = "1", type = Comp.Type.GTE), @Comp(value = "3", type = Comp.Type.LTE)})
+    public static class RecipeBuilder extends AbstractRecipeBuilder<KilnRecipe> {
+
+        @Property
+        private BlockIngredient input;
+        @Property(defaultValue = "1")
+        private int heat = 1;
+        @Property
+        private boolean ignoreHeat;
+
+        public RecipeBuilder input(BlockIngredient input) {
+            this.input = input;
+            return this;
+        }
+
+        public RecipeBuilder input(String input) {
+            this.input = new BlockIngredient(input);
+            return this;
+        }
+
+        public RecipeBuilder input(List<ItemStack> input) {
+            this.input = new BlockIngredient(input);
+            return this;
+        }
+
+        public RecipeBuilder input(ItemStack... input) {
+            this.input = new BlockIngredient(input);
+            return this;
+        }
+
+        public RecipeBuilder input(IIngredient input) {
+            this.input = new BlockIngredient(input.toMcIngredient());
+            return this;
+        }
+
+        public RecipeBuilder heat(int heat) {
+            this.heat = heat;
+            return this;
+        }
+
+        public RecipeBuilder ignoreHeat(boolean ignoreHeat) {
+            this.ignoreHeat = ignoreHeat;
+            return this;
+        }
+
+        public RecipeBuilder ignoreHeat() {
+            this.ignoreHeat = !ignoreHeat;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Better With Mods Kiln recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 0, 0, 1, 3);
+            validateFluids(msg);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable KilnRecipe register() {
+            if (!validate()) return null;
+
+            KilnRecipe recipe = new KilnRecipe(input, output, heat);
+            recipe.setIgnoreHeat(ignoreHeat);
+            ModSupport.BETTER_WITH_MODS.get().kiln.add(recipe);
+            return recipe;
+        }
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/MillStone.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/MillStone.java
@@ -1,0 +1,158 @@
+package com.cleanroommc.groovyscript.compat.mods.betterwithmods;
+
+import betterwithmods.common.BWRegistry;
+import betterwithmods.common.registry.bulk.recipes.MillRecipe;
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.Alias;
+import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
+import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.Ingredient;
+import net.minecraft.util.SoundEvent;
+import net.minecraftforge.items.ItemHandlerHelper;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.stream.Collectors;
+
+@RegistryDescription
+public class MillStone extends VirtualizedRegistry<MillRecipe> {
+
+    public MillStone() {
+        super(Alias.generateOfClass(MillStone.class).andGenerate("Mill"));
+    }
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:diamond') * 2).output(item('minecraft:gold_ingot') * 16)"),
+            @Example(".input(item('minecraft:diamond_block')).output(item('minecraft:gold_ingot'), item('minecraft:gold_block'), item('minecraft:clay'))")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @Override
+    public void onReload() {
+        removeScripted().forEach(recipe -> BWRegistry.MILLSTONE.getRecipes().removeIf(r -> r == recipe));
+        BWRegistry.MILLSTONE.getRecipes().addAll(restoreFromBackup());
+    }
+
+    public MillRecipe add(MillRecipe recipe) {
+        if (recipe != null) {
+            addScripted(recipe);
+            BWRegistry.MILLSTONE.getRecipes().add(recipe);
+        }
+        return recipe;
+    }
+
+    public boolean remove(MillRecipe recipe) {
+        if (BWRegistry.MILLSTONE.getRecipes().removeIf(r -> r == recipe)) {
+            addBackup(recipe);
+            return true;
+        }
+        return false;
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('minecraft:blaze_powder')"))
+    public boolean removeByOutput(ItemStack output) {
+        return BWRegistry.MILLSTONE.getRecipes().removeIf(r -> {
+            for (ItemStack itemstack : r.getOutputs()) {
+                if (ItemHandlerHelper.canItemStacksStack(itemstack, output)) {
+                    addBackup(r);
+                    return true;
+                }
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:netherrack')"))
+    public boolean removeByInput(ItemStack input) {
+        return BWRegistry.MILLSTONE.getRecipes().removeIf(r -> {
+            for (Ingredient ingredient : r.getInputs()) {
+                if (ingredient.test(input)) {
+                    addBackup(r);
+                    return true;
+                }
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeByInput")
+    public boolean removeByInput(IIngredient input) {
+        return removeByInput(IngredientHelper.toItemStack(input));
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    public SimpleObjectStream<MillRecipe> streamRecipes() {
+        return new SimpleObjectStream<>(BWRegistry.MILLSTONE.getRecipes()).setRemover(this::remove);
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    public void removeAll() {
+        BWRegistry.MILLSTONE.getRecipes().forEach(this::addBackup);
+        BWRegistry.MILLSTONE.getRecipes().clear();
+    }
+
+    @Property(property = "input", valid = {@Comp(value = "1", type = Comp.Type.GTE), @Comp(value = "3", type = Comp.Type.LTE)})
+    @Property(property = "output", valid = {@Comp(value = "1", type = Comp.Type.GTE), @Comp(value = "3", type = Comp.Type.LTE)})
+    public static class RecipeBuilder extends AbstractRecipeBuilder<MillRecipe> {
+
+        @Property
+        private SoundEvent soundEvent;
+        @Property(defaultValue = "1", valid = @Comp(value = "1", type = Comp.Type.GTE))
+        private int ticks = 1;
+        @Property(defaultValue = "1")
+        private int priority = 1;
+
+        public RecipeBuilder ticks(int ticks) {
+            this.ticks = ticks;
+            return this;
+        }
+
+        public RecipeBuilder time(int ticks) {
+            this.ticks = ticks;
+            return this;
+        }
+
+        public RecipeBuilder soundEvent(SoundEvent soundEvent) {
+            this.soundEvent = soundEvent;
+            return this;
+        }
+
+        public RecipeBuilder priority(int priority) {
+            this.priority = priority;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Better With Mods Mill recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 1, 3, 1, 3);
+            validateFluids(msg);
+            msg.add(ticks <= 0, "ticks must be a positive integer greater than 0, yet it was {}", ticks);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable MillRecipe register() {
+            if (!validate()) return null;
+
+            MillRecipe recipe = new MillRecipe(input.stream().map(IIngredient::toMcIngredient).collect(Collectors.toList()), output);
+            recipe.setSound(soundEvent);
+            recipe.setTicks(ticks);
+            recipe.setPriority(priority);
+            ModSupport.BETTER_WITH_MODS.get().millStone.add(recipe);
+            return recipe;
+        }
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/MillStone.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/MillStone.java
@@ -27,7 +27,7 @@ public class MillStone extends VirtualizedRegistry<MillRecipe> {
     }
 
     @RecipeBuilderDescription(example = {
-            @Example(".input(item('minecraft:diamond') * 2).output(item('minecraft:gold_ingot') * 16)"),
+            @Example(".input(item('minecraft:diamond')).output(item('minecraft:gold_ingot') * 16)"),
             @Example(".input(item('minecraft:diamond_block')).output(item('minecraft:gold_ingot'), item('minecraft:gold_block'), item('minecraft:clay'))")
     })
     public RecipeBuilder recipeBuilder() {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/MillStone.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/MillStone.java
@@ -8,13 +8,11 @@ import com.cleanroommc.groovyscript.api.documentation.annotations.*;
 import com.cleanroommc.groovyscript.compat.mods.ModSupport;
 import com.cleanroommc.groovyscript.helper.Alias;
 import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
-import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
 import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.Ingredient;
 import net.minecraft.util.SoundEvent;
-import net.minecraftforge.items.ItemHandlerHelper;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.stream.Collectors;
@@ -57,10 +55,10 @@ public class MillStone extends VirtualizedRegistry<MillRecipe> {
     }
 
     @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('minecraft:blaze_powder')"))
-    public boolean removeByOutput(ItemStack output) {
+    public boolean removeByOutput(IIngredient output) {
         return BWRegistry.MILLSTONE.getRecipes().removeIf(r -> {
             for (ItemStack itemstack : r.getOutputs()) {
-                if (ItemHandlerHelper.canItemStacksStack(itemstack, output)) {
+                if (output.test(itemstack)) {
                     addBackup(r);
                     return true;
                 }
@@ -70,21 +68,18 @@ public class MillStone extends VirtualizedRegistry<MillRecipe> {
     }
 
     @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:netherrack')"))
-    public boolean removeByInput(ItemStack input) {
+    public boolean removeByInput(IIngredient input) {
         return BWRegistry.MILLSTONE.getRecipes().removeIf(r -> {
             for (Ingredient ingredient : r.getInputs()) {
-                if (ingredient.test(input)) {
-                    addBackup(r);
-                    return true;
+                for (ItemStack item : ingredient.getMatchingStacks()) {
+                    if (input.test(item)) {
+                        addBackup(r);
+                        return true;
+                    }
                 }
             }
             return false;
         });
-    }
-
-    @MethodDescription(description = "groovyscript.wiki.removeByInput")
-    public boolean removeByInput(IIngredient input) {
-        return removeByInput(IngredientHelper.toItemStack(input));
     }
 
     @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/Saw.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/Saw.java
@@ -1,0 +1,145 @@
+package com.cleanroommc.groovyscript.compat.mods.betterwithmods;
+
+import betterwithmods.common.BWRegistry;
+import betterwithmods.common.registry.block.recipe.BlockIngredient;
+import betterwithmods.common.registry.block.recipe.SawRecipe;
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
+import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.items.ItemHandlerHelper;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+@RegistryDescription
+public class Saw extends VirtualizedRegistry<SawRecipe> {
+
+    @RecipeBuilderDescription(example = @Example(".input(item('minecraft:diamond_block')).output(item('minecraft:gold_ingot') * 16)"))
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @Override
+    public void onReload() {
+        removeScripted().forEach(recipe -> BWRegistry.WOOD_SAW.getRecipes().removeIf(r -> r == recipe));
+        BWRegistry.WOOD_SAW.getRecipes().addAll(restoreFromBackup());
+    }
+
+    public SawRecipe add(SawRecipe recipe) {
+        if (recipe != null) {
+            addScripted(recipe);
+            BWRegistry.WOOD_SAW.getRecipes().add(recipe);
+        }
+        return recipe;
+    }
+
+    public boolean remove(SawRecipe recipe) {
+        if (BWRegistry.WOOD_SAW.getRecipes().removeIf(r -> r == recipe)) {
+            addBackup(recipe);
+            return true;
+        }
+        return false;
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('minecraft:pumpkin')"))
+    public boolean removeByOutput(ItemStack output) {
+        return BWRegistry.WOOD_SAW.getRecipes().removeIf(r -> {
+            for (ItemStack itemstack : r.getOutputs()) {
+                if (ItemHandlerHelper.canItemStacksStack(itemstack, output)) {
+                    addBackup(r);
+                    return true;
+                }
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:vine')"))
+    public boolean removeByInput(ItemStack input) {
+        return BWRegistry.WOOD_SAW.getRecipes().removeIf(r -> {
+            for (ItemStack itemstack : r.getInput().getMatchingStacks()) {
+                if (ItemHandlerHelper.canItemStacksStack(itemstack, input)) {
+                    addBackup(r);
+                    return true;
+                }
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeByInput")
+    public boolean removeByInput(IIngredient input) {
+        return removeByInput(IngredientHelper.toItemStack(input));
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    public SimpleObjectStream<SawRecipe> streamRecipes() {
+        return new SimpleObjectStream<>(BWRegistry.WOOD_SAW.getRecipes()).setRemover(this::remove);
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    public void removeAll() {
+        BWRegistry.WOOD_SAW.getRecipes().forEach(this::addBackup);
+        BWRegistry.WOOD_SAW.getRecipes().clear();
+    }
+
+    @Property(property = "output", valid = {@Comp(value = "1", type = Comp.Type.GTE), @Comp(value = "9", type = Comp.Type.LTE)})
+    public static class RecipeBuilder extends AbstractRecipeBuilder<SawRecipe> {
+
+        @Property
+        private BlockIngredient input;
+
+        public RecipeBuilder input(BlockIngredient input) {
+            this.input = input;
+            return this;
+        }
+
+        public RecipeBuilder input(String input) {
+            this.input = new BlockIngredient(input);
+            return this;
+        }
+
+        public RecipeBuilder input(List<ItemStack> input) {
+            this.input = new BlockIngredient(input);
+            return this;
+        }
+
+        public RecipeBuilder input(ItemStack... input) {
+            this.input = new BlockIngredient(input);
+            return this;
+        }
+
+        public RecipeBuilder input(IIngredient input) {
+            this.input = new BlockIngredient(input.toMcIngredient());
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Better With Mods Saw recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 0, 0, 1, 3);
+            validateFluids(msg);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable SawRecipe register() {
+            if (!validate()) return null;
+
+            SawRecipe recipe = new SawRecipe(input, output);
+            ModSupport.BETTER_WITH_MODS.get().saw.add(recipe);
+            return recipe;
+        }
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/Saw.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/Saw.java
@@ -8,11 +8,9 @@ import com.cleanroommc.groovyscript.api.IIngredient;
 import com.cleanroommc.groovyscript.api.documentation.annotations.*;
 import com.cleanroommc.groovyscript.compat.mods.ModSupport;
 import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
-import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
 import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
 import net.minecraft.item.ItemStack;
-import net.minecraftforge.items.ItemHandlerHelper;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
@@ -48,10 +46,10 @@ public class Saw extends VirtualizedRegistry<SawRecipe> {
     }
 
     @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('minecraft:pumpkin')"))
-    public boolean removeByOutput(ItemStack output) {
+    public boolean removeByOutput(IIngredient output) {
         return BWRegistry.WOOD_SAW.getRecipes().removeIf(r -> {
             for (ItemStack itemstack : r.getOutputs()) {
-                if (ItemHandlerHelper.canItemStacksStack(itemstack, output)) {
+                if (output.test(itemstack)) {
                     addBackup(r);
                     return true;
                 }
@@ -61,21 +59,16 @@ public class Saw extends VirtualizedRegistry<SawRecipe> {
     }
 
     @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:vine')"))
-    public boolean removeByInput(ItemStack input) {
+    public boolean removeByInput(IIngredient input) {
         return BWRegistry.WOOD_SAW.getRecipes().removeIf(r -> {
             for (ItemStack itemstack : r.getInput().getMatchingStacks()) {
-                if (ItemHandlerHelper.canItemStacksStack(itemstack, input)) {
+                if (input.test(itemstack)) {
                     addBackup(r);
                     return true;
                 }
             }
             return false;
         });
-    }
-
-    @MethodDescription(description = "groovyscript.wiki.removeByInput")
-    public boolean removeByInput(IIngredient input) {
-        return removeByInput(IngredientHelper.toItemStack(input));
     }
 
     @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/Turntable.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/Turntable.java
@@ -1,0 +1,164 @@
+package com.cleanroommc.groovyscript.compat.mods.betterwithmods;
+
+import betterwithmods.common.BWRegistry;
+import betterwithmods.common.registry.block.recipe.BlockIngredient;
+import betterwithmods.common.registry.block.recipe.TurntableRecipe;
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
+import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.init.Blocks;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.items.ItemHandlerHelper;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+@RegistryDescription
+public class Turntable extends VirtualizedRegistry<TurntableRecipe> {
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:gold_block')).outputBlock(blockstate('minecraft:clay')).output(item('minecraft:gold_ingot') * 5).rotations(5)"),
+            @Example(".input(item('minecraft:clay')).output(item('minecraft:gold_ingot')).rotations(2)")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @Override
+    public void onReload() {
+        removeScripted().forEach(recipe -> BWRegistry.TURNTABLE.getRecipes().removeIf(r -> r == recipe));
+        BWRegistry.TURNTABLE.getRecipes().addAll(restoreFromBackup());
+    }
+
+    public TurntableRecipe add(TurntableRecipe recipe) {
+        if (recipe != null) {
+            addScripted(recipe);
+            BWRegistry.TURNTABLE.getRecipes().add(recipe);
+        }
+        return recipe;
+    }
+
+    public boolean remove(TurntableRecipe recipe) {
+        if (BWRegistry.TURNTABLE.getRecipes().removeIf(r -> r == recipe)) {
+            addBackup(recipe);
+            return true;
+        }
+        return false;
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('minecraft:clay_ball')"))
+    public boolean removeByOutput(ItemStack output) {
+        return BWRegistry.TURNTABLE.getRecipes().removeIf(r -> {
+            for (ItemStack itemstack : r.getOutputs()) {
+                if (ItemHandlerHelper.canItemStacksStack(itemstack, output)) {
+                    addBackup(r);
+                    return true;
+                }
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('betterwithmods:unfired_pottery')"))
+    public boolean removeByInput(ItemStack input) {
+        return BWRegistry.TURNTABLE.getRecipes().removeIf(r -> {
+            for (ItemStack itemstack : r.getInput().getMatchingStacks()) {
+                if (ItemHandlerHelper.canItemStacksStack(itemstack, input)) {
+                    addBackup(r);
+                    return true;
+                }
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeByInput")
+    public boolean removeByInput(IIngredient input) {
+        return removeByInput(IngredientHelper.toItemStack(input));
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    public SimpleObjectStream<TurntableRecipe> streamRecipes() {
+        return new SimpleObjectStream<>(BWRegistry.TURNTABLE.getRecipes()).setRemover(this::remove);
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    public void removeAll() {
+        BWRegistry.TURNTABLE.getRecipes().forEach(this::addBackup);
+        BWRegistry.TURNTABLE.getRecipes().clear();
+    }
+
+    @Property(property = "output", valid = {@Comp(value = "0", type = Comp.Type.GTE), @Comp(value = "2", type = Comp.Type.LTE)})
+    public static class RecipeBuilder extends AbstractRecipeBuilder<TurntableRecipe> {
+
+        @Property
+        private BlockIngredient input;
+        @Property(defaultValue = "Blocks.AIR.getDefaultState()")
+        private IBlockState outputBlock = Blocks.AIR.getDefaultState();
+        @Property(defaultValue = "1")
+        private int rotations = 1;
+
+        public RecipeBuilder input(BlockIngredient input) {
+            this.input = input;
+            return this;
+        }
+
+        public RecipeBuilder input(String input) {
+            this.input = new BlockIngredient(input);
+            return this;
+        }
+
+        public RecipeBuilder input(List<ItemStack> input) {
+            this.input = new BlockIngredient(input);
+            return this;
+        }
+
+        public RecipeBuilder input(ItemStack... input) {
+            this.input = new BlockIngredient(input);
+            return this;
+        }
+
+        public RecipeBuilder input(IIngredient input) {
+            this.input = new BlockIngredient(input.toMcIngredient());
+            return this;
+        }
+
+        public RecipeBuilder outputBlock(IBlockState outputBlock) {
+            this.outputBlock = outputBlock;
+            return this;
+        }
+
+        public RecipeBuilder rotations(int rotations) {
+            this.rotations = rotations;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Better With Mods Turntable recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 0, 0, 0, 2);
+            validateFluids(msg);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable TurntableRecipe register() {
+            if (!validate()) return null;
+
+            TurntableRecipe recipe = new TurntableRecipe(input, output, outputBlock, rotations);
+            ModSupport.BETTER_WITH_MODS.get().turntable.add(recipe);
+            return recipe;
+        }
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/Turntable.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/Turntable.java
@@ -8,13 +8,11 @@ import com.cleanroommc.groovyscript.api.IIngredient;
 import com.cleanroommc.groovyscript.api.documentation.annotations.*;
 import com.cleanroommc.groovyscript.compat.mods.ModSupport;
 import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
-import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
 import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
-import net.minecraftforge.items.ItemHandlerHelper;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
@@ -53,10 +51,10 @@ public class Turntable extends VirtualizedRegistry<TurntableRecipe> {
     }
 
     @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('minecraft:clay_ball')"))
-    public boolean removeByOutput(ItemStack output) {
+    public boolean removeByOutput(IIngredient output) {
         return BWRegistry.TURNTABLE.getRecipes().removeIf(r -> {
             for (ItemStack itemstack : r.getOutputs()) {
-                if (ItemHandlerHelper.canItemStacksStack(itemstack, output)) {
+                if (output.test(itemstack)) {
                     addBackup(r);
                     return true;
                 }
@@ -66,21 +64,16 @@ public class Turntable extends VirtualizedRegistry<TurntableRecipe> {
     }
 
     @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('betterwithmods:unfired_pottery')"))
-    public boolean removeByInput(ItemStack input) {
+    public boolean removeByInput(IIngredient input) {
         return BWRegistry.TURNTABLE.getRecipes().removeIf(r -> {
             for (ItemStack itemstack : r.getInput().getMatchingStacks()) {
-                if (ItemHandlerHelper.canItemStacksStack(itemstack, input)) {
+                if (input.test(itemstack)) {
                     addBackup(r);
                     return true;
                 }
             }
             return false;
         });
-    }
-
-    @MethodDescription(description = "groovyscript.wiki.removeByInput")
-    public boolean removeByInput(IIngredient input) {
-        return removeByInput(IngredientHelper.toItemStack(input));
     }
 
     @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)

--- a/src/main/java/com/cleanroommc/groovyscript/core/LateMixin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/LateMixin.java
@@ -14,6 +14,7 @@ public class LateMixin implements ILateMixinLoader {
             "advancedmortars",
             "appliedenergistics2",
             "astralsorcery",
+            "betterwithmods",
             "bloodmagic",
             "botania",
             "draconicevolution",

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/betterwithmods/BWMHeatRegistryAccessor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/betterwithmods/BWMHeatRegistryAccessor.java
@@ -1,0 +1,17 @@
+package com.cleanroommc.groovyscript.core.mixin.betterwithmods;
+
+import betterwithmods.common.registry.heat.BWMHeatRegistry;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import java.util.List;
+
+@Mixin(value = BWMHeatRegistry.class, remap = false)
+public interface BWMHeatRegistryAccessor {
+
+    @Accessor
+    static List<BWMHeatRegistry.HeatSource> getHEAT_SOURCES() {
+        throw new UnsupportedOperationException();
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/betterwithmods/HopperFiltersAccessor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/betterwithmods/HopperFiltersAccessor.java
@@ -1,0 +1,16 @@
+package com.cleanroommc.groovyscript.core.mixin.betterwithmods;
+
+import betterwithmods.api.tile.IHopperFilter;
+import betterwithmods.common.registry.HopperFilters;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import java.util.Map;
+
+@Mixin(value = HopperFilters.class, remap = false)
+public interface HopperFiltersAccessor {
+
+    @Accessor
+    Map<String, IHopperFilter> getFILTERS();
+
+}

--- a/src/main/resources/assets/groovyscript/lang/en_us.lang
+++ b/src/main/resources/assets/groovyscript/lang/en_us.lang
@@ -343,6 +343,24 @@ groovyscript.wiki.betterwithmods.crucible.heat.value=Sets if the Cauldron requir
 groovyscript.wiki.betterwithmods.crucible.priority.value=Sets the priority of the recipe in relation to other valid recipes for the given items
 groovyscript.wiki.betterwithmods.crucible.ignoreHeat.value=Sets if the Cauldron requires any heat source below it
 
+groovyscript.wiki.betterwithmods.heat.title=Heat
+groovyscript.wiki.betterwithmods.heat.description=Creates new levels or adds new blocks to old heat levels.
+groovyscript.wiki.betterwithmods.heat.note0=Anything using heat levels will create a new JEI tab for each heat level it has recipes for. This will have a lang key name.
+groovyscript.wiki.betterwithmods.heat.add=Adds new heat levels in the format `heat`, `ingredient`
+
+groovyscript.wiki.betterwithmods.hopper.title=Filtered Hopper
+groovyscript.wiki.betterwithmods.hopper.description=Recipes for the Filtered Hopper to process. The filter targeted must allow the input item in to function.
+groovyscript.wiki.betterwithmods.hopper.name.value=Sets the name of the filter used for the recipe, the input item must be capable of passing through the filter to be processed
+groovyscript.wiki.betterwithmods.hopper.inWorldItemOutput.value=Sets the items dropped in-world when the recipe is processed
+
+groovyscript.wiki.betterwithmods.hopper_filters.title=Hopper Filters
+groovyscript.wiki.betterwithmods.hopper_filters.description=Items placed in the middle slot of the Filtered Hopper to restrict what is capable of passing through.
+groovyscript.wiki.betterwithmods.hopper_filters.filter.value=Sets the filter itemstack
+groovyscript.wiki.betterwithmods.hopper_filters.filtered.value=Sets the valid items allowed through the filter
+groovyscript.wiki.betterwithmods.hopper_filters.removeByFilter=Removes all filters with the given filter item
+groovyscript.wiki.betterwithmods.hopper_filters.removeByFiltered=Removes all filters with the given items allowed through the filter
+groovyscript.wiki.betterwithmods.hopper_filters.removeByName=Removes the filter with the given name
+
 groovyscript.wiki.betterwithmods.kiln.title=Kiln
 groovyscript.wiki.betterwithmods.kiln.description=Converts a block into up to three output itemstacks, with the ability to require specific amounts of heat.
 groovyscript.wiki.betterwithmods.kiln.heat.value=Sets if the Kiln requires a normal fire (1) or a Stoked Fire (2) below it

--- a/src/main/resources/assets/groovyscript/lang/en_us.lang
+++ b/src/main/resources/assets/groovyscript/lang/en_us.lang
@@ -327,6 +327,45 @@ groovyscript.wiki.avaritia.extreme_crafting.description=A normal crafting table,
 groovyscript.wiki.avaritia.extreme_crafting.addShaped=Adds a shaped crafting recipe in the format `output`, `input`
 groovyscript.wiki.avaritia.extreme_crafting.addShapeless=Adds a shapeless crafting recipe in the format `output`, `input`
 
+# Better With Mods
+groovyscript.wiki.betterwithmods.anvil_crafting.title=Anvil Crafting
+groovyscript.wiki.betterwithmods.anvil_crafting.description=Similar to a normal crafting table, but 4x4 instead.
+
+groovyscript.wiki.betterwithmods.cauldron.title=Cauldron
+groovyscript.wiki.betterwithmods.cauldron.description=Converts a large number of items into other items, with the ability to require specific amounts of heat.
+groovyscript.wiki.betterwithmods.cauldron.heat.value=Sets if the Cauldron requires a normal fire (1) or a Stoked Fire (2) below it
+groovyscript.wiki.betterwithmods.cauldron.priority.value=Sets the priority of the recipe in relation to other valid recipes for the given items
+groovyscript.wiki.betterwithmods.cauldron.ignoreHeat.value=Sets if the Cauldron requires any heat source below it
+
+groovyscript.wiki.betterwithmods.crucible.title=Crucible
+groovyscript.wiki.betterwithmods.crucible.description=Converts a large number of items into other items, with the ability to require specific amounts of heat.
+groovyscript.wiki.betterwithmods.crucible.heat.value=Sets if the Cauldron requires a normal fire (1) or a Stoked Fire (2) below it
+groovyscript.wiki.betterwithmods.crucible.priority.value=Sets the priority of the recipe in relation to other valid recipes for the given items
+groovyscript.wiki.betterwithmods.crucible.ignoreHeat.value=Sets if the Cauldron requires any heat source below it
+
+groovyscript.wiki.betterwithmods.kiln.title=Kiln
+groovyscript.wiki.betterwithmods.kiln.description=Converts a block into up to three output itemstacks, with the ability to require specific amounts of heat.
+groovyscript.wiki.betterwithmods.kiln.heat.value=Sets if the Kiln requires a normal fire (1) or a Stoked Fire (2) below it
+groovyscript.wiki.betterwithmods.kiln.input.value=Sets the input block of the recipe
+groovyscript.wiki.betterwithmods.kiln.ignoreHeat.value=Sets if the Kiln requires any heat source below it
+
+groovyscript.wiki.betterwithmods.mill_stone.title=Mill Stone
+groovyscript.wiki.betterwithmods.mill_stone.description=Converts input itemstacks into output itemstacks after being ground via rotation power for a given time.
+groovyscript.wiki.betterwithmods.mill_stone.ticks.value=Sets the time in ticks the recipe takes to complete
+groovyscript.wiki.betterwithmods.mill_stone.priority.value=Sets the priority of the recipe in relation to other valid recipes for the given items
+groovyscript.wiki.betterwithmods.mill_stone.soundEvent.value=Sets what sound is played by the mill during the recipe
+
+groovyscript.wiki.betterwithmods.saw.title=Saw
+groovyscript.wiki.betterwithmods.saw.description=Converts a block into output itemstacks after being powered via rotation power.
+groovyscript.wiki.betterwithmods.saw.input.value=Sets the input block of the recipe
+
+groovyscript.wiki.betterwithmods.turntable.title=Turntable
+groovyscript.wiki.betterwithmods.turntable.description=Converts a block into an output block and up to two itemstacks after being powered via rotation power.
+groovyscript.wiki.betterwithmods.turntable.input.value=Sets the input block
+groovyscript.wiki.betterwithmods.turntable.rotations.value=Sets the number of rotations required to complete the recipe
+groovyscript.wiki.betterwithmods.turntable.outputBlock.value=Sets the blockstate that replaces the input block
+
+
 # Blood Magic
 groovyscript.wiki.bloodmagic.alchemy_array.title=Alchemy Array
 groovyscript.wiki.bloodmagic.alchemy_array.description=Converts two items into an output itemstack by using Arcane Ashes in-world. Has a configurable texture for the animation.

--- a/src/main/resources/mixin.groovyscript.betterwithmods.json
+++ b/src/main/resources/mixin.groovyscript.betterwithmods.json
@@ -1,0 +1,11 @@
+{
+  "package": "com.cleanroommc.groovyscript.core.mixin.betterwithmods",
+  "refmap": "mixins.groovyscript.refmap.json",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": [
+    "BWMHeatRegistryAccessor",
+    "HopperFiltersAccessor"
+  ]
+}


### PR DESCRIPTION
what this PR adds:
- compat with `anvilCrafting`, `cauldron`, `crucible`, `kiln`, `millStone`, `saw`, `turntable`, `heat`, `hopper`, and `hopperFilters`
- `anvilCrafting` has all the abilities of a normal crafting table (recipeFunction and recipeAction), which i believe adds novel functionality
- examples for the above
- i18n keys for the above

CraftTweaker, through ModTweaker, has the following explicit compat with Better With Mods that is _not_ added in this PR:
- `bellows`, controlling how far specific items are blown by the Bellows block
- `pulleymanager`, allows adding what blocks can be pulleys
- `buoyancy`, controlling if specific items float or sink in water
- `hcfurnace`, allows setting the time in ticks a given input smelting item takes (only active with the hardmode module enabled)
- `hcmovement`, allows controlling how fast the player walks on specific blocks (only active with the hardmode module enabled)

these werent added because
1. i got tired
2. they already have java methods to set the value and the actual Map used to store the data is a public field
3. they dont have much benefit for being reloadable

relevant classes for anyone who wants access to those, or me if i decide to implement compat
```
betterwithmods.common.registry.BellowsManager
betterwithmods.common.registry.PulleyStructureManager
betterwithmods.module.hardcore.world.HCBuoy
betterwithmods.module.hardcore.crafting.HCFurnace
betterwithmods.module.hardcore.needs.HCMovement
```
