### PR TITLE
Better JEI compat

### DIFF
--- a/examples/postInit/jei.groovy
+++ b/examples/postInit/jei.groovy
@@ -2,8 +2,6 @@
 // Auto generated groovyscript example file
 // MODS_LOADED: jei
 
-import com.buuz135.thaumicjei.ThaumcraftJEIPlugin
-import mekanism.client.jei.MekanismJEI
 import mezz.jei.api.ingredients.VanillaTypes
 
 println 'mod \'jei\' detected, running script'
@@ -26,7 +24,7 @@ mods.jei.category.hideCategory('minecraft.fuel')
 // Description Category:
 // Modify the description of the input items, where the description is a unique JEI tab containing text.
 
-mods.jei.description.remove(item('thaumcraft:triple_meat_treat'))
+// mods.jei.description.remove(item('thaumcraft:triple_meat_treat'))
 
 mods.jei.description.add(item('minecraft:clay'), ['wow', 'this', 'is', 'neat'])
 mods.jei.description.add(item('minecraft:gold_ingot'), 'groovyscript.recipe.fluid_recipe')
@@ -37,12 +35,12 @@ mods.jei.description.add(item('minecraft:gold_ingot'), 'groovyscript.recipe.flui
 mods.jei.ingredient.hide(fluid('water'))
 mods.jei.ingredient.hide(item('minecraft:stone:1'), item('minecraft:stone:3'))
 mods.jei.ingredient.hide(VanillaTypes.ITEM, item('minecraft:bed:*'))
-mods.jei.ingredient.hide(MekanismJEI.TYPE_GAS, gas('tritium'))
-mods.jei.ingredient.hideByType(ThaumcraftJEIPlugin.ASPECT_LIST)
+// mods.jei.ingredient.hide(mekanism.client.jei.MekanismJEI.TYPE_GAS, gas('tritium'))
 // mods.jei.ingredient.hideByType(VanillaTypes.ITEM)
 // mods.jei.ingredient.hideByType(VanillaTypes.FLUID)
-// mods.jei.ingredient.hideByType(MekanismJEI.TYPE_GAS)
 // mods.jei.ingredient.hideByType(VanillaTypes.ENCHANT)
+// mods.jei.ingredient.hideByType(mekanism.client.jei.MekanismJEI.TYPE_GAS)
+// mods.jei.ingredient.hideByType(com.buuz135.thaumicjei.ThaumcraftJEIPlugin.ASPECT_LIST)
 // mods.jei.ingredient.hideAll()
 
 mods.jei.ingredient.add(item('minecraft:stone:1').withNbt([display:[Name:'Special Granite']]))

--- a/examples/postInit/jei.groovy
+++ b/examples/postInit/jei.groovy
@@ -1,0 +1,50 @@
+
+// Auto generated groovyscript example file
+// MODS_LOADED: jei
+
+import com.buuz135.thaumicjei.ThaumcraftJEIPlugin
+import mekanism.client.jei.MekanismJEI
+import mezz.jei.api.ingredients.VanillaTypes
+
+println 'mod \'jei\' detected, running script'
+
+// Category Catalysts:
+// Modify the items shown on the left of JEI Categories which indicate where the recipe takes place
+
+mods.jei.catalyst.remove('minecraft.smelting', item('minecraft:furnace'))
+// mods.jei.catalyst.removeByType('minecraft.anvil')
+
+mods.jei.catalyst.add('minecraft.smelting', item('minecraft:clay') * 8, item('minecraft:cobblestone'))
+
+// Categories:
+// Modify the Categories visible in JEI, each of which contain recipes and are associated with specific blocks, typically
+// machines.
+
+mods.jei.category.hideCategory('minecraft.fuel')
+// mods.jei.category.hideAll()
+
+// Description Category:
+// Modify the description of the input items, where the description is a unique JEI tab containing text.
+
+mods.jei.description.remove(item('thaumcraft:triple_meat_treat'))
+
+mods.jei.description.add(item('minecraft:clay'), ['wow', 'this', 'is', 'neat'])
+mods.jei.description.add(item('minecraft:gold_ingot'), 'groovyscript.recipe.fluid_recipe')
+
+// Ingredient Sidebar:
+// Modify what ingredients show up in the search menu sidebar.
+
+mods.jei.ingredient.hide(fluid('water'))
+mods.jei.ingredient.hide(item('minecraft:stone:1'), item('minecraft:stone:3'))
+mods.jei.ingredient.hide(VanillaTypes.ITEM, item('minecraft:bed:*'))
+mods.jei.ingredient.hide(MekanismJEI.TYPE_GAS, gas('tritium'))
+mods.jei.ingredient.hideByType(ThaumcraftJEIPlugin.ASPECT_LIST)
+// mods.jei.ingredient.hideByType(VanillaTypes.ITEM)
+// mods.jei.ingredient.hideByType(VanillaTypes.FLUID)
+// mods.jei.ingredient.hideByType(MekanismJEI.TYPE_GAS)
+// mods.jei.ingredient.hideByType(VanillaTypes.ENCHANT)
+// mods.jei.ingredient.hideAll()
+
+mods.jei.ingredient.add(item('minecraft:stone:1').withNbt([display:[Name:'Special Granite']]))
+mods.jei.ingredient.add(VanillaTypes.ITEM, item('minecraft:bed').withNbt([display:[Name:'Beds come in 16 different colors!']]))
+

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/Catalyst.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/Catalyst.java
@@ -1,0 +1,76 @@
+package com.cleanroommc.groovyscript.compat.mods.jei;
+
+import com.cleanroommc.groovyscript.api.GroovyBlacklist;
+import com.cleanroommc.groovyscript.api.documentation.annotations.Example;
+import com.cleanroommc.groovyscript.api.documentation.annotations.MethodDescription;
+import com.cleanroommc.groovyscript.api.documentation.annotations.RegistryDescription;
+import com.cleanroommc.groovyscript.core.mixin.jei.ModRegistryAccessor;
+import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import mezz.jei.api.IModRegistry;
+import net.minecraft.item.ItemStack;
+import org.apache.commons.lang3.tuple.Pair;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+@RegistryDescription(category = RegistryDescription.Category.ENTRIES)
+public class Catalyst extends VirtualizedRegistry<Pair<String, ItemStack>> {
+
+    /**
+     * Called by {@link JeiPlugin#register}
+     */
+    @GroovyBlacklist
+    public void applyChanges(IModRegistry modRegistry) {
+        for (var backupRecipe : getBackupRecipes()) {
+            ((ModRegistryAccessor) modRegistry).getRecipeCatalysts().get(backupRecipe.getKey())
+                    .removeIf(x -> backupRecipe.getValue() == null ||
+                                   x instanceof ItemStack &&
+                                   ItemStack.areItemStacksEqual((ItemStack) x, backupRecipe.getValue()));
+        }
+        for (var scriptedRecipe : getScriptedRecipes()) {
+            modRegistry.addRecipeCatalyst(scriptedRecipe.getValue(), scriptedRecipe.getKey());
+        }
+    }
+
+    @Override
+    public void onReload() {
+        restoreFromBackup();
+        removeScripted();
+    }
+
+    @MethodDescription(type = MethodDescription.Type.ADDITION)
+    public void add(String category, ItemStack item) {
+        addScripted(Pair.of(category, item));
+    }
+
+    @MethodDescription(type = MethodDescription.Type.ADDITION, example = @Example("'minecraft.smelting', item('minecraft:clay') * 8, item('minecraft:cobblestone')"))
+    public void add(String category, ItemStack... item) {
+        Arrays.stream(item).map(i -> Pair.of(category, i)).forEach(this::addScripted);
+    }
+
+    @MethodDescription(type = MethodDescription.Type.ADDITION)
+    public void add(String category, Collection<ItemStack> item) {
+        item.stream().map(i -> Pair.of(category, i)).forEach(this::addScripted);
+    }
+
+    @MethodDescription(example = @Example("'minecraft.smelting', item('minecraft:furnace')"))
+    public void remove(String category, ItemStack item) {
+        addBackup(Pair.of(category, item));
+    }
+
+    @MethodDescription
+    public void remove(String category, ItemStack... item) {
+        Arrays.stream(item).map(i -> Pair.of(category, i)).forEach(this::addBackup);
+    }
+
+    @MethodDescription
+    public void remove(String category, Collection<ItemStack> item) {
+        item.stream().map(i -> Pair.of(category, i)).forEach(this::addBackup);
+    }
+
+    @MethodDescription(example = @Example(value = "'minecraft.anvil'", commented = true))
+    public void removeByType(String category) {
+        addBackup(Pair.of(category, null));
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/Category.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/Category.java
@@ -1,0 +1,56 @@
+package com.cleanroommc.groovyscript.compat.mods.jei;
+
+import com.cleanroommc.groovyscript.api.GroovyBlacklist;
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.documentation.annotations.Admonition;
+import com.cleanroommc.groovyscript.api.documentation.annotations.Example;
+import com.cleanroommc.groovyscript.api.documentation.annotations.MethodDescription;
+import com.cleanroommc.groovyscript.api.documentation.annotations.RegistryDescription;
+import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import mezz.jei.api.IRecipeRegistry;
+import mezz.jei.api.recipe.IRecipeCategory;
+
+@RegistryDescription(category = RegistryDescription.Category.ENTRIES,
+                     admonition = @Admonition("groovyscript.wiki.jei.category.note0"))
+public class Category extends VirtualizedRegistry<String> {
+
+    private boolean hideAllCategories;
+
+    /**
+     * Called by {@link JeiPlugin#onRuntimeAvailable}
+     */
+    @GroovyBlacklist
+    public void applyChanges(IRecipeRegistry recipeRegistry) {
+        if (hideAllCategories) recipeRegistry.getRecipeCategories().stream().map(IRecipeCategory::getUid).forEach(this::addBackup);
+        getBackupRecipes().forEach(recipeRegistry::hideRecipeCategory);
+    }
+
+    @Override
+    public void onReload() {
+        restoreFromBackup();
+        hideAllCategories = false;
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.jei.category.hideCategory")
+    public void remove(String category) {
+        if (category == null || category.isEmpty()) {
+            GroovyLog.msg("Error hiding category")
+                    .add("category must not be empty")
+                    .error()
+                    .post();
+            return;
+        }
+        addBackup(category);
+    }
+
+    @MethodDescription(example = @Example("'minecraft.fuel'"))
+    public void hideCategory(String category) {
+        remove(category);
+    }
+
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
+    public void hideAll() {
+        hideAllCategories = true;
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/Description.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/Description.java
@@ -84,7 +84,7 @@ public class Description extends VirtualizedRegistry<Pair<List<IIngredient>, Lis
         addScripted(Pair.of(Lists.newArrayList(target), Lists.newArrayList(description)));
     }
 
-    @MethodDescription(example = @Example("item('thaumcraft:triple_meat_treat')"))
+    @MethodDescription(example = @Example(value = "item('thaumcraft:triple_meat_treat')", commented = true))
     public void remove(List<IIngredient> target) {
         addBackup(Pair.of(target, null));
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/Description.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/Description.java
@@ -7,7 +7,6 @@ import com.cleanroommc.groovyscript.api.documentation.annotations.MethodDescript
 import com.cleanroommc.groovyscript.api.documentation.annotations.RegistryDescription;
 import com.cleanroommc.groovyscript.core.mixin.jei.IngredientInfoRecipeAccessor;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
-import com.google.common.collect.Lists;
 import mezz.jei.api.IModRegistry;
 import mezz.jei.api.IRecipeRegistry;
 import mezz.jei.api.ingredients.VanillaTypes;
@@ -16,6 +15,8 @@ import mezz.jei.plugins.jei.info.IngredientInfoRecipeCategory;
 import net.minecraft.item.ItemStack;
 import org.apache.commons.lang3.tuple.Pair;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -71,17 +72,17 @@ public class Description extends VirtualizedRegistry<Pair<List<IIngredient>, Lis
 
     @MethodDescription(type = MethodDescription.Type.ADDITION)
     public void add(List<IIngredient> target, String... description) {
-        addScripted(Pair.of(target, Lists.newArrayList(description)));
+        addScripted(Pair.of(target, Arrays.asList(description)));
     }
 
     @MethodDescription(type = MethodDescription.Type.ADDITION, example = @Example("item('minecraft:clay'), ['wow', 'this', 'is', 'neat']"))
     public void add(IIngredient target, List<String> description) {
-        addScripted(Pair.of(Lists.newArrayList(target), description));
+        addScripted(Pair.of(Collections.singletonList(target), description));
     }
 
     @MethodDescription(type = MethodDescription.Type.ADDITION, example = @Example("item('minecraft:gold_ingot'), 'groovyscript.recipe.fluid_recipe'"))
     public void add(IIngredient target, String... description) {
-        addScripted(Pair.of(Lists.newArrayList(target), Lists.newArrayList(description)));
+        addScripted(Pair.of(Collections.singletonList(target), Arrays.asList(description)));
     }
 
     @MethodDescription(example = @Example(value = "item('thaumcraft:triple_meat_treat')", commented = true))
@@ -91,7 +92,7 @@ public class Description extends VirtualizedRegistry<Pair<List<IIngredient>, Lis
 
     @MethodDescription
     public void remove(IIngredient... target) {
-        addBackup(Pair.of(Lists.newArrayList(target), null));
+        addBackup(Pair.of(Arrays.asList(target), null));
     }
 
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/Description.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/Description.java
@@ -1,0 +1,97 @@
+package com.cleanroommc.groovyscript.compat.mods.jei;
+
+import com.cleanroommc.groovyscript.api.GroovyBlacklist;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.Example;
+import com.cleanroommc.groovyscript.api.documentation.annotations.MethodDescription;
+import com.cleanroommc.groovyscript.api.documentation.annotations.RegistryDescription;
+import com.cleanroommc.groovyscript.core.mixin.jei.IngredientInfoRecipeAccessor;
+import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import com.google.common.collect.Lists;
+import mezz.jei.api.IModRegistry;
+import mezz.jei.api.IRecipeRegistry;
+import mezz.jei.api.ingredients.VanillaTypes;
+import mezz.jei.api.recipe.VanillaRecipeCategoryUid;
+import mezz.jei.plugins.jei.info.IngredientInfoRecipeCategory;
+import net.minecraft.item.ItemStack;
+import org.apache.commons.lang3.tuple.Pair;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@RegistryDescription(category = RegistryDescription.Category.ENTRIES)
+public class Description extends VirtualizedRegistry<Pair<List<IIngredient>, List<String>>> {
+
+    /**
+     * Called by {@link JeiPlugin#register}
+     */
+    @GroovyBlacklist
+    public void applyAdditions(IModRegistry modRegistry) {
+        for (Pair<List<IIngredient>, List<String>> entry : this.getScriptedRecipes()) {
+            modRegistry.addIngredientInfo(entry.getLeft().stream().flatMap(x -> Stream.of(x.getMatchingStacks())).collect(Collectors.toList()),
+                                          // Currently, it is only possible to add VanillaTypes.ITEM. It may be desirable to add the ability to do other types.
+                                          VanillaTypes.ITEM,
+                                          entry.getRight().toArray(new String[0]));
+        }
+    }
+
+    /**
+     * Called by {@link JeiPlugin#onRuntimeAvailable}
+     */
+    @GroovyBlacklist
+    public void applyRemovals(IRecipeRegistry recipeRegistry) {
+        IngredientInfoRecipeCategory category = (IngredientInfoRecipeCategory) recipeRegistry.getRecipeCategory(VanillaRecipeCategoryUid.INFORMATION);
+        if (category != null) {
+            recipeRegistry.getRecipeWrappers(category).forEach(wrapper -> {
+                IngredientInfoRecipeAccessor<?> accessor = (IngredientInfoRecipeAccessor<?>) wrapper;
+
+                // Currently, it is only possible to remove VanillaTypes.ITEM. It may be desirable to add the ability to do other types.
+                if (!VanillaTypes.ITEM.equals(accessor.getIngredientType())) return;
+
+                for (Pair<List<IIngredient>, List<String>> entry : this.getBackupRecipes()) {
+                    if (entry.getKey().stream().anyMatch(x -> accessor.getIngredients().stream().anyMatch(a -> a instanceof ItemStack && x.test((ItemStack) a)))) {
+                        recipeRegistry.hideRecipe(wrapper, VanillaRecipeCategoryUid.INFORMATION);
+                    }
+                }
+            });
+        }
+    }
+
+    @Override
+    public void onReload() {
+        restoreFromBackup();
+        removeScripted();
+    }
+
+    @MethodDescription(type = MethodDescription.Type.ADDITION)
+    public void add(List<IIngredient> target, List<String> description) {
+        addScripted(Pair.of(target, description));
+    }
+
+    @MethodDescription(type = MethodDescription.Type.ADDITION)
+    public void add(List<IIngredient> target, String... description) {
+        addScripted(Pair.of(target, Lists.newArrayList(description)));
+    }
+
+    @MethodDescription(type = MethodDescription.Type.ADDITION, example = @Example("item('minecraft:clay'), ['wow', 'this', 'is', 'neat']"))
+    public void add(IIngredient target, List<String> description) {
+        addScripted(Pair.of(Lists.newArrayList(target), description));
+    }
+
+    @MethodDescription(type = MethodDescription.Type.ADDITION, example = @Example("item('minecraft:gold_ingot'), 'groovyscript.recipe.fluid_recipe'"))
+    public void add(IIngredient target, String... description) {
+        addScripted(Pair.of(Lists.newArrayList(target), Lists.newArrayList(description)));
+    }
+
+    @MethodDescription(example = @Example("item('thaumcraft:triple_meat_treat')"))
+    public void remove(List<IIngredient> target) {
+        addBackup(Pair.of(target, null));
+    }
+
+    @MethodDescription
+    public void remove(IIngredient... target) {
+        addBackup(Pair.of(Lists.newArrayList(target), null));
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/Ingredient.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/Ingredient.java
@@ -114,7 +114,7 @@ public class Ingredient extends VirtualizedRegistry<Void> {
         hiddenIngredients.computeIfAbsent(type, k -> new ArrayList<>()).addAll(entries);
     }
 
-    @MethodDescription(example = @Example(value = "MekanismJEI.TYPE_GAS, gas('tritium')", imports = "mekanism.client.jei.MekanismJEI"))
+    @MethodDescription(example = @Example(value = "mekanism.client.jei.MekanismJEI.TYPE_GAS, gas('tritium')", commented = true))
     public void hide(IIngredientType<?> type, Object... entries) {
         hide(type, Arrays.asList(entries));
     }
@@ -158,8 +158,8 @@ public class Ingredient extends VirtualizedRegistry<Void> {
     }
 
     @MethodDescription(example = {
-            @Example(value = "ThaumcraftJEIPlugin.ASPECT_LIST", imports = "com.buuz135.thaumicjei.ThaumcraftJEIPlugin"),
-            @Example(value = "MekanismJEI.TYPE_GAS", imports = "mekanism.client.jei.MekanismJEI", commented = true),
+            @Example(value = "com.buuz135.thaumicjei.ThaumcraftJEIPlugin.ASPECT_LIST", commented = true),
+            @Example(value = "mekanism.client.jei.MekanismJEI.TYPE_GAS", commented = true),
             @Example(value = "VanillaTypes.ITEM", imports = "mezz.jei.api.ingredients.VanillaTypes", commented = true),
             @Example(value = "VanillaTypes.ENCHANT", imports = "mezz.jei.api.ingredients.VanillaTypes", commented = true),
             @Example(value = "VanillaTypes.FLUID", imports = "mezz.jei.api.ingredients.VanillaTypes", commented = true),

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/Ingredient.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/Ingredient.java
@@ -8,6 +8,7 @@ import com.cleanroommc.groovyscript.api.documentation.annotations.Example;
 import com.cleanroommc.groovyscript.api.documentation.annotations.MethodDescription;
 import com.cleanroommc.groovyscript.api.documentation.annotations.RegistryDescription;
 import com.cleanroommc.groovyscript.compat.vanilla.VanillaModule;
+import com.cleanroommc.groovyscript.helper.Alias;
 import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
 import com.cleanroommc.groovyscript.registry.ReloadableRegistryManager;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
@@ -28,6 +29,10 @@ public class Ingredient extends VirtualizedRegistry<Void> {
     private final Map<IIngredientType<?>, List<Object>> addedIngredients = new Object2ObjectOpenHashMap<>();
     private final List<IIngredientType<?>> hiddenTypes = new ArrayList<>();
     private boolean hideAllIngredients;
+
+    public Ingredient() {
+        super(Alias.generateOfClass(Ingredient.class).andGenerate("Sidebar"));
+    }
 
     /**
      * Called by {@link JeiPlugin#onRuntimeAvailable}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/Ingredient.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/Ingredient.java
@@ -1,0 +1,252 @@
+package com.cleanroommc.groovyscript.compat.mods.jei;
+
+import com.cleanroommc.groovyscript.api.GroovyBlacklist;
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.Admonition;
+import com.cleanroommc.groovyscript.api.documentation.annotations.Example;
+import com.cleanroommc.groovyscript.api.documentation.annotations.MethodDescription;
+import com.cleanroommc.groovyscript.api.documentation.annotations.RegistryDescription;
+import com.cleanroommc.groovyscript.compat.vanilla.VanillaModule;
+import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
+import com.cleanroommc.groovyscript.registry.ReloadableRegistryManager;
+import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import mezz.jei.api.ingredients.IIngredientRegistry;
+import mezz.jei.api.ingredients.VanillaTypes;
+import mezz.jei.api.recipe.IIngredientType;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraftforge.fml.common.registry.ForgeRegistries;
+
+import java.util.*;
+
+@RegistryDescription(category = RegistryDescription.Category.ENTRIES,
+                     admonition = @Admonition("groovyscript.wiki.jei.ingredient.note0"))
+public class Ingredient extends VirtualizedRegistry<Void> {
+
+    private final Map<IIngredientType<?>, List<Object>> hiddenIngredients = new Object2ObjectOpenHashMap<>();
+    private final Map<IIngredientType<?>, List<Object>> addedIngredients = new Object2ObjectOpenHashMap<>();
+    private final List<IIngredientType<?>> hiddenTypes = new ArrayList<>();
+    private boolean hideAllIngredients;
+
+    /**
+     * Called by {@link JeiPlugin#onRuntimeAvailable}
+     */
+    @GroovyBlacklist
+    public void applyChanges(IIngredientRegistry ingredientRegistry) {
+        if (hideAllIngredients) {
+            ingredientRegistry.getRegisteredIngredientTypes().forEach(hiddenTypes::add);
+        }
+        for (var type : hiddenTypes) {
+            hiddenIngredients.computeIfAbsent(type, k -> new ArrayList<>()).addAll(ingredientRegistry.getAllIngredients(type));
+        }
+        for (var entry : hiddenIngredients.entrySet()) {
+            if (entry.getValue().isEmpty()) continue;
+            //noinspection unchecked,rawtypes
+            ingredientRegistry.removeIngredientsAtRuntime(entry.getKey(), ingredientRegistry.getIngredientHelper(entry.getKey()).expandSubtypes((List) entry.getValue()));
+        }
+
+        for (var entry : addedIngredients.entrySet()) {
+            //noinspection unchecked,rawtypes
+            ingredientRegistry.addIngredientsAtRuntime(entry.getKey(), ingredientRegistry.getIngredientHelper(entry.getKey()).expandSubtypes((List) entry.getValue()));
+        }
+
+    }
+
+    @Override
+    public void onReload() {
+        addedIngredients.clear();
+        hiddenIngredients.clear();
+        hiddenTypes.clear();
+        hideAllIngredients = false;
+    }
+
+    @MethodDescription(
+            type = MethodDescription.Type.ADDITION,
+            example = @Example(value = "VanillaTypes.ITEM, item('minecraft:bed').withNbt([display:[Name:'Beds come in 16 different colors!']])", imports = "mezz.jei.api.ingredients.VanillaTypes")
+    )
+    public void add(IIngredientType<?> type, Collection<Object> entries) {
+        addedIngredients.computeIfAbsent(type, k -> new ArrayList<>()).addAll(entries);
+    }
+
+    @MethodDescription(type = MethodDescription.Type.ADDITION)
+    public void add(IIngredientType<?> type, Object... entries) {
+        add(type, Arrays.asList(entries));
+    }
+
+    @MethodDescription(type = MethodDescription.Type.ADDITION, example = @Example("item('minecraft:stone:1').withNbt([display:[Name:'Special Granite']])"))
+    public void add(IIngredient ingredient) {
+        if (IngredientHelper.isEmpty(ingredient)) {
+            GroovyLog.msg("Error adding items {}", ingredient)
+                    .add("Items must not be empty")
+                    .error()
+                    .post();
+            return;
+        }
+        if (IngredientHelper.isItem(ingredient)) {
+            addedIngredients.computeIfAbsent(VanillaTypes.ITEM, k -> new ArrayList<>()).addAll(Arrays.asList(ingredient.getMatchingStacks()));
+        } else if (IngredientHelper.isFluid(ingredient)) {
+            addedIngredients.computeIfAbsent(VanillaTypes.FLUID, k -> new ArrayList<>()).add(IngredientHelper.toFluidStack(ingredient));
+        } else {
+            GroovyLog.msg("Error adding items {}", ingredient)
+                    .add("Could not identify the type")
+                    .error()
+                    .post();
+        }
+    }
+
+    @MethodDescription(type = MethodDescription.Type.ADDITION)
+    public void add(IIngredient... ingredients) {
+        for (IIngredient ingredient : ingredients) {
+            add(ingredient);
+        }
+    }
+
+    @MethodDescription(type = MethodDescription.Type.ADDITION)
+    public void add(Iterable<IIngredient> ingredients) {
+        for (IIngredient ingredient : ingredients) {
+            add(ingredient);
+        }
+    }
+
+    @MethodDescription(example = @Example(value = "VanillaTypes.ITEM, item('minecraft:bed:*')", imports = "mezz.jei.api.ingredients.VanillaTypes"))
+    public void hide(IIngredientType<?> type, Collection<Object> entries) {
+        hiddenIngredients.computeIfAbsent(type, k -> new ArrayList<>()).addAll(entries);
+    }
+
+    @MethodDescription(example = @Example(value = "MekanismJEI.TYPE_GAS, gas('tritium')", imports = "mekanism.client.jei.MekanismJEI"))
+    public void hide(IIngredientType<?> type, Object... entries) {
+        hide(type, Arrays.asList(entries));
+    }
+
+    @MethodDescription(example = {
+            @Example("fluid('water')"),
+            @Example("item('minecraft:stone:1'), item('minecraft:stone:3')")
+    })
+    public void hide(IIngredient ingredient) {
+        if (IngredientHelper.isEmpty(ingredient)) {
+            GroovyLog.msg("Error hiding items {}", ingredient)
+                    .add("Items must not be empty")
+                    .error()
+                    .post();
+            return;
+        }
+        if (IngredientHelper.isItem(ingredient)) {
+            hiddenIngredients.computeIfAbsent(VanillaTypes.ITEM, k -> new ArrayList<>()).addAll(Arrays.asList(ingredient.getMatchingStacks()));
+        } else if (IngredientHelper.isFluid(ingredient)) {
+            hiddenIngredients.computeIfAbsent(VanillaTypes.FLUID, k -> new ArrayList<>()).add(IngredientHelper.toFluidStack(ingredient));
+        } else {
+            GroovyLog.msg("Error hiding items {}", ingredient)
+                    .add("Could not identify the type")
+                    .error()
+                    .post();
+        }
+    }
+
+    @MethodDescription
+    public void hide(IIngredient... ingredients) {
+        for (IIngredient ingredient : ingredients) {
+            hide(ingredient);
+        }
+    }
+
+    @MethodDescription
+    public void hide(Iterable<IIngredient> ingredients) {
+        for (IIngredient ingredient : ingredients) {
+            hide(ingredient);
+        }
+    }
+
+    @MethodDescription(example = {
+            @Example(value = "ThaumcraftJEIPlugin.ASPECT_LIST", imports = "com.buuz135.thaumicjei.ThaumcraftJEIPlugin"),
+            @Example(value = "MekanismJEI.TYPE_GAS", imports = "mekanism.client.jei.MekanismJEI", commented = true),
+            @Example(value = "VanillaTypes.ITEM", imports = "mezz.jei.api.ingredients.VanillaTypes", commented = true),
+            @Example(value = "VanillaTypes.ENCHANT", imports = "mezz.jei.api.ingredients.VanillaTypes", commented = true),
+            @Example(value = "VanillaTypes.FLUID", imports = "mezz.jei.api.ingredients.VanillaTypes", commented = true),
+    })
+    public void hideByType(IIngredientType<?> type) {
+        hiddenTypes.add(type);
+    }
+
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
+    public void hideAll() {
+        hideAllIngredients = true;
+    }
+
+    @MethodDescription
+    public void removeAndHide(IIngredient ingredient) {
+        if (IngredientHelper.isEmpty(ingredient)) {
+            GroovyLog.msg("Error remove and hide items {}", ingredient)
+                    .add("Items must not be empty")
+                    .error()
+                    .post();
+            return;
+        }
+        hide(ingredient);
+        VanillaModule.crafting.removeByOutput(ingredient, false);
+    }
+
+    @MethodDescription
+    public void removeAndHide(IIngredient... ingredients) {
+        for (IIngredient ingredient : ingredients) {
+            if (IngredientHelper.isEmpty(ingredient)) {
+                GroovyLog.msg("Error remove and hide items {}", ingredient)
+                        .add("Items must not be empty")
+                        .error()
+                        .post();
+                return;
+            }
+            hide(ingredient);
+        }
+        for (IRecipe recipe : ForgeRegistries.RECIPES) {
+            if (recipe.getRegistryName() != null) {
+                for (IIngredient ingredient : ingredients) {
+                    if (ingredient.test(recipe.getRecipeOutput())) {
+                        ReloadableRegistryManager.removeRegistryEntry(ForgeRegistries.RECIPES, recipe.getRegistryName());
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    @MethodDescription
+    public void removeAndHide(Iterable<IIngredient> ingredients) {
+        for (IIngredient ingredient : ingredients) {
+            if (IngredientHelper.isEmpty(ingredient)) {
+                GroovyLog.msg("Error remove and hide items {}", ingredient)
+                        .add("Items must not be empty")
+                        .error()
+                        .post();
+                return;
+            }
+            hide(ingredient);
+        }
+        for (IRecipe recipe : ForgeRegistries.RECIPES) {
+            if (recipe.getRegistryName() != null) {
+                for (IIngredient ingredient : ingredients) {
+                    if (ingredient.test(recipe.getRecipeOutput())) {
+                        ReloadableRegistryManager.removeRegistryEntry(ForgeRegistries.RECIPES, recipe.getRegistryName());
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    @MethodDescription
+    public void yeet(IIngredient ingredient) {
+        removeAndHide(ingredient);
+    }
+
+    @MethodDescription
+    public void yeet(IIngredient... ingredients) {
+        removeAndHide(ingredients);
+    }
+
+    @MethodDescription
+    public void yeet(Iterable<IIngredient> ingredients) {
+        removeAndHide(ingredients);
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/JeiPlugin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/JeiPlugin.java
@@ -97,6 +97,7 @@ public class JeiPlugin implements IModPlugin {
         jeiRuntime = iJeiRuntime;
 
         ModSupport.JEI.get().ingredient.applyChanges(itemRegistry);
+        ModSupport.JEI.get().category.applyChanges(recipeRegistry);
     }
 
     public static SimpleCommand getJeiCategoriesCommand() {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/JeiPlugin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/JeiPlugin.java
@@ -9,6 +9,7 @@ import com.cleanroommc.groovyscript.compat.inworldcrafting.jei.BurningRecipeCate
 import com.cleanroommc.groovyscript.compat.inworldcrafting.jei.ExplosionRecipeCategory;
 import com.cleanroommc.groovyscript.compat.inworldcrafting.jei.FluidRecipeCategory;
 import com.cleanroommc.groovyscript.compat.inworldcrafting.jei.PistonPushRecipeCategory;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
 import com.cleanroommc.groovyscript.compat.vanilla.ShapedCraftingRecipe;
 import com.cleanroommc.groovyscript.compat.vanilla.ShapelessCraftingRecipe;
 import com.cleanroommc.groovyscript.compat.vanilla.VanillaModule;
@@ -18,9 +19,7 @@ import mezz.jei.api.ingredients.IIngredientHelper;
 import mezz.jei.api.ingredients.IIngredientRegistry;
 import mezz.jei.api.ingredients.IIngredientRenderer;
 import mezz.jei.api.ingredients.VanillaTypes;
-import mezz.jei.api.recipe.IRecipeCategory;
-import mezz.jei.api.recipe.IRecipeCategoryRegistration;
-import mezz.jei.api.recipe.VanillaRecipeCategoryUid;
+import mezz.jei.api.recipe.*;
 import mezz.jei.ingredients.IngredientRegistry;
 import mezz.jei.plugins.vanilla.crafting.ShapelessRecipeWrapper;
 import net.minecraft.init.Blocks;
@@ -30,9 +29,10 @@ import net.minecraft.util.text.TextComponentString;
 import net.minecraftforge.fluids.FluidStack;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
+
+@SuppressWarnings("AssignmentToStaticFieldFromInstanceMethod")
 @GroovyBlacklist
 @JEIPlugin
 public class JeiPlugin implements IModPlugin {
@@ -46,21 +46,9 @@ public class JeiPlugin implements IModPlugin {
 
     public static IIngredientRenderer<FluidStack> fluidRenderer;
 
-    public static final List<ItemStack> HIDDEN = new ArrayList<>();
-    public static final List<FluidStack> HIDDEN_FLUIDS = new ArrayList<>();
-    public static final List<String> HIDDEN_CATEGORY = new ArrayList<>();
 
     public static boolean isLoaded() {
         return jeiRuntime != null;
-    }
-
-    public static void reload() {
-        HIDDEN.clear();
-        HIDDEN_CATEGORY.clear();
-    }
-
-    public static void hideItem(ItemStack... stack) {
-        Collections.addAll(HIDDEN, stack);
     }
 
     @Override
@@ -108,15 +96,7 @@ public class JeiPlugin implements IModPlugin {
         recipeRegistry = iJeiRuntime.getRecipeRegistry();
         jeiRuntime = iJeiRuntime;
 
-        if (!HIDDEN.isEmpty()) {
-            itemRegistry.removeIngredientsAtRuntime(VanillaTypes.ITEM, ingredientHelper.expandSubtypes(HIDDEN));
-        }
-        if (!HIDDEN_FLUIDS.isEmpty()) {
-            itemRegistry.removeIngredientsAtRuntime(VanillaTypes.FLUID, HIDDEN_FLUIDS);
-        }
-        for (String category : HIDDEN_CATEGORY) {
-            recipeRegistry.hideRecipeCategory(category);
-        }
+        ModSupport.JEI.get().ingredient.applyChanges(itemRegistry);
     }
 
     public static SimpleCommand getJeiCategoriesCommand() {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/JeiPlugin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/JeiPlugin.java
@@ -91,6 +91,7 @@ public class JeiPlugin implements IModPlugin {
         registry.addRecipes(VanillaModule.inWorldCrafting.pistonPush.getRecipeWrappers(), PistonPushRecipeCategory.UID);
 
         ModSupport.JEI.get().description.applyAdditions(modRegistry);
+        ModSupport.JEI.get().catalyst.applyChanges(registry);
     }
 
     @Override

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/JeiPlugin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/JeiPlugin.java
@@ -89,6 +89,8 @@ public class JeiPlugin implements IModPlugin {
         registry.addRecipes(VanillaModule.inWorldCrafting.explosion.getRecipeWrappers(), ExplosionRecipeCategory.UID);
         registry.addRecipes(VanillaModule.inWorldCrafting.burning.getRecipeWrappers(), BurningRecipeCategory.UID);
         registry.addRecipes(VanillaModule.inWorldCrafting.pistonPush.getRecipeWrappers(), PistonPushRecipeCategory.UID);
+
+        ModSupport.JEI.get().description.applyAdditions(modRegistry);
     }
 
     @Override
@@ -98,6 +100,7 @@ public class JeiPlugin implements IModPlugin {
 
         ModSupport.JEI.get().ingredient.applyChanges(itemRegistry);
         ModSupport.JEI.get().category.applyChanges(recipeRegistry);
+        ModSupport.JEI.get().description.applyRemovals(recipeRegistry);
     }
 
     public static SimpleCommand getJeiCategoriesCommand() {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/JustEnoughItems.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/JustEnoughItems.java
@@ -5,9 +5,11 @@ import com.cleanroommc.groovyscript.compat.mods.ModPropertyContainer;
 public class JustEnoughItems extends ModPropertyContainer {
 
     public final Ingredient ingredient = new Ingredient();
+    public final Category category = new Category();
 
     public JustEnoughItems() {
         addRegistry(ingredient);
+        addRegistry(category);
     }
 
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/JustEnoughItems.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/JustEnoughItems.java
@@ -7,11 +7,13 @@ public class JustEnoughItems extends ModPropertyContainer {
     public final Ingredient ingredient = new Ingredient();
     public final Category category = new Category();
     public final Description description = new Description();
+    public final Catalyst catalyst = new Catalyst();
 
     public JustEnoughItems() {
         addRegistry(ingredient);
         addRegistry(category);
         addRegistry(description);
+        addRegistry(catalyst);
     }
 
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/JustEnoughItems.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/JustEnoughItems.java
@@ -6,10 +6,12 @@ public class JustEnoughItems extends ModPropertyContainer {
 
     public final Ingredient ingredient = new Ingredient();
     public final Category category = new Category();
+    public final Description description = new Description();
 
     public JustEnoughItems() {
         addRegistry(ingredient);
         addRegistry(category);
+        addRegistry(description);
     }
 
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/JustEnoughItems.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/JustEnoughItems.java
@@ -1,121 +1,13 @@
 package com.cleanroommc.groovyscript.compat.mods.jei;
 
-import com.cleanroommc.groovyscript.api.GroovyLog;
-import com.cleanroommc.groovyscript.api.IIngredient;
 import com.cleanroommc.groovyscript.compat.mods.ModPropertyContainer;
-import com.cleanroommc.groovyscript.compat.vanilla.VanillaModule;
-import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
-import com.cleanroommc.groovyscript.registry.ReloadableRegistryManager;
-import net.minecraft.item.crafting.IRecipe;
-import net.minecraftforge.fml.common.registry.ForgeRegistries;
 
 public class JustEnoughItems extends ModPropertyContainer {
 
-    public void hide(IIngredient ingredient) {
-        if (IngredientHelper.isEmpty(ingredient)) {
-            GroovyLog.msg("Error hiding items {}", ingredient)
-                    .add("Items must not be empty")
-                    .error()
-                    .post();
-            return;
-        }
-        if (IngredientHelper.isFluid(ingredient)) {
-            JeiPlugin.HIDDEN_FLUIDS.add(IngredientHelper.toFluidStack(ingredient));
-        } else {
-            JeiPlugin.hideItem(ingredient.getMatchingStacks());
-        }
+    public final Ingredient ingredient = new Ingredient();
+
+    public JustEnoughItems() {
+        addRegistry(ingredient);
     }
 
-    public void hide(IIngredient... ingredients) {
-        for (IIngredient ingredient : ingredients) {
-            hide(ingredient);
-        }
-    }
-
-    public void hide(Iterable<IIngredient> ingredients) {
-        for (IIngredient ingredient : ingredients) {
-            hide(ingredient);
-        }
-    }
-
-    public void removeAndHide(IIngredient ingredient) {
-        if (IngredientHelper.isEmpty(ingredient)) {
-            GroovyLog.msg("Error remove and hide items {}", ingredient)
-                    .add("Items must not be empty")
-                    .error()
-                    .post();
-            return;
-        }
-        VanillaModule.crafting.removeByOutput(ingredient, false);
-        JeiPlugin.hideItem(ingredient.getMatchingStacks());
-    }
-
-    public void removeAndHide(IIngredient... ingredients) {
-        for (IIngredient ingredient : ingredients) {
-            if (IngredientHelper.isEmpty(ingredient)) {
-                GroovyLog.msg("Error remove and hide items {}", ingredient)
-                        .add("Items must not be empty")
-                        .error()
-                        .post();
-                return;
-            }
-            JeiPlugin.hideItem(ingredient.getMatchingStacks());
-        }
-        for (IRecipe recipe : ForgeRegistries.RECIPES) {
-            if (recipe.getRegistryName() != null) {
-                for (IIngredient ingredient : ingredients) {
-                    if (ingredient.test(recipe.getRecipeOutput())) {
-                        ReloadableRegistryManager.removeRegistryEntry(ForgeRegistries.RECIPES, recipe.getRegistryName());
-                        break;
-                    }
-                }
-            }
-        }
-    }
-
-    public void removeAndHide(Iterable<IIngredient> ingredients) {
-        for (IIngredient ingredient : ingredients) {
-            if (IngredientHelper.isEmpty(ingredient)) {
-                GroovyLog.msg("Error remove and hide items {}", ingredient)
-                        .add("Items must not be empty")
-                        .error()
-                        .post();
-                return;
-            }
-            JeiPlugin.hideItem(ingredient.getMatchingStacks());
-        }
-        for (IRecipe recipe : ForgeRegistries.RECIPES) {
-            if (recipe.getRegistryName() != null) {
-                for (IIngredient ingredient : ingredients) {
-                    if (ingredient.test(recipe.getRecipeOutput())) {
-                        ReloadableRegistryManager.removeRegistryEntry(ForgeRegistries.RECIPES, recipe.getRegistryName());
-                        break;
-                    }
-                }
-            }
-        }
-    }
-
-    public void yeet(IIngredient ingredient) {
-        removeAndHide(ingredient);
-    }
-
-    public void yeet(IIngredient... ingredients) {
-        removeAndHide(ingredients);
-    }
-
-    public void yeet(Iterable<IIngredient> ingredients) {
-        removeAndHide(ingredients);
-    }
-
-    public void hideCategory(String category) {
-        if (category == null || category.isEmpty()) {
-            GroovyLog.msg("Error hiding category")
-                    .add("category must not be empty")
-                    .error()
-                    .post();
-            return;
-        }
-        JeiPlugin.HIDDEN_CATEGORY.add(category);
-    }
 }

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/jei/IngredientInfoRecipeAccessor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/jei/IngredientInfoRecipeAccessor.java
@@ -1,0 +1,19 @@
+package com.cleanroommc.groovyscript.core.mixin.jei;
+
+import mezz.jei.api.recipe.IIngredientType;
+import mezz.jei.plugins.jei.info.IngredientInfoRecipe;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import java.util.List;
+
+@Mixin(value = IngredientInfoRecipe.class, remap = false)
+public interface IngredientInfoRecipeAccessor<T> {
+
+    @Accessor
+    List<T> getIngredients();
+
+    @Accessor
+    IIngredientType<T> getIngredientType();
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/jei/ModRegistryAccessor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/jei/ModRegistryAccessor.java
@@ -1,0 +1,14 @@
+package com.cleanroommc.groovyscript.core.mixin.jei;
+
+import mezz.jei.collect.ListMultiMap;
+import mezz.jei.startup.ModRegistry;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(value = ModRegistry.class, remap = false)
+public interface ModRegistryAccessor {
+
+    @Accessor
+    ListMultiMap<String, Object> getRecipeCatalysts();
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/registry/ReloadableRegistryManager.java
+++ b/src/main/java/com/cleanroommc/groovyscript/registry/ReloadableRegistryManager.java
@@ -84,9 +84,6 @@ public class ReloadableRegistryManager {
                 .flatMap(Collection::stream)
                 .filter(IScriptReloadable::isEnabled)
                 .forEach(IScriptReloadable::onReload);
-        if (ModSupport.JEI.isLoaded()) {
-            JeiPlugin.reload();
-        }
     }
 
     @ApiStatus.Internal

--- a/src/main/resources/assets/groovyscript/lang/en_us.lang
+++ b/src/main/resources/assets/groovyscript/lang/en_us.lang
@@ -795,6 +795,35 @@ groovyscript.wiki.integrateddynamics.squeezer.output.value=Sets the possible ite
 groovyscript.wiki.integrateddynamics.squeezer.duration.value=Sets the time in ticks the recipe takes to process in the Mechanical Squeezer, has no effect on the Squeezer
 groovyscript.wiki.integrateddynamics.squeezer.mechanical.value=Sets if the recipe is added to the mechanical (Mechanical Squeezer) machine
 
+# Just Enough Items
+groovyscript.wiki.jei.catalyst.title=Category Catalysts
+groovyscript.wiki.jei.catalyst.description=Modify the items shown on the left of JEI Categories which indicate where the recipe takes place
+groovyscript.wiki.jei.catalyst.add=Adds the given catalyst items to the given category
+groovyscript.wiki.jei.catalyst.remove=Removes the given catalyst items from the given category
+groovyscript.wiki.jei.catalyst.removeByType=Removes all catalyst items from the given category
+
+groovyscript.wiki.jei.category.title=Categories
+groovyscript.wiki.jei.category.description=Modify the Categories visible in JEI, each of which contain recipes and are associated with specific blocks, typically machines.
+groovyscript.wiki.jei.category.note0=Hidden Categories will still take up load time, and recipes contained within can still be processed. This only prevents seeing Categories.
+groovyscript.wiki.jei.category.hideCategory=Hides the given category from JEI
+groovyscript.wiki.jei.category.hideAll=Hides all categories from JEI
+
+groovyscript.wiki.jei.description.title=Description Category
+groovyscript.wiki.jei.description.description=Modify the description of the input items, where the description is a unique JEI tab containing text.
+groovyscript.wiki.jei.description.add=Adds the given description to the given ingredients, translating the description lines as needed
+groovyscript.wiki.jei.description.remove=Removes any description from the given ingredients
+
+groovyscript.wiki.jei.ingredient.title=Ingredient Sidebar
+groovyscript.wiki.jei.ingredient.description=Modify what ingredients show up in the search menu sidebar.
+groovyscript.wiki.jei.ingredient.note0=Hidden ingredients will still take up load time, and recipes to create them can still be done. This only prevents seeing the ingredients in JEI.
+groovyscript.wiki.jei.ingredient.add=Adds the given ingredient with its given NBT data to JEI
+groovyscript.wiki.jei.ingredient.hide=Hides the ingredient from JEI
+groovyscript.wiki.jei.ingredient.hideByType=Hides all ingredients of the given type
+groovyscript.wiki.jei.ingredient.removeAndHide=Removes the vanilla crafting recipe for the given ItemStack and hides the item from JEI
+groovyscript.wiki.jei.ingredient.yeet=Alias for `removeAndHide`
+groovyscript.wiki.jei.ingredient.hideAll=Hides all ingredients of all types from the sidebar. Functionally disables JEI
+
+
 # Mekanism
 groovyscript.wiki.mekanism.gasInput.value=Sets the gas inputs of the recipe
 groovyscript.wiki.mekanism.gasOutput.value=Sets the gas outputs of the recipe

--- a/src/main/resources/mixin.groovyscript.jei.json
+++ b/src/main/resources/mixin.groovyscript.jei.json
@@ -5,6 +5,7 @@
   "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
-    "JeiProxyAccessor"
+    "IngredientInfoRecipeAccessor",
+    "JeiProxyAccessor",
   ]
 }

--- a/src/main/resources/mixin.groovyscript.jei.json
+++ b/src/main/resources/mixin.groovyscript.jei.json
@@ -7,5 +7,6 @@
   "mixins": [
     "IngredientInfoRecipeAccessor",
     "JeiProxyAccessor",
+    "ModRegistryAccessor"
   ]
 }


### PR DESCRIPTION
changes in this PR:
- added the ability to remove non-items and non-fluids from the ingredients side (requires the type of ingredient to be specified)
- adds the ability to remove all ingredients of a given type
- adds the ability to remove all ingredients :trollface: 
- adds the ability to add and remove catalyst items from categories
- adds the ability to remove all catalysts of a specific category
- adds the ability to add and remove JEI descriptions (a special tab in JEI which displays information related to an item)
- adds lang keys for the wiki and an examples file for the above
- methods formerly directly inside `JEI` are now inside subregistries, so eg `mods.jei.hide` must now be `mods.jei.ingredient.hide`
