### PR TITLE
add Alchemistry compat

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -36,6 +36,15 @@ dependencies {
         runtimeOnly rfg.deobf('curse.maven:avaritia_1_10-261348:3143349')
     }
 
+    compileOnly rfg.deobf("curse.maven:shadowfacts-forgelin-248453:2785465")
+    compileOnly rfg.deobf("curse.maven:alchemylib-293426:2761706")
+    compileOnly rfg.deobf("curse.maven:alchemistry-293425:3186612")
+    if (project.debug_alchemistry.toBoolean()) {
+        runtimeOnly rfg.deobf('curse.maven:shadowfacts-forgelin-248453:2785465')
+        runtimeOnly rfg.deobf('curse.maven:alchemylib-293426:2761706')
+        runtimeOnly rfg.deobf('curse.maven:alchemistry-293425:3186612')
+    }
+
     compileOnly rfg.deobf("curse.maven:ctm-267602:2915363")
     compileOnly rfg.deobf("curse.maven:chisel-235279:2915375")
     if (project.debug_chisel.toBoolean()) {

--- a/examples/postInit/alchemistry.groovy
+++ b/examples/postInit/alchemistry.groovy
@@ -1,0 +1,127 @@
+
+// Auto generated groovyscript example file
+// MODS_LOADED: alchemistry
+
+println 'mod \'alchemistry\' detected, running script'
+
+// groovyscript.wiki.alchemistry.atomizer.title:
+// groovyscript.wiki.alchemistry.atomizer.description
+
+mods.alchemistry.atomizer.removeByInput(fluid('water'))
+// mods.alchemistry.atomizer.removeByOutput(item('alchemistry:compound:7'))
+// mods.alchemistry.atomizer.removeAll()
+
+mods.alchemistry.atomizer.recipeBuilder()
+    .fluidInput(fluid('water') * 125)
+    .output(item('minecraft:clay'))
+    .register()
+
+mods.alchemistry.atomizer.recipeBuilder()
+    .fluidInput(fluid('lava') * 500)
+    .output(item('minecraft:gold_ingot'))
+    .reversible()
+    .register()
+
+
+// groovyscript.wiki.alchemistry.combiner.title:
+// groovyscript.wiki.alchemistry.combiner.description
+
+mods.alchemistry.combiner.removeByInput(element('carbon'))
+mods.alchemistry.combiner.removeByOutput(item('minecraft:glowstone'))
+// mods.alchemistry.combiner.removeAll()
+
+mods.alchemistry.combiner.recipeBuilder()
+    .input(item('minecraft:gold_ingot') * 2, item('minecraft:gold_ingot') * 2, item('minecraft:gold_ingot') * 2, item('minecraft:gold_ingot') * 2, item('minecraft:gold_ingot') * 2, item('minecraft:gold_ingot') * 2, item('minecraft:gold_ingot') * 2, item('minecraft:gold_ingot') * 2, item('minecraft:gold_ingot') * 2)
+    .output(item('minecraft:gold_block') * 2)
+    .register()
+
+mods.alchemistry.combiner.recipeBuilder()
+    .input(ItemStack.EMPTY, ItemStack.EMPTY, item('minecraft:clay'))
+    .output(item('minecraft:gold_ingot'))
+    .register()
+
+
+// groovyscript.wiki.alchemistry.dissolver.title:
+// groovyscript.wiki.alchemistry.dissolver.description
+
+mods.alchemistry.dissolver.removeByInput(item('alchemistry:compound:1'))
+// mods.alchemistry.dissolver.removeAll()
+
+mods.alchemistry.dissolver.recipeBuilder()
+    .input(item('minecraft:gold_ingot'))
+    .probabilityOutput(item('minecraft:clay'))
+    .reversible()
+    .rolls(1)
+    .register()
+
+mods.alchemistry.dissolver.recipeBuilder()
+    .input(item('minecraft:diamond'))
+    .probabilityOutput(30, item('minecraft:clay'))
+    .probabilityOutput(30, item('minecraft:clay'))
+    .probabilityOutput(30, item('minecraft:clay'))
+    .rolls(10)
+    .register()
+
+
+// groovyscript.wiki.alchemistry.electrolyzer.title:
+// groovyscript.wiki.alchemistry.electrolyzer.description
+
+// mods.alchemistry.electrolyzer.removeByInput(fluid('water'))
+mods.alchemistry.electrolyzer.removeByInput(element('calcium_carbonate'))
+mods.alchemistry.electrolyzer.removeByOutput(element('chlorine'))
+// mods.alchemistry.electrolyzer.removeAll()
+
+mods.alchemistry.electrolyzer.recipeBuilder()
+    .fluidInput(fluid('lava') * 100)
+    .output(item('minecraft:clay'))
+    .register()
+
+mods.alchemistry.electrolyzer.recipeBuilder()
+    .fluidInput(fluid('water') * 100)
+    .input(item('minecraft:gold_ingot'))
+    .consumptionChance(100)
+    .output(item('minecraft:gold_nugget') * 4)
+    .output(item('minecraft:gold_nugget') * 4)
+    .output(item('minecraft:gold_nugget') * 4)
+    .output(item('minecraft:gold_nugget') * 4)
+    .chance(50)
+    .chance(50)
+    .register()
+
+
+// groovyscript.wiki.alchemistry.evaporator.title:
+// groovyscript.wiki.alchemistry.evaporator.description
+
+mods.alchemistry.evaporator.removeByInput(fluid('lava'))
+mods.alchemistry.evaporator.removeByOutput(item('alchemistry:mineral_salt'))
+// mods.alchemistry.evaporator.removeAll()
+
+mods.alchemistry.evaporator.recipeBuilder()
+    .fluidInput(fluid('lava') * 100)
+    .output(item('minecraft:redstone') * 8)
+    .register()
+
+mods.alchemistry.evaporator.recipeBuilder()
+    .fluidInput(fluid('water') * 10)
+    .output(item('minecraft:clay'))
+    .register()
+
+
+// groovyscript.wiki.alchemistry.liquifier.title:
+// groovyscript.wiki.alchemistry.liquifier.description
+
+mods.alchemistry.liquifier.removeByInput(element('water'))
+// mods.alchemistry.liquifier.removeByOutput(fluid('water'))
+// mods.alchemistry.liquifier.removeAll()
+
+mods.alchemistry.liquifier.recipeBuilder()
+    .input(element('carbon') * 32)
+    .fluidOutput(fluid('water') * 1000)
+    .register()
+
+mods.alchemistry.liquifier.recipeBuilder()
+    .input(item('minecraft:magma'))
+    .fluidOutput(fluid('lava') * 750)
+    .register()
+
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,7 @@
 # Debug mod compat
 debug_actually_additions = false
 debug_adv_mortars = false
+debug_alchemistry = false
 debug_applied_energistics_2 = false
 debug_astral = false
 debug_avaritia = false

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ModSupport.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ModSupport.java
@@ -6,6 +6,7 @@ import com.cleanroommc.groovyscript.api.GroovyPlugin;
 import com.cleanroommc.groovyscript.api.IDynamicGroovyProperty;
 import com.cleanroommc.groovyscript.compat.mods.actuallyadditions.ActuallyAdditions;
 import com.cleanroommc.groovyscript.compat.mods.advancedmortars.AdvancedMortars;
+import com.cleanroommc.groovyscript.compat.mods.alchemistry.Alchemistry;
 import com.cleanroommc.groovyscript.compat.mods.appliedenergistics2.AppliedEnergistics2;
 import com.cleanroommc.groovyscript.compat.mods.astralsorcery.AstralSorcery;
 import com.cleanroommc.groovyscript.compat.mods.avaritia.Avaritia;
@@ -52,6 +53,7 @@ public class ModSupport implements IDynamicGroovyProperty {
 
     public static final GroovyContainer<ActuallyAdditions> ACTUALLY_ADDITIONS = new InternalModContainer<>("actuallyadditions", "Actually Additions", ActuallyAdditions::new, "aa");
     public static final GroovyContainer<AdvancedMortars> ADVANCED_MORTARS = new InternalModContainer<>("advancedmortars", "Advanced Mortars", AdvancedMortars::new);
+    public static final GroovyContainer<Alchemistry> ALCHEMISTRY = new InternalModContainer<>("alchemistry", "Alchemistry", Alchemistry::new);
     public static final GroovyContainer<AppliedEnergistics2> APPLIED_ENERGISTICS_2 = new InternalModContainer<>("appliedenergistics2", "Applied Energistics 2", AppliedEnergistics2::new, "ae2");
     public static final GroovyContainer<AstralSorcery> ASTRAL_SORCERY = new InternalModContainer<>("astralsorcery", "Astral Sorcery", AstralSorcery::new, "astral");
     public static final GroovyContainer<Avaritia> AVARITIA = new InternalModContainer<>("avaritia", "Avaritia", Avaritia::new);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Alchemistry.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Alchemistry.java
@@ -1,0 +1,47 @@
+package com.cleanroommc.groovyscript.compat.mods.alchemistry;
+
+import al132.alchemistry.chemistry.ChemicalCompound;
+import al132.alchemistry.chemistry.ChemicalElement;
+import al132.alchemistry.chemistry.CompoundRegistry;
+import al132.alchemistry.chemistry.ElementRegistry;
+import com.cleanroommc.groovyscript.api.Result;
+import com.cleanroommc.groovyscript.compat.mods.ModPropertyContainer;
+import com.cleanroommc.groovyscript.gameobjects.GameObjectHandlerManager;
+
+public class Alchemistry extends ModPropertyContainer {
+
+    public final Atomizer atomizer = new Atomizer();
+    public final Combiner combiner = new Combiner();
+    public final Dissolver dissolver = new Dissolver();
+    public final Electrolyzer electrolyzer = new Electrolyzer();
+    public final Evaporator evaporator = new Evaporator();
+    public final Liquifier liquifier = new Liquifier();
+
+    public Alchemistry() {
+        addRegistry(atomizer);
+        addRegistry(combiner);
+        addRegistry(dissolver);
+        addRegistry(electrolyzer);
+        addRegistry(evaporator);
+        addRegistry(liquifier);
+        // TODO:
+        //  Compound Creation and Element Creation
+    }
+
+    @Override
+    public void initialize() {
+        GameObjectHandlerManager.registerGameObjectHandler("alchemistry", "element", (s, args) -> {
+            String parsedName = s.trim().toLowerCase().replace(" ", "_");
+            ChemicalCompound compound = CompoundRegistry.INSTANCE.get(parsedName);
+            if (compound == null || compound.toItemStack(1).isEmpty()) {
+                ChemicalElement element = ElementRegistry.INSTANCE.get(parsedName);
+                if (element == null || element.toItemStack(1).isEmpty()) {
+                    return Result.error();
+                }
+                return Result.some(element.toItemStack(1));
+            }
+            return Result.some(compound.toItemStack(1));
+        });
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Atomizer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Atomizer.java
@@ -8,10 +8,8 @@ import com.cleanroommc.groovyscript.api.IIngredient;
 import com.cleanroommc.groovyscript.api.documentation.annotations.*;
 import com.cleanroommc.groovyscript.compat.mods.ModSupport;
 import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
-import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
 import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
-import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 import org.jetbrains.annotations.Nullable;
 
@@ -49,9 +47,9 @@ public class Atomizer extends VirtualizedRegistry<AtomizerRecipe> {
     }
 
     @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example(value = "item('alchemistry:compound:7')", commented = true))
-    public boolean removeByOutput(ItemStack output) {
+    public boolean removeByOutput(IIngredient output) {
         return ModRecipes.INSTANCE.getAtomizerRecipes().removeIf(r -> {
-            if (r.getOutput().equals(output)) {
+            if (output.test(r.getOutput())) {
                 addBackup(r);
                 return true;
             }
@@ -68,11 +66,6 @@ public class Atomizer extends VirtualizedRegistry<AtomizerRecipe> {
             }
             return false;
         });
-    }
-
-    @MethodDescription(description = "groovyscript.wiki.removeByInput")
-    public boolean removeByInput(IIngredient input) {
-        return removeByInput(IngredientHelper.toFluidStack(input));
     }
 
     @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Atomizer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Atomizer.java
@@ -1,0 +1,131 @@
+package com.cleanroommc.groovyscript.compat.mods.alchemistry;
+
+import al132.alchemistry.recipes.AtomizerRecipe;
+import al132.alchemistry.recipes.LiquifierRecipe;
+import al132.alchemistry.recipes.ModRecipes;
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
+import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
+import org.jetbrains.annotations.Nullable;
+
+@RegistryDescription
+public class Atomizer extends VirtualizedRegistry<AtomizerRecipe> {
+
+    @Override
+    public void onReload() {
+        removeScripted().forEach(recipe -> ModRecipes.INSTANCE.getAtomizerRecipes().removeIf(r -> r == recipe));
+        ModRecipes.INSTANCE.getAtomizerRecipes().addAll(restoreFromBackup());
+    }
+
+    @RecipeBuilderDescription(example = {
+            @Example(".fluidInput(fluid('water') * 125).output(item('minecraft:clay'))"),
+            @Example(".fluidInput(fluid('lava') * 500).output(item('minecraft:gold_ingot')).reversible()")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    public AtomizerRecipe add(AtomizerRecipe recipe) {
+        if (recipe != null) {
+            addScripted(recipe);
+            ModRecipes.INSTANCE.getAtomizerRecipes().add(recipe);
+        }
+        return recipe;
+    }
+
+    public boolean remove(AtomizerRecipe recipe) {
+        if (ModRecipes.INSTANCE.getAtomizerRecipes().removeIf(r -> r == recipe)) {
+            addBackup(recipe);
+            return true;
+        }
+        return false;
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example(value = "item('alchemistry:compound:7')", commented = true))
+    public boolean removeByOutput(ItemStack output) {
+        return ModRecipes.INSTANCE.getAtomizerRecipes().removeIf(r -> {
+            if (r.getOutput().equals(output)) {
+                addBackup(r);
+                return true;
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("fluid('water')"))
+    public boolean removeByInput(FluidStack input) {
+        return ModRecipes.INSTANCE.getAtomizerRecipes().removeIf(r -> {
+            if (r.getInput().isFluidEqual(input)) {
+                addBackup(r);
+                return true;
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeByInput")
+    public boolean removeByInput(IIngredient input) {
+        return removeByInput(IngredientHelper.toFluidStack(input));
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    public SimpleObjectStream<AtomizerRecipe> streamRecipes() {
+        return new SimpleObjectStream<>(ModRecipes.INSTANCE.getAtomizerRecipes()).setRemover(this::remove);
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    public void removeAll() {
+        ModRecipes.INSTANCE.getAtomizerRecipes().forEach(this::addBackup);
+        ModRecipes.INSTANCE.getAtomizerRecipes().clear();
+    }
+
+    @Property(property = "fluidInput", valid = @Comp("1"))
+    @Property(property = "output", valid = @Comp("1"))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<AtomizerRecipe> {
+
+        @Property
+        private boolean reversible;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder reversible(boolean reversible) {
+            this.reversible = reversible;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder reversible() {
+            this.reversible = !reversible;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Alchemistry Atomizer recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 0, 0, 1, 1);
+            validateFluids(msg, 1, 1, 0, 0);
+        }
+
+        @Nullable
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public AtomizerRecipe register() {
+            if (!validate()) return null;
+
+            AtomizerRecipe recipe = new AtomizerRecipe(false, fluidInput.get(0), output.get(0));
+            if (reversible) ModSupport.ALCHEMISTRY.get().liquifier.add(new LiquifierRecipe(output.get(0), fluidInput.get(0)));
+            ModSupport.ALCHEMISTRY.get().atomizer.add(recipe);
+            return recipe;
+        }
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Atomizer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Atomizer.java
@@ -10,6 +10,7 @@ import com.cleanroommc.groovyscript.compat.mods.ModSupport;
 import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
 import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 import org.jetbrains.annotations.Nullable;
 
@@ -28,6 +29,11 @@ public class Atomizer extends VirtualizedRegistry<AtomizerRecipe> {
     })
     public RecipeBuilder recipeBuilder() {
         return new RecipeBuilder();
+    }
+
+    @MethodDescription(type = MethodDescription.Type.ADDITION)
+    public AtomizerRecipe add(FluidStack input, ItemStack output) {
+        return new RecipeBuilder().fluidInput(input).output(output).register();
     }
 
     public AtomizerRecipe add(AtomizerRecipe recipe) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Combiner.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Combiner.java
@@ -1,0 +1,136 @@
+package com.cleanroommc.groovyscript.compat.mods.alchemistry;
+
+import al132.alchemistry.recipes.CombinerRecipe;
+import al132.alchemistry.recipes.ModRecipes;
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.Alias;
+import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
+import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.items.ItemHandlerHelper;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RegistryDescription
+public class Combiner extends VirtualizedRegistry<CombinerRecipe> {
+
+    public Combiner() {
+        super(Alias.generateOfClass(Combiner.class).andGenerate("ChemicalCombiner"));
+    }
+
+    @Override
+    public void onReload() {
+        removeScripted().forEach(recipe -> ModRecipes.INSTANCE.getCombinerRecipes().removeIf(r -> r == recipe));
+        ModRecipes.INSTANCE.getCombinerRecipes().addAll(restoreFromBackup());
+    }
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:gold_ingot') * 2, item('minecraft:gold_ingot') * 2, item('minecraft:gold_ingot') * 2, item('minecraft:gold_ingot') * 2, item('minecraft:gold_ingot') * 2, item('minecraft:gold_ingot') * 2, item('minecraft:gold_ingot') * 2, item('minecraft:gold_ingot') * 2, item('minecraft:gold_ingot') * 2).output(item('minecraft:gold_block') * 2)"),
+            @Example(".input(ItemStack.EMPTY, ItemStack.EMPTY, item('minecraft:clay')).output(item('minecraft:gold_ingot'))")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    public CombinerRecipe add(CombinerRecipe recipe) {
+        if (recipe != null) {
+            addScripted(recipe);
+            ModRecipes.INSTANCE.getCombinerRecipes().add(recipe);
+        }
+        return recipe;
+    }
+
+    public boolean remove(CombinerRecipe recipe) {
+        if (ModRecipes.INSTANCE.getCombinerRecipes().removeIf(r -> r == recipe)) {
+            addBackup(recipe);
+            return true;
+        }
+        return false;
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('minecraft:glowstone')"))
+    public boolean removeByOutput(ItemStack output) {
+        return ModRecipes.INSTANCE.getCombinerRecipes().removeIf(r -> {
+            if (ItemHandlerHelper.canItemStacksStack(r.getOutput(), output)) {
+                addBackup(r);
+                return true;
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("element('carbon')"))
+    public boolean removeByInput(ItemStack input) {
+        return ModRecipes.INSTANCE.getCombinerRecipes().removeIf(r -> {
+            for (ItemStack itemstack : r.getInputs()) {
+                if (ItemHandlerHelper.canItemStacksStack(itemstack, input)) {
+                    addBackup(r);
+                    return true;
+                }
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeByInput")
+    public boolean removeByInput(IIngredient input) {
+        return removeByInput(IngredientHelper.toItemStack(input));
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    public SimpleObjectStream<CombinerRecipe> streamRecipes() {
+        return new SimpleObjectStream<>(ModRecipes.INSTANCE.getCombinerRecipes()).setRemover(this::remove);
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    public void removeAll() {
+        ModRecipes.INSTANCE.getCombinerRecipes().forEach(this::addBackup);
+        ModRecipes.INSTANCE.getCombinerRecipes().clear();
+    }
+
+    @Property(property = "input", valid = {@Comp(type = Comp.Type.GTE, value = "1"), @Comp(type = Comp.Type.LTE, value = "9")})
+    @Property(property = "output", valid = @Comp("1"))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<CombinerRecipe> {
+
+        @Property
+        protected String gamestage = "";
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder gamestage(String gamestage) {
+            this.gamestage = gamestage;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Alchemistry Combiner recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            int inputSize = input.getRealSize();
+            output.trim();
+            msg.add(inputSize < 1 || inputSize > 9, () -> "Must have 1 - 9 inputs, but found " + input.size());
+            msg.add(output.size() != 1, () -> "Must have exactly 1 output, but found " + output.size());
+            validateFluids(msg);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable CombinerRecipe register() {
+            if (!validate()) return null;
+
+            List<ItemStack> inputs = input.stream().map(x -> x.isEmpty() ? ItemStack.EMPTY : IngredientHelper.toItemStack(x)).collect(Collectors.toList());
+            CombinerRecipe recipe = new CombinerRecipe(output.get(0), inputs, gamestage);
+            ModSupport.ALCHEMISTRY.get().combiner.add(recipe);
+            return recipe;
+        }
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Combiner.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Combiner.java
@@ -12,7 +12,6 @@ import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
 import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
 import net.minecraft.item.ItemStack;
-import net.minecraftforge.items.ItemHandlerHelper;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
@@ -56,9 +55,9 @@ public class Combiner extends VirtualizedRegistry<CombinerRecipe> {
     }
 
     @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('minecraft:glowstone')"))
-    public boolean removeByOutput(ItemStack output) {
+    public boolean removeByOutput(IIngredient output) {
         return ModRecipes.INSTANCE.getCombinerRecipes().removeIf(r -> {
-            if (ItemHandlerHelper.canItemStacksStack(r.getOutput(), output)) {
+            if (output.test(r.getOutput())) {
                 addBackup(r);
                 return true;
             }
@@ -67,21 +66,16 @@ public class Combiner extends VirtualizedRegistry<CombinerRecipe> {
     }
 
     @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("element('carbon')"))
-    public boolean removeByInput(ItemStack input) {
+    public boolean removeByInput(IIngredient input) {
         return ModRecipes.INSTANCE.getCombinerRecipes().removeIf(r -> {
             for (ItemStack itemstack : r.getInputs()) {
-                if (ItemHandlerHelper.canItemStacksStack(itemstack, input)) {
+                if (input.test(itemstack)) {
                     addBackup(r);
                     return true;
                 }
             }
             return false;
         });
-    }
-
-    @MethodDescription(description = "groovyscript.wiki.removeByInput")
-    public boolean removeByInput(IIngredient input) {
-        return removeByInput(IngredientHelper.toItemStack(input));
     }
 
     @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Dissolver.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Dissolver.java
@@ -7,11 +7,9 @@ import com.cleanroommc.groovyscript.api.documentation.annotations.*;
 import com.cleanroommc.groovyscript.compat.mods.ModSupport;
 import com.cleanroommc.groovyscript.helper.Alias;
 import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
-import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
 import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
 import net.minecraft.item.ItemStack;
-import net.minecraftforge.items.ItemHandlerHelper;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
@@ -58,21 +56,16 @@ public class Dissolver extends VirtualizedRegistry<DissolverRecipe> {
     }
 
     @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('alchemistry:compound:1')"))
-    public boolean removeByInput(ItemStack input) {
+    public boolean removeByInput(IIngredient input) {
         return ModRecipes.INSTANCE.getDissolverRecipes().removeIf(r -> {
             for (ItemStack itemstack : r.getInputs()) {
-                if (ItemHandlerHelper.canItemStacksStack(itemstack, input)) {
+                if (input.test(itemstack)) {
                     addBackup(r);
                     return true;
                 }
             }
             return false;
         });
-    }
-
-    @MethodDescription(description = "groovyscript.wiki.removeByInput")
-    public boolean removeByInput(IIngredient input) {
-        return removeByInput(IngredientHelper.toItemStack(input));
     }
 
     @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Dissolver.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Dissolver.java
@@ -1,0 +1,191 @@
+package com.cleanroommc.groovyscript.compat.mods.alchemistry;
+
+import al132.alchemistry.recipes.*;
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.Alias;
+import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
+import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.items.ItemHandlerHelper;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RegistryDescription
+public class Dissolver extends VirtualizedRegistry<DissolverRecipe> {
+
+    public Dissolver() {
+        super(Alias.generateOfClass(Dissolver.class).andGenerate("ChemicalDissolver"));
+    }
+
+    @Override
+    public void onReload() {
+        removeScripted().forEach(recipe -> ModRecipes.INSTANCE.getDissolverRecipes().removeIf(r -> r == recipe));
+        ModRecipes.INSTANCE.getDissolverRecipes().addAll(restoreFromBackup());
+    }
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:gold_ingot')).probabilityOutput(item('minecraft:clay')).reversible().rolls(1)"),
+            @Example(".input(item('minecraft:diamond')).probabilityOutput(30, item('minecraft:clay')).probabilityOutput(30, item('minecraft:clay')).probabilityOutput(30, item('minecraft:clay')).rolls(10)")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    public DissolverRecipe add(DissolverRecipe recipe) {
+        if (recipe != null) {
+            addScripted(recipe);
+            ModRecipes.INSTANCE.getDissolverRecipes().add(recipe);
+        }
+        return recipe;
+    }
+
+    public boolean remove(DissolverRecipe recipe) {
+        if (ModRecipes.INSTANCE.getDissolverRecipes().removeIf(r -> r == recipe)) {
+            addBackup(recipe);
+            return true;
+        }
+        return false;
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('alchemistry:compound:1')"))
+    public boolean removeByInput(ItemStack input) {
+        return ModRecipes.INSTANCE.getDissolverRecipes().removeIf(r -> {
+            for (ItemStack itemstack : r.getInputs()) {
+                if (ItemHandlerHelper.canItemStacksStack(itemstack, input)) {
+                    addBackup(r);
+                    return true;
+                }
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeByInput")
+    public boolean removeByInput(IIngredient input) {
+        return removeByInput(IngredientHelper.toItemStack(input));
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    public SimpleObjectStream<DissolverRecipe> streamRecipes() {
+        return new SimpleObjectStream<>(ModRecipes.INSTANCE.getDissolverRecipes()).setRemover(this::remove);
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    public void removeAll() {
+        ModRecipes.INSTANCE.getDissolverRecipes().forEach(this::addBackup);
+        ModRecipes.INSTANCE.getDissolverRecipes().clear();
+    }
+
+    @Property(property = "input", valid = @Comp("1"))
+    @Property(property = "output", valid = @Comp("1"))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<DissolverRecipe> {
+
+        @Property(valid = @Comp(value = "1", type = Comp.Type.GTE))
+        private final ArrayList<ProbabilityGroup> probabilityGroup = new ArrayList<>();
+        @Property
+        private boolean reversible;
+        @Property
+        private boolean relativeProbability;
+        @Property(defaultValue = "1", valid = @Comp(value = "1", type = Comp.Type.GTE))
+        private int rolls = 1;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder probabilityOutput(double probability, ItemStack... probabilityOutputs) {
+            probabilityGroup.add(new ProbabilityGroup(Arrays.asList(probabilityOutputs), probability));
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder probabilityOutput(ItemStack... probabilityOutputs) {
+            return this.probabilityOutput(100, probabilityOutputs);
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder probabilityOutput(double probability, Collection<ItemStack> probabilityOutputs) {
+            probabilityGroup.add(new ProbabilityGroup((List<ItemStack>) probabilityOutputs, probability));
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder probabilityOutput(Collection<ItemStack> probabilityOutputs) {
+            return this.probabilityOutput(100, probabilityOutputs);
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder output(ItemStack... probabilityOutputs) {
+            return this.probabilityOutput(100, probabilityOutputs);
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder output(Collection<ItemStack> probabilityOutputs) {
+            return this.probabilityOutput(100, probabilityOutputs);
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder reversible(boolean reversible) {
+            this.reversible = reversible;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder reversible() {
+            this.reversible = !reversible;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder relativeProbability(boolean relativeProbability) {
+            this.relativeProbability = relativeProbability;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder relativeProbability() {
+            this.relativeProbability = !relativeProbability;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder rolls(int rolls) {
+            this.rolls = rolls;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Alchemistry Dissolver recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 1, 1, 0, 0);
+            validateFluids(msg);
+            validateCustom(msg, probabilityGroup, 1, Integer.MAX_VALUE, "probability group");
+            msg.add(rolls < 1, "rolls must be greater than or equal to 1, yet it was {}", rolls);
+        }
+
+        @Nullable
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public DissolverRecipe register() {
+            if (!validate()) return null;
+
+            DissolverRecipe recipe = new DissolverRecipe(input.get(0).toMcIngredient(), false, new ProbabilitySet(probabilityGroup, relativeProbability, rolls));
+            if (reversible) {
+                ModSupport.ALCHEMISTRY.get().combiner.add(new CombinerRecipe(recipe.getInputs().get(0), probabilityGroup.stream().map(ProbabilityGroup::getOutput).flatMap(Collection::stream).collect(Collectors.toList()), ""));
+            }
+            ModSupport.ALCHEMISTRY.get().dissolver.add(recipe);
+            return recipe;
+        }
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Electrolyzer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Electrolyzer.java
@@ -1,0 +1,180 @@
+package com.cleanroommc.groovyscript.compat.mods.alchemistry;
+
+import al132.alchemistry.recipes.ElectrolyzerRecipe;
+import al132.alchemistry.recipes.ModRecipes;
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
+import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.Ingredient;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.items.ItemHandlerHelper;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+
+@RegistryDescription
+public class Electrolyzer extends VirtualizedRegistry<ElectrolyzerRecipe> {
+
+    @Override
+    public void onReload() {
+        removeScripted().forEach(recipe -> ModRecipes.INSTANCE.getElectrolyzerRecipes().removeIf(r -> r == recipe));
+        ModRecipes.INSTANCE.getElectrolyzerRecipes().addAll(restoreFromBackup());
+    }
+
+    @RecipeBuilderDescription(example = {
+            @Example(".fluidInput(fluid('lava') * 100).output(item('minecraft:clay'))"),
+            @Example(".fluidInput(fluid('water') * 100).input(item('minecraft:gold_ingot')).consumptionChance(100).output(item('minecraft:gold_nugget') * 4).output(item('minecraft:gold_nugget') * 4).output(item('minecraft:gold_nugget') * 4).output(item('minecraft:gold_nugget') * 4).chance(50).chance(50)")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    public ElectrolyzerRecipe add(ElectrolyzerRecipe recipe) {
+        if (recipe != null) {
+            addScripted(recipe);
+            ModRecipes.INSTANCE.getElectrolyzerRecipes().add(recipe);
+        }
+        return recipe;
+    }
+
+    public boolean remove(ElectrolyzerRecipe recipe) {
+        if (ModRecipes.INSTANCE.getElectrolyzerRecipes().removeIf(r -> r == recipe)) {
+            addBackup(recipe);
+            return true;
+        }
+        return false;
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("element('chlorine')"))
+    public boolean removeByOutput(ItemStack output) {
+        return ModRecipes.INSTANCE.getElectrolyzerRecipes().removeIf(r -> {
+            for (ItemStack itemstack : r.getOutputs()) {
+                if (ItemHandlerHelper.canItemStacksStack(itemstack, output)) {
+                    addBackup(r);
+                    return true;
+                }
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example(value = "fluid('water')", commented = true))
+    public boolean removeByInput(FluidStack input) {
+        return ModRecipes.INSTANCE.getElectrolyzerRecipes().removeIf(r -> {
+            if (r.getInput().isFluidEqual(input)) {
+                addBackup(r);
+                return true;
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("element('calcium_carbonate')"))
+    public boolean removeByInput(ItemStack input) {
+        return ModRecipes.INSTANCE.getElectrolyzerRecipes().removeIf(r -> {
+            for (ItemStack itemstack : r.getElectrolytes()) {
+                if (ItemHandlerHelper.canItemStacksStack(itemstack, input)) {
+                    addBackup(r);
+                    return true;
+                }
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeByInput")
+    public boolean removeByInput(IIngredient input) {
+        return removeByInput(IngredientHelper.toItemStack(input));
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    public SimpleObjectStream<ElectrolyzerRecipe> streamRecipes() {
+        return new SimpleObjectStream<>(ModRecipes.INSTANCE.getElectrolyzerRecipes()).setRemover(this::remove);
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    public void removeAll() {
+        ModRecipes.INSTANCE.getElectrolyzerRecipes().forEach(this::addBackup);
+        ModRecipes.INSTANCE.getElectrolyzerRecipes().clear();
+    }
+
+    @Property(property = "input", valid = {@Comp(value = "0", type = Comp.Type.GTE), @Comp(value = "1", type = Comp.Type.LTE)})
+    @Property(property = "output", valid = {@Comp(value = "1", type = Comp.Type.GTE), @Comp(value = "4", type = Comp.Type.LTE)})
+    public static class RecipeBuilder extends AbstractRecipeBuilder<ElectrolyzerRecipe> {
+
+        @Property(valid = {@Comp(value = "0", type = Comp.Type.GTE), @Comp(value = "2", type = Comp.Type.LTE)})
+        private final IntArrayList chance = new IntArrayList();
+        @Property(valid = {@Comp(value = "0", type = Comp.Type.GTE), @Comp(value = "100", type = Comp.Type.LTE)})
+        private int consumptionChance;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder input(IIngredient ingredient, int chance) {
+            this.input.add(ingredient);
+            this.chance.add(chance);
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder chance(int chance) {
+            this.chance.add(chance);
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder chance(int... chances) {
+            for (int chance : chances) {
+                chance(chance);
+            }
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder chance(Collection<Integer> chances) {
+            for (int chance : chances) {
+                chance(chance);
+            }
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder consumptionChance(int consumptionChance) {
+            this.consumptionChance = consumptionChance;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Alchemistry Electrolyzer recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 0, 1, 1, 4);
+            validateFluids(msg, 1, 1, 0, 0);
+            validateCustom(msg, chance, 0, 2, "chance");
+            msg.add(!chance.isEmpty() && chance.size() > (output.size() - 2), "chance only applies to output items after the second, cannot have more chance than output items above 2, had {} chance and {} output", chance.size(), output.size());
+            msg.add(consumptionChance < 0 || consumptionChance > 100, "consumption chance must be between 0 and 100, yet it was {}", consumptionChance);
+        }
+
+        @Nullable
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public ElectrolyzerRecipe register() {
+            if (!validate()) return null;
+            ElectrolyzerRecipe recipe = new ElectrolyzerRecipe(fluidInput.get(0),
+                                                               input.size() >= 1 ? input.get(0).toMcIngredient() : Ingredient.EMPTY, consumptionChance,
+                                                               output.get(0), output.getOrEmpty(1),
+                                                               output.getOrEmpty(2), chance.size() >= 1 ? chance.getInt(0) : 0,
+                                                               output.getOrEmpty(3), chance.size() >= 2 ? chance.getInt(1) : 0);
+            ModSupport.ALCHEMISTRY.get().electrolyzer.add(recipe);
+            return recipe;
+        }
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Electrolyzer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Electrolyzer.java
@@ -7,14 +7,12 @@ import com.cleanroommc.groovyscript.api.IIngredient;
 import com.cleanroommc.groovyscript.api.documentation.annotations.*;
 import com.cleanroommc.groovyscript.compat.mods.ModSupport;
 import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
-import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
 import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.Ingredient;
 import net.minecraftforge.fluids.FluidStack;
-import net.minecraftforge.items.ItemHandlerHelper;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
@@ -53,10 +51,10 @@ public class Electrolyzer extends VirtualizedRegistry<ElectrolyzerRecipe> {
     }
 
     @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("element('chlorine')"))
-    public boolean removeByOutput(ItemStack output) {
+    public boolean removeByOutput(IIngredient output) {
         return ModRecipes.INSTANCE.getElectrolyzerRecipes().removeIf(r -> {
             for (ItemStack itemstack : r.getOutputs()) {
-                if (ItemHandlerHelper.canItemStacksStack(itemstack, output)) {
+                if (output.test(itemstack)) {
                     addBackup(r);
                     return true;
                 }
@@ -77,21 +75,16 @@ public class Electrolyzer extends VirtualizedRegistry<ElectrolyzerRecipe> {
     }
 
     @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("element('calcium_carbonate')"))
-    public boolean removeByInput(ItemStack input) {
+    public boolean removeByInput(IIngredient input) {
         return ModRecipes.INSTANCE.getElectrolyzerRecipes().removeIf(r -> {
             for (ItemStack itemstack : r.getElectrolytes()) {
-                if (ItemHandlerHelper.canItemStacksStack(itemstack, input)) {
+                if (input.test(itemstack)) {
                     addBackup(r);
                     return true;
                 }
             }
             return false;
         });
-    }
-
-    @MethodDescription(description = "groovyscript.wiki.removeByInput")
-    public boolean removeByInput(IIngredient input) {
-        return removeByInput(IngredientHelper.toItemStack(input));
     }
 
     @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Evaporator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Evaporator.java
@@ -9,6 +9,7 @@ import com.cleanroommc.groovyscript.compat.mods.ModSupport;
 import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
 import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 import org.jetbrains.annotations.Nullable;
 
@@ -27,6 +28,11 @@ public class Evaporator extends VirtualizedRegistry<EvaporatorRecipe> {
     })
     public RecipeBuilder recipeBuilder() {
         return new RecipeBuilder();
+    }
+
+    @MethodDescription(type = MethodDescription.Type.ADDITION)
+    public EvaporatorRecipe add(FluidStack input, ItemStack output) {
+        return new RecipeBuilder().fluidInput(input).output(output).register();
     }
 
     public EvaporatorRecipe add(EvaporatorRecipe recipe) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Evaporator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Evaporator.java
@@ -7,12 +7,9 @@ import com.cleanroommc.groovyscript.api.IIngredient;
 import com.cleanroommc.groovyscript.api.documentation.annotations.*;
 import com.cleanroommc.groovyscript.compat.mods.ModSupport;
 import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
-import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
 import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
-import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
-import net.minecraftforge.items.ItemHandlerHelper;
 import org.jetbrains.annotations.Nullable;
 
 @RegistryDescription
@@ -49,9 +46,9 @@ public class Evaporator extends VirtualizedRegistry<EvaporatorRecipe> {
     }
 
     @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('alchemistry:mineral_salt')"))
-    public boolean removeByOutput(ItemStack output) {
+    public boolean removeByOutput(IIngredient output) {
         return ModRecipes.INSTANCE.getEvaporatorRecipes().removeIf(r -> {
-            if (ItemHandlerHelper.canItemStacksStack(r.getOutput(), output)) {
+            if (output.test(r.getOutput())) {
                 addBackup(r);
                 return true;
             }
@@ -68,11 +65,6 @@ public class Evaporator extends VirtualizedRegistry<EvaporatorRecipe> {
             }
             return false;
         });
-    }
-
-    @MethodDescription(description = "groovyscript.wiki.removeByInput")
-    public boolean removeByInput(IIngredient input) {
-        return removeByInput(IngredientHelper.toFluidStack(input));
     }
 
     @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Evaporator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Evaporator.java
@@ -1,0 +1,114 @@
+package com.cleanroommc.groovyscript.compat.mods.alchemistry;
+
+import al132.alchemistry.recipes.EvaporatorRecipe;
+import al132.alchemistry.recipes.ModRecipes;
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
+import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.items.ItemHandlerHelper;
+import org.jetbrains.annotations.Nullable;
+
+@RegistryDescription
+public class Evaporator extends VirtualizedRegistry<EvaporatorRecipe> {
+
+    @Override
+    public void onReload() {
+        removeScripted().forEach(recipe -> ModRecipes.INSTANCE.getEvaporatorRecipes().removeIf(r -> r == recipe));
+        ModRecipes.INSTANCE.getEvaporatorRecipes().addAll(restoreFromBackup());
+    }
+
+    @RecipeBuilderDescription(example = {
+            @Example(".fluidInput(fluid('lava') * 100).output(item('minecraft:redstone') * 8)"),
+            @Example(".fluidInput(fluid('water') * 10).output(item('minecraft:clay'))")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    public EvaporatorRecipe add(EvaporatorRecipe recipe) {
+        if (recipe != null) {
+            addScripted(recipe);
+            ModRecipes.INSTANCE.getEvaporatorRecipes().add(recipe);
+        }
+        return recipe;
+    }
+
+    public boolean remove(EvaporatorRecipe recipe) {
+        if (ModRecipes.INSTANCE.getEvaporatorRecipes().removeIf(r -> r == recipe)) {
+            addBackup(recipe);
+            return true;
+        }
+        return false;
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('alchemistry:mineral_salt')"))
+    public boolean removeByOutput(ItemStack output) {
+        return ModRecipes.INSTANCE.getEvaporatorRecipes().removeIf(r -> {
+            if (ItemHandlerHelper.canItemStacksStack(r.getOutput(), output)) {
+                addBackup(r);
+                return true;
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("fluid('lava')"))
+    public boolean removeByInput(FluidStack input) {
+        return ModRecipes.INSTANCE.getEvaporatorRecipes().removeIf(r -> {
+            if (r.getInput().isFluidEqual(input)) {
+                addBackup(r);
+                return true;
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeByInput")
+    public boolean removeByInput(IIngredient input) {
+        return removeByInput(IngredientHelper.toFluidStack(input));
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    public SimpleObjectStream<EvaporatorRecipe> streamRecipes() {
+        return new SimpleObjectStream<>(ModRecipes.INSTANCE.getEvaporatorRecipes()).setRemover(this::remove);
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    public void removeAll() {
+        ModRecipes.INSTANCE.getEvaporatorRecipes().forEach(this::addBackup);
+        ModRecipes.INSTANCE.getEvaporatorRecipes().clear();
+    }
+
+    @Property(property = "fluidInput", valid = @Comp("1"))
+    @Property(property = "output", valid = @Comp("1"))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<EvaporatorRecipe> {
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Alchemistry Evaporator recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 0, 0, 1, 1);
+            validateFluids(msg, 1, 1, 0, 0);
+        }
+
+        @Nullable
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public EvaporatorRecipe register() {
+            if (!validate()) return null;
+            EvaporatorRecipe recipe = new EvaporatorRecipe(fluidInput.get(0), output.get(0));
+            ModSupport.ALCHEMISTRY.get().evaporator.add(recipe);
+            return recipe;
+        }
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Liquifier.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Liquifier.java
@@ -1,0 +1,114 @@
+package com.cleanroommc.groovyscript.compat.mods.alchemistry;
+
+import al132.alchemistry.recipes.LiquifierRecipe;
+import al132.alchemistry.recipes.ModRecipes;
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
+import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.items.ItemHandlerHelper;
+import org.jetbrains.annotations.Nullable;
+
+@RegistryDescription
+public class Liquifier extends VirtualizedRegistry<LiquifierRecipe> {
+
+    @Override
+    public void onReload() {
+        removeScripted().forEach(recipe -> ModRecipes.INSTANCE.getLiquifierRecipes().removeIf(r -> r == recipe));
+        ModRecipes.INSTANCE.getLiquifierRecipes().addAll(restoreFromBackup());
+    }
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(element('carbon') * 32).fluidOutput(fluid('water') * 1000)"),
+            @Example(".input(item('minecraft:magma')).fluidOutput(fluid('lava') * 750)")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    public LiquifierRecipe add(LiquifierRecipe recipe) {
+        if (recipe != null) {
+            addScripted(recipe);
+            ModRecipes.INSTANCE.getLiquifierRecipes().add(recipe);
+        }
+        return recipe;
+    }
+
+    public boolean remove(LiquifierRecipe recipe) {
+        if (ModRecipes.INSTANCE.getLiquifierRecipes().removeIf(r -> r == recipe)) {
+            addBackup(recipe);
+            return true;
+        }
+        return false;
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example(value = "fluid('water')", commented = true))
+    public boolean removeByOutput(FluidStack output) {
+        return ModRecipes.INSTANCE.getLiquifierRecipes().removeIf(r -> {
+            if (r.getOutput().isFluidEqual(output)) {
+                addBackup(r);
+                return true;
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("element('water')"))
+    public boolean removeByInput(ItemStack input) {
+        return ModRecipes.INSTANCE.getLiquifierRecipes().removeIf(r -> {
+            if (ItemHandlerHelper.canItemStacksStack(r.getInput(), input)) {
+                addBackup(r);
+                return true;
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeByInput")
+    public boolean removeByInput(IIngredient input) {
+        return removeByInput(IngredientHelper.toItemStack(input));
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    public SimpleObjectStream<LiquifierRecipe> streamRecipes() {
+        return new SimpleObjectStream<>(ModRecipes.INSTANCE.getLiquifierRecipes()).setRemover(this::remove);
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    public void removeAll() {
+        ModRecipes.INSTANCE.getLiquifierRecipes().forEach(this::addBackup);
+        ModRecipes.INSTANCE.getLiquifierRecipes().clear();
+    }
+
+    @Property(property = "input", valid = @Comp("1"))
+    @Property(property = "fluidOutput", valid = @Comp("1"))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<LiquifierRecipe> {
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Alchemistry Liquifier recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 1, 1, 0, 0);
+            validateFluids(msg, 0, 0, 1, 1);
+        }
+
+        @Nullable
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public LiquifierRecipe register() {
+            if (!validate()) return null;
+            LiquifierRecipe recipe = new LiquifierRecipe(IngredientHelper.toItemStack(input.get(0)), fluidOutput.get(0));
+            ModSupport.ALCHEMISTRY.get().liquifier.add(recipe);
+            return recipe;
+        }
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Liquifier.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Liquifier.java
@@ -10,9 +10,7 @@ import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
 import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
 import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
-import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
-import net.minecraftforge.items.ItemHandlerHelper;
 import org.jetbrains.annotations.Nullable;
 
 @RegistryDescription
@@ -60,19 +58,14 @@ public class Liquifier extends VirtualizedRegistry<LiquifierRecipe> {
     }
 
     @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("element('water')"))
-    public boolean removeByInput(ItemStack input) {
+    public boolean removeByInput(IIngredient input) {
         return ModRecipes.INSTANCE.getLiquifierRecipes().removeIf(r -> {
-            if (ItemHandlerHelper.canItemStacksStack(r.getInput(), input)) {
+            if (input.test(r.getInput())) {
                 addBackup(r);
                 return true;
             }
             return false;
         });
-    }
-
-    @MethodDescription(description = "groovyscript.wiki.removeByInput")
-    public boolean removeByInput(IIngredient input) {
-        return removeByInput(IngredientHelper.toItemStack(input));
     }
 
     @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Liquifier.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Liquifier.java
@@ -30,6 +30,11 @@ public class Liquifier extends VirtualizedRegistry<LiquifierRecipe> {
         return new RecipeBuilder();
     }
 
+    @MethodDescription(type = MethodDescription.Type.ADDITION)
+    public LiquifierRecipe add(IIngredient input, FluidStack output) {
+        return new RecipeBuilder().input(input).fluidOutput(output).register();
+    }
+
     public LiquifierRecipe add(LiquifierRecipe recipe) {
         if (recipe != null) {
             addScripted(recipe);

--- a/src/main/resources/assets/groovyscript/lang/en_us.lang
+++ b/src/main/resources/assets/groovyscript/lang/en_us.lang
@@ -148,7 +148,7 @@ groovyscript.wiki.advancedmortars.mortar.secondaryOutputChance.value=Sets the ch
 
 # Alchemistry
 groovyscript.wiki.alchemistry.atomizer.title=Atomizer
-groovyscript.wiki.alchemistry.atomizer.description=
+groovyscript.wiki.alchemistry.atomizer.description=Converts a non-element into its component elements.
 groovyscript.wiki.alchemistry.atomizer.reversible.value=Sets if the recipe will also create a Liquifier recipe to invert the process
 
 groovyscript.wiki.alchemistry.combiner.title=Chemical Combiner

--- a/src/main/resources/assets/groovyscript/lang/en_us.lang
+++ b/src/main/resources/assets/groovyscript/lang/en_us.lang
@@ -145,6 +145,35 @@ groovyscript.wiki.advancedmortars.mortar.duration.value=Sets how many interactio
 groovyscript.wiki.advancedmortars.mortar.secondaryOutput.value=Sets the additional output itemstack
 groovyscript.wiki.advancedmortars.mortar.secondaryOutputChance.value=Sets the chance of the additional output itemstack being output
 
+
+# Alchemistry
+groovyscript.wiki.alchemistry.atomizer.title=Atomizer
+groovyscript.wiki.alchemistry.atomizer.description=
+groovyscript.wiki.alchemistry.atomizer.reversible.value=Sets if the recipe will also create a Liquifier recipe to invert the process
+
+groovyscript.wiki.alchemistry.combiner.title=Chemical Combiner
+groovyscript.wiki.alchemistry.combiner.description=Converts up to 9 input itemstacks into an output itemstack.
+groovyscript.wiki.alchemistry.combiner.gamestage.value=Sets the required gamestage to add the recipe
+
+groovyscript.wiki.alchemistry.dissolver.title=Chemical Dissolver
+groovyscript.wiki.alchemistry.dissolver.description=Converts an input itemstack into any number of output itemstacks, divided in any manner between different chances, with the ability to run multiple rolls to produce additional outputs.
+groovyscript.wiki.alchemistry.dissolver.rolls.value=Sets the number of rolls to produce outputs
+groovyscript.wiki.alchemistry.dissolver.reversible.value=Sets if the recipe will also create a Chemical Combiner to invert the process. Only properly works on some recipes
+groovyscript.wiki.alchemistry.dissolver.probabilityGroup.value=Sets the probability sets rolled to produce output
+groovyscript.wiki.alchemistry.dissolver.relativeProbability.value=Sets if there is guaranteed to always be one and exactly one set output, or if each set is rolled individually
+
+groovyscript.wiki.alchemistry.electrolyzer.title=Electrolyzer
+groovyscript.wiki.alchemistry.electrolyzer.description=Converts an input fluidstack into up to 4 output itemstacks, with the 3rd and 4th output itemstacks being able to have chances applied to them. May require a catalyst input itemstack, which may also have a chance to be consumed.
+groovyscript.wiki.alchemistry.electrolyzer.chance.value=Sets the output chance of the 3rd and 4th output itemstacks
+groovyscript.wiki.alchemistry.electrolyzer.consumptionChance.value=Sets the chance the catalyst input itemstack has to be consumed
+
+groovyscript.wiki.alchemistry.evaporator.title=Evaporator
+groovyscript.wiki.alchemistry.evaporator.description=Converts an input fluidstack into an output fluidstack, taking a set amount of time.
+
+groovyscript.wiki.alchemistry.liquifier.title=Liquifier
+groovyscript.wiki.alchemistry.liquifier.description=Converts an input itemstack into an output fluidstack, consuming a set amount of power.
+
+
 # Applied Energistics 2
 groovyscript.wiki.appliedenergistics2.attunement.title=P2P Attunement
 groovyscript.wiki.appliedenergistics2.attunement.description=Controls using specific items, any items from a mod, or any items with a Capability to convert a P2P into a specific tunnel type.

--- a/src/main/resources/assets/groovyscript/lang/en_us.lang
+++ b/src/main/resources/assets/groovyscript/lang/en_us.lang
@@ -149,6 +149,7 @@ groovyscript.wiki.advancedmortars.mortar.secondaryOutputChance.value=Sets the ch
 # Alchemistry
 groovyscript.wiki.alchemistry.atomizer.title=Atomizer
 groovyscript.wiki.alchemistry.atomizer.description=Converts a non-element into its component elements.
+groovyscript.wiki.alchemistry.atomizer.add=Adds recipes in the format `input`, `output`
 groovyscript.wiki.alchemistry.atomizer.reversible.value=Sets if the recipe will also create a Liquifier recipe to invert the process
 
 groovyscript.wiki.alchemistry.combiner.title=Chemical Combiner
@@ -168,9 +169,11 @@ groovyscript.wiki.alchemistry.electrolyzer.chance.value=Sets the output chance o
 groovyscript.wiki.alchemistry.electrolyzer.consumptionChance.value=Sets the chance the catalyst input itemstack has to be consumed
 
 groovyscript.wiki.alchemistry.evaporator.title=Evaporator
+groovyscript.wiki.alchemistry.evaporator.add=Adds recipes in the format `input`, `output`
 groovyscript.wiki.alchemistry.evaporator.description=Converts an input fluidstack into an output fluidstack, taking a set amount of time.
 
 groovyscript.wiki.alchemistry.liquifier.title=Liquifier
+groovyscript.wiki.alchemistry.liquifier.add=Adds recipes in the format `input`, `output`
 groovyscript.wiki.alchemistry.liquifier.description=Converts an input itemstack into an output fluidstack, consuming a set amount of power.
 
 


### PR DESCRIPTION
what this PR adds:
- Adds compat for the `atomizer`, `combiner`, `dissolver`, `electrolyzer`, `evaporator`, `liquifier`.
- i18n wiki keys for the above
- examples file for the above
- `element` game object handler to get the alchemistry element or compound for the given name

something that is not added in this PR:
- crafttweaker, through native compat, adds Create Element and Create Compound helpers. these are not added in this PR. a TODO is added for these helpers.

note: when testing, i suggest also enabling Draconic Evolution for the Creative Power Source (no way to get power otherwise)