### PR TITLE
Create AbstractCraftingRecipeBuilder

### DIFF
--- a/examples/postInit/astralsorcery.groovy
+++ b/examples/postInit/astralsorcery.groovy
@@ -234,7 +234,7 @@ mods.astralsorcery.starlight_altar.discoveryRecipeBuilder()
     .row(' B ')
     .row('   ')
     .key('B', item('minecraft:bucket'))
-    .starlight(1)
+    .starlight(500)
     .craftTime(10)
     .register()
 

--- a/src/main/java/com/cleanroommc/groovyscript/api/documentation/annotations/Property.java
+++ b/src/main/java/com/cleanroommc/groovyscript/api/documentation/annotations/Property.java
@@ -123,7 +123,9 @@ public @interface Property {
 
     /**
      * Controls if the property needs an overriding property to enable it. Used in wrapper classes, such as {@link com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder AbstractRecipeBuilderr}, where some or all of the fields
-     * may not be needed in subclasses. At least one property must have this element be {@code false} for the property to be documented.
+     * may not be needed in subclasses.
+     * This can also be used to effectively disable properties from being documented by attaching it to the lowest hierarchy.
+     * The annotation for the given property field with the lowest {@link #hierarchy} score must have this be {@code false} for the property to be documented.
      *
      * @return if the property needs an overriding annotation to enable it, defaults to {@code false}
      */

--- a/src/main/java/com/cleanroommc/groovyscript/api/documentation/annotations/Property.java
+++ b/src/main/java/com/cleanroommc/groovyscript/api/documentation/annotations/Property.java
@@ -123,7 +123,7 @@ public @interface Property {
 
     /**
      * Controls if the property needs an overriding property to enable it. Used in wrapper classes, such as {@link com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder AbstractRecipeBuilderr}, where some or all of the fields
-     * may not be needed in subclasses. At least one property must have this element be {@code true} for the property to be documented.
+     * may not be needed in subclasses. At least one property must have this element be {@code false} for the property to be documented.
      *
      * @return if the property needs an overriding annotation to enable it, defaults to {@code false}
      */

--- a/src/main/java/com/cleanroommc/groovyscript/api/documentation/annotations/Property.java
+++ b/src/main/java/com/cleanroommc/groovyscript/api/documentation/annotations/Property.java
@@ -6,9 +6,18 @@ import java.lang.reflect.Field;
 /**
  * Functions in one of three ways depending on what the annotation is attached to:
  * <ul>
- *     <li>{@link ElementType#FIELD}: Marks the target field with this {@link Property}. {@link #property()} must be either set to the field name or unset.</li>
- *     <li>{@link ElementType#TYPE}: Marks the field targeted by {@link #property()} within the attached class with this {@link Property}.</li>
- *     <li>{@link ElementType#METHOD}: Marks the field targeted by {@link #property()} within the class the attached method returns with this {@link Property}.</li>
+ *     <li>
+ *         {@link ElementType#FIELD}: Marks the target field with this {@link Property}. {@link #property()} must be either set to the field name or unset.
+ *         Can only allow one annotation per field.
+ *     </li>
+ *     <li>
+ *         {@link ElementType#TYPE}: Marks the field targeted by {@link #property()} within the attached class with this {@link Property}.
+ *         Multiple will be wrapped in {@link Properties}.
+ *     </li>
+ *     <li>
+ *         {@link ElementType#METHOD}: Marks the field targeted by {@link #property()} within the class the attached method returns with this {@link Property}.
+ *         Can only be attached via being inside {@link RecipeBuilderDescription#requirement()}.
+ *     </li>
  * </ul>
  * <p>
  * Elements:
@@ -38,7 +47,7 @@ import java.lang.reflect.Field;
  */
 @Repeatable(Property.Properties.class)
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.FIELD, ElementType.TYPE, ElementType.METHOD})
+@Target({ElementType.FIELD, ElementType.TYPE})
 public @interface Property {
 
     /**
@@ -149,11 +158,14 @@ public @interface Property {
 
     /**
      * Wrapper to allow repeatable instances of {@link Property}.
+     * If more than one {@link Property} is applied to anywhere other than a class, it will generate an error.
+     * For a given Field. only a single {@link Property} should be attached,
+     * and for a given Method, all {@link Property} annotations should be placed inside {@link RecipeBuilderDescription#requirement()}
      *
      * @see Property
      */
     @Retention(RetentionPolicy.RUNTIME)
-    @Target({ElementType.FIELD, ElementType.TYPE, ElementType.METHOD})
+    @Target(ElementType.TYPE)
     @interface Properties {
 
         Property[] value();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/starlightaltar/AltarRecipeBuilder.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/starlightaltar/AltarRecipeBuilder.java
@@ -1,5 +1,6 @@
 package com.cleanroommc.groovyscript.compat.mods.astralsorcery.starlightaltar;
 
+import com.cleanroommc.groovyscript.api.GroovyBlacklist;
 import com.cleanroommc.groovyscript.api.GroovyLog;
 import com.cleanroommc.groovyscript.api.IIngredient;
 import com.cleanroommc.groovyscript.api.documentation.annotations.Comp;
@@ -8,13 +9,21 @@ import com.cleanroommc.groovyscript.api.documentation.annotations.RecipeBuilderM
 import com.cleanroommc.groovyscript.api.documentation.annotations.RecipeBuilderRegistrationMethod;
 import com.cleanroommc.groovyscript.compat.mods.ModSupport;
 import com.cleanroommc.groovyscript.compat.mods.astralsorcery.AstralSorcery;
-import com.cleanroommc.groovyscript.compat.vanilla.CraftingRecipeBuilder;
+import com.cleanroommc.groovyscript.helper.recipe.RecipeName;
+import com.cleanroommc.groovyscript.registry.AbstractCraftingRecipeBuilder;
+import com.google.common.collect.Lists;
 import hellfirepvp.astralsorcery.common.constellation.IConstellation;
 import hellfirepvp.astralsorcery.common.crafting.ItemHandle;
+import hellfirepvp.astralsorcery.common.crafting.altar.AbstractAltarRecipe;
+import hellfirepvp.astralsorcery.common.crafting.altar.recipes.AttunementRecipe;
+import hellfirepvp.astralsorcery.common.crafting.altar.recipes.ConstellationRecipe;
+import hellfirepvp.astralsorcery.common.crafting.altar.recipes.DiscoveryRecipe;
+import hellfirepvp.astralsorcery.common.crafting.altar.recipes.TraitRecipe;
+import hellfirepvp.astralsorcery.common.crafting.helper.AccessibleRecipeAdapater;
+import hellfirepvp.astralsorcery.common.crafting.helper.ShapedRecipe;
+import hellfirepvp.astralsorcery.common.crafting.helper.ShapedRecipeSlot;
 import hellfirepvp.astralsorcery.common.tile.TileAltar;
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.crafting.IRecipe;
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.logging.log4j.Level;
 
 import java.util.ArrayList;
@@ -22,187 +31,354 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
-@Property(property = "replace", needsOverride = true)
-@Property(property = "mirrored", needsOverride = true)
-@Property(property = "recipeFunction", needsOverride = true)
-@Property(property = "recipeAction", needsOverride = true)
-public class AltarRecipeBuilder extends CraftingRecipeBuilder.Shaped {
+public class AltarRecipeBuilder {
 
-    private final TileAltar.AltarLevel altarLevel;
-    @Property(needsOverride = true)
-    private final ArrayList<IIngredient> outerIngredients = new ArrayList<>();
-    @Property(ignoresInheritedMethods = true)
-    protected String name;
-    protected ItemHandle[] inputs = null;
-    protected ItemHandle[] outerInputs = null;
-    @Property(needsOverride = true)
-    protected int starlightRequired = 0;
-    @Property(valid = @Comp(value = "0", type = Comp.Type.GT))
-    protected int craftingTickTime = 1;
-    @Property
-    private IConstellation requiredConstellation = null;
+    private static AccessibleRecipeAdapater registerNative(String name, ItemStack output, ItemHandle[] inputs) {
+        ShapedRecipe.Builder builder = ShapedRecipe.Builder.newShapedRecipe(name, output);
 
-    public AltarRecipeBuilder(int width, int height, TileAltar.AltarLevel level) {
-        super(width, height);
-        this.altarLevel = level;
-        this.keyMap.put(' ', IIngredient.EMPTY);
-    }
-
-    @RecipeBuilderMethodDescription
-    public AltarRecipeBuilder name(String name) {
-        this.name = name;
-        return this;
-    }
-
-    @RecipeBuilderMethodDescription(field = "inputs")
-    public AltarRecipeBuilder input(ItemHandle[] inputs) {
-        this.inputs = inputs;
-        return this;
-    }
-
-    @RecipeBuilderMethodDescription(field = "keyBasedMatrix")
-    public AltarRecipeBuilder row(String row) {
-        if (this.keyBasedMatrix == null)
-            this.keyBasedMatrix = new String[]{row};
-        else
-            this.keyBasedMatrix = ArrayUtils.add(this.keyBasedMatrix, row);
-        return this;
-    }
-
-    @RecipeBuilderMethodDescription(field = "ingredientMatrix")
-    public AltarRecipeBuilder matrix(List<List<IIngredient>> matrix) {
-        this.ingredientMatrix = matrix;
-        return this;
-    }
-
-    @RecipeBuilderMethodDescription(field = "ingredientMatrix")
-    public AltarRecipeBuilder shape(List<List<IIngredient>> matrix) {
-        this.ingredientMatrix = matrix;
-        return this;
-    }
-
-    @RecipeBuilderMethodDescription(field = "keyBasedMatrix")
-    public AltarRecipeBuilder matrix(String... matrix) {
-        this.keyBasedMatrix = matrix;
-        return this;
-    }
-
-    @RecipeBuilderMethodDescription(field = "keyBasedMatrix")
-    public AltarRecipeBuilder shape(String... matrix) {
-        this.keyBasedMatrix = matrix;
-        return this;
-    }
-
-    @RecipeBuilderMethodDescription(field = "starlightRequired")
-    public AltarRecipeBuilder starlight(int starlight) {
-        this.starlightRequired = starlight;
-        return this;
-    }
-
-    @RecipeBuilderMethodDescription(field = "craftingTickTime")
-    public AltarRecipeBuilder craftTime(int ticks) {
-        this.craftingTickTime = ticks;
-        return this;
-    }
-
-    @RecipeBuilderMethodDescription(field = "requiredConstellation")
-    public AltarRecipeBuilder constellation(IConstellation constellation) {
-        this.requiredConstellation = constellation;
-        return this;
-    }
-
-    @RecipeBuilderMethodDescription(field = "outerIngredients")
-    public AltarRecipeBuilder outerInput(IIngredient ing) {
-        this.outerIngredients.add(ing);
-        return this;
-    }
-
-    @RecipeBuilderMethodDescription(field = "outerIngredients")
-    public AltarRecipeBuilder outerInput(IIngredient... ings) {
-        this.outerIngredients.addAll(Arrays.asList(ings));
-        return this;
-    }
-
-    @RecipeBuilderMethodDescription(field = "outerIngredients")
-    public AltarRecipeBuilder outerInput(Collection<IIngredient> ings) {
-        this.outerIngredients.addAll(ings);
-        return this;
-    }
-
-    private boolean flattenMatrix() {
-        ItemHandle[] in = AltarInputOrder.initInputList(this.altarLevel);
-        int[][] map = AltarInputOrder.getMap(this.altarLevel);
-        if (map == null || in == null) return false;
-
-        for (int i = 0; i < this.keyBasedMatrix.length; i++) {
-            String row = this.keyBasedMatrix[i];
-            for (int j = 0; j < row.length(); j++) {
-                if (map[i][j] >= 0 && row.charAt(j) != ' ') {
-                    in[map[i][j]] = AstralSorcery.toItemHandle(keyMap.get(row.charAt(j)));
-                }
+        for (int i = 0; i < 9; ++i) {
+            ItemHandle itemHandle = inputs[i];
+            if (itemHandle != null) {
+                ShapedRecipeSlot srs = ShapedRecipeSlot.values()[i];
+                builder.addPart(inputs[i], srs);
             }
         }
 
-        this.input(in);
-
-        ItemHandle[] outerIn = new ItemHandle[this.outerIngredients.size()];
-        for (int j = 0; j < this.outerIngredients.size(); j++)
-            outerIn[j] = AstralSorcery.toItemHandle(this.outerIngredients.get(j));
-        this.outerInputs = outerIn;
-
-        return true;
+        return builder.unregisteredAccessibleShapedRecipe();
     }
 
-    public boolean validate() {
-        GroovyLog.Msg out = GroovyLog.msg("Error adding Astral Sorcery Starlight Altar recipe").warn();
+    private static List<Integer> computeFluidConsumptionSlots(ItemHandle[] inputs) {
+        List<Integer> fluidInputs = Lists.newLinkedList();
 
-        if (this.output == null || this.output.isItemEqual(ItemStack.EMPTY)) {
-            out.add("Recipe output cannot be empty.").error();
-        }
-        if (this.starlightRequired < 0) {
-            out.add("Starlight amount cannot be negative, setting starlight amount to 0.");
-            this.starlightRequired = 0;
-        }
-        if (this.craftingTickTime <= 0) {
-            out.add("Crafting time cannot be negative or 0, setting crafting time to 1.");
-            this.craftingTickTime = 1;
+        for (int i = 0; i < inputs.length; ++i) {
+            ItemHandle handle = inputs[i];
+            if (handle != null && handle.handleType == ItemHandle.Type.FLUID) {
+                fluidInputs.add(i);
+            }
         }
 
-        switch (this.altarLevel) {
-            case DISCOVERY:
-                if (this.starlightRequired > 1000)
-                    out.add("Discovery Altar recipe cannot exceed 1000 starlight, clamping starlight to max table value.");
-                this.starlightRequired = Math.min(starlightRequired, 1000);
-            case ATTUNEMENT:
-                if (this.starlightRequired > 2000)
-                    out.add("Attunement Altar recipe cannot exceed 2000 starlight, clamping starlight to max table value.");
-                this.starlightRequired = Math.min(starlightRequired, 2000);
-            case CONSTELLATION_CRAFT:
-                if (this.starlightRequired > 4000)
-                    out.add("Constellation Altar recipe cannot exceed 4000 starlight, clamping starlight to max table value.");
-                this.starlightRequired = Math.min(starlightRequired, 4000);
-            case TRAIT_CRAFT:
-                if (this.starlightRequired > 8000)
-                    out.add("Trait Altar recipe cannot exceed 8000 starlight, clamping starlight to max table value.");
-                this.starlightRequired = Math.min(starlightRequired, 8000);
-        }
-
-        if (keyBasedMatrix != null) {
-            validateShape(out, errors, keyBasedMatrix, keyMap, (width, height, ingredients) -> null);
-        } else if (ingredientMatrix != null) {
-            validateShape(out, ingredientMatrix, (width, height, ingredients) -> null);
-        }
-
-        out.postIfNotEmpty();
-        return (out.getLevel() != Level.ERROR && this.flattenMatrix());
+        return fluidInputs;
     }
 
-    @Override
-    @RecipeBuilderRegistrationMethod
-    public IRecipe register() {
-        if (!validate()) return null;
+    private static DiscoveryRecipe discoveryAltar(String name, ItemStack output, ItemHandle[] inputs, int starlightRequired, int craftingTickTime, List<Integer> fluidStacks) {
+        return new DiscoveryRecipe(registerNative(name, output, inputs)) {
+            @Override
+            public int getPassiveStarlightRequired() {
+                return starlightRequired;
+            }
 
-        ModSupport.ASTRAL_SORCERY.get().altar.add(this.name, this.output, this.inputs, this.starlightRequired, this.craftingTickTime, this.altarLevel, this.requiredConstellation, this.outerInputs);
-        return null;
+            @Override
+            public int craftingTickTime() {
+                return craftingTickTime;
+            }
+
+            @Override
+            public boolean mayDecrement(TileAltar ta, ShapedRecipeSlot slot) {
+                return !fluidStacks.contains(slot.getSlotID());
+            }
+        };
+    }
+
+    private static AttunementRecipe attunementAltar(String name, ItemStack output, ItemHandle[] inputs, int starlightRequired, int craftingTickTime, List<Integer> fluidStacks) {
+        AttunementRecipe recipe = new AttunementRecipe(registerNative(name, output, inputs)) {
+            @Override
+            public int getPassiveStarlightRequired() {
+                return starlightRequired;
+            }
+
+            @Override
+            public int craftingTickTime() {
+                return craftingTickTime;
+            }
+
+            @Override
+            public boolean mayDecrement(TileAltar ta, ShapedRecipeSlot slot) {
+                return !fluidStacks.contains(slot.getSlotID());
+            }
+
+            @Override
+            public boolean mayDecrement(TileAltar ta, AttunementAltarSlot slot) {
+                return !fluidStacks.contains(slot.getSlotId());
+            }
+        };
+
+        for (AttunementRecipe.AttunementAltarSlot al : AttunementRecipe.AttunementAltarSlot.values()) {
+            if (inputs[al.getSlotId()] != null) {
+                recipe.setAttItem(inputs[al.getSlotId()], al);
+            }
+        }
+
+        return recipe;
+    }
+
+    private static ConstellationRecipe constellationAltar(String name, ItemStack output, ItemHandle[] inputs, int starlightRequired, int craftingTickTime, List<Integer> fluidStacks) {
+        ConstellationRecipe recipe = new ConstellationRecipe(registerNative(name, output, inputs)) {
+            @Override
+            public int getPassiveStarlightRequired() {
+                return starlightRequired;
+            }
+
+            @Override
+            public int craftingTickTime() {
+                return craftingTickTime;
+            }
+
+            @Override
+            public boolean mayDecrement(TileAltar ta, ShapedRecipeSlot slot) {
+                return !fluidStacks.contains(slot.getSlotID());
+            }
+
+            @Override
+            public boolean mayDecrement(TileAltar ta, AttunementAltarSlot slot) {
+                return !fluidStacks.contains(slot.getSlotId());
+            }
+
+            @Override
+            public boolean mayDecrement(TileAltar ta, ConstellationAtlarSlot slot) {
+                return !fluidStacks.contains(slot.getSlotId());
+            }
+        };
+
+        for (AttunementRecipe.AttunementAltarSlot al : AttunementRecipe.AttunementAltarSlot.values()) {
+            if (inputs[al.getSlotId()] != null) {
+                recipe.setAttItem(inputs[al.getSlotId()], al);
+            }
+        }
+        for (ConstellationRecipe.ConstellationAtlarSlot al : ConstellationRecipe.ConstellationAtlarSlot.values()) {
+            if (inputs[al.getSlotId()] != null) {
+                recipe.setCstItem(inputs[al.getSlotId()], al);
+            }
+        }
+
+        return recipe;
+    }
+
+    private static TraitRecipe traitAltar(String name, ItemStack output, ItemHandle[] inputs, int starlightRequired, int craftingTickTime, List<Integer> fluidStacks, IConstellation requiredConstellation, ItemHandle[] outerInputs) {
+        TraitRecipe recipe = new TraitRecipe(registerNative(name, output, inputs)) {
+            @Override
+            public int getPassiveStarlightRequired() {
+                return starlightRequired;
+            }
+
+            @Override
+            public int craftingTickTime() {
+                return craftingTickTime;
+            }
+
+            @Override
+            public boolean mayDecrement(TileAltar ta, ShapedRecipeSlot slot) {
+                return !fluidStacks.contains(slot.getSlotID());
+            }
+
+            @Override
+            public boolean mayDecrement(TileAltar ta, AttunementAltarSlot slot) {
+                return !fluidStacks.contains(slot.getSlotId());
+            }
+
+            @Override
+            public boolean mayDecrement(TileAltar ta, ConstellationAtlarSlot slot) {
+                return !fluidStacks.contains(slot.getSlotId());
+            }
+
+            @Override
+            public boolean mayDecrement(TileAltar ta, TraitRecipeSlot slot) {
+                return !fluidStacks.contains(slot.getSlotId());
+            }
+        };
+
+        for (AttunementRecipe.AttunementAltarSlot al : AttunementRecipe.AttunementAltarSlot.values()) {
+            if (inputs[al.getSlotId()] != null) {
+                recipe.setAttItem(inputs[al.getSlotId()], al);
+            }
+        }
+        for (ConstellationRecipe.ConstellationAtlarSlot al : ConstellationRecipe.ConstellationAtlarSlot.values()) {
+            if (inputs[al.getSlotId()] != null) {
+                recipe.setCstItem(inputs[al.getSlotId()], al);
+            }
+        }
+        for (TraitRecipe.TraitRecipeSlot al : TraitRecipe.TraitRecipeSlot.values()) {
+            if (inputs[al.getSlotId()] != null) {
+                recipe.setInnerTraitItem(inputs[al.getSlotId()], al);
+            }
+        }
+        for (int i = 25; i < inputs.length; i++) {
+            if (inputs[i] != null) {
+                recipe.addOuterTraitItem(inputs[i]);
+            }
+        }
+        if (requiredConstellation != null) {
+            recipe.setRequiredConstellation(requiredConstellation);
+        }
+        for (ItemHandle item : outerInputs) {
+            recipe.addOuterTraitItem(item);
+        }
+
+        return recipe;
+    }
+
+    @Property(property = "mirrored", needsOverride = true)
+    @Property(property = "recipeFunction", needsOverride = true)
+    @Property(property = "recipeAction", needsOverride = true)
+    @Property(property = "name", ignoresInheritedMethods = true, value = "groovyscript.wiki.astralsorcery.starlight_altar.name.value")
+    public static class Shaped extends AbstractCraftingRecipeBuilder.AbstractShaped<AbstractAltarRecipe> {
+
+        private final TileAltar.AltarLevel altarLevel;
+        @Property(needsOverride = true)
+        private final ArrayList<IIngredient> outerIngredients = new ArrayList<>();
+        @Property(ignoresInheritedMethods = true)
+        protected String name;
+        @Property(defaultValue = "1")
+        protected int starlightRequired = 1;
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GT), defaultValue = "1")
+        protected int craftingTickTime = 1;
+        @Property(needsOverride = true)
+        protected IConstellation requiredConstellation;
+        private ItemHandle[] inputs;
+        private ItemHandle[] outerInputs;
+
+        public Shaped(int width, int height, TileAltar.AltarLevel level) {
+            super(width, height);
+            this.altarLevel = level;
+            this.keyMap.put(' ', IIngredient.EMPTY);
+        }
+
+        @Override
+        @RecipeBuilderMethodDescription
+        public Shaped name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription(field = "inputs")
+        public Shaped input(ItemHandle[] inputs) {
+            this.inputs = inputs;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription(field = "starlightRequired")
+        public Shaped starlight(int starlight) {
+            this.starlightRequired = starlight;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription(field = "craftingTickTime")
+        public Shaped craftTime(int ticks) {
+            this.craftingTickTime = ticks;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription(field = "requiredConstellation")
+        public Shaped constellation(IConstellation constellation) {
+            this.requiredConstellation = constellation;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription(field = "outerIngredients")
+        public Shaped outerInput(IIngredient ing) {
+            this.outerIngredients.add(ing);
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription(field = "outerIngredients")
+        public Shaped outerInput(IIngredient... ings) {
+            this.outerIngredients.addAll(Arrays.asList(ings));
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription(field = "outerIngredients")
+        public Shaped outerInput(Collection<IIngredient> ings) {
+            this.outerIngredients.addAll(ings);
+            return this;
+        }
+
+        private boolean flattenMatrix() {
+            ItemHandle[] in = AltarInputOrder.initInputList(this.altarLevel);
+            int[][] map = AltarInputOrder.getMap(this.altarLevel);
+            if (map == null || in == null) {
+                return false;
+            }
+
+            for (int i = 0; i < this.keyBasedMatrix.length; i++) {
+                String row = this.keyBasedMatrix[i];
+                for (int j = 0; j < row.length(); j++) {
+                    if (map[i][j] >= 0 && row.charAt(j) != ' ') {
+                        in[map[i][j]] = AstralSorcery.toItemHandle(keyMap.get(row.charAt(j)));
+                    }
+                }
+            }
+
+            this.input(in);
+
+            ItemHandle[] outerIn = new ItemHandle[this.outerIngredients.size()];
+            for (int j = 0; j < this.outerIngredients.size(); j++) {
+                outerIn[j] = AstralSorcery.toItemHandle(this.outerIngredients.get(j));
+            }
+            this.outerInputs = outerIn;
+
+            return true;
+        }
+
+        @Override
+        public String getRecipeNamePrefix() {
+            return "groovyscript_starlight_altar_recipe_";
+        }
+
+        @Override
+        @GroovyBlacklist
+        public void validateName() {
+            if (name == null) {
+                name = RecipeName.generate(getRecipeNamePrefix());
+            }
+        }
+
+        public boolean validate() {
+            GroovyLog.Msg out = GroovyLog.msg("Error adding Astral Sorcery Starlight Altar recipe").warn();
+
+            validateName();
+
+            if (this.output == null || this.output.isItemEqual(ItemStack.EMPTY)) {
+                out.add("Recipe output cannot be empty.").error();
+            }
+            if (this.starlightRequired <= 0) {
+                out.add("Starlight amount cannot be negative or 0, setting starlight amount to 1.");
+                this.starlightRequired = 1;
+            }
+            if (this.craftingTickTime <= 0) {
+                out.add("Crafting time cannot be negative or 0, setting crafting time to 1.");
+                this.craftingTickTime = 1;
+            }
+
+            int maximumValue = altarLevel.getStarlightMaxStorage();
+            if (this.starlightRequired > maximumValue) {
+                out.add("Altar recipe cannot exceed {} starlight, clamping starlight to {} value.", maximumValue, maximumValue);
+                this.starlightRequired = Math.min(starlightRequired, maximumValue);
+            }
+
+            if (keyBasedMatrix != null) {
+                validateShape(out, errors, keyBasedMatrix, keyMap, (width, height, ingredients) -> null);
+            } else if (ingredientMatrix != null) {
+                validateShape(out, ingredientMatrix, (width, height, ingredients) -> null);
+            }
+
+            out.postIfNotEmpty();
+            return (out.getLevel() != Level.ERROR && this.flattenMatrix());
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public AbstractAltarRecipe register() {
+            if (!validate()) return null;
+
+            List<Integer> fluidStacks = computeFluidConsumptionSlots(inputs);
+            AbstractAltarRecipe recipe = switch (altarLevel) {
+                case DISCOVERY -> discoveryAltar(name, output, inputs, starlightRequired, craftingTickTime, fluidStacks);
+                case ATTUNEMENT -> attunementAltar(name, output, inputs, starlightRequired, craftingTickTime, fluidStacks);
+                case CONSTELLATION_CRAFT -> constellationAltar(name, output, inputs, starlightRequired, craftingTickTime, fluidStacks);
+                case TRAIT_CRAFT -> traitAltar(name, output, inputs, starlightRequired, craftingTickTime, fluidStacks, requiredConstellation, outerInputs);
+                default -> null;
+            };
+            ModSupport.ASTRAL_SORCERY.get().altar.add(recipe);
+            return recipe;
+        }
     }
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/starlightaltar/StarlightAltar.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/starlightaltar/StarlightAltar.java
@@ -3,62 +3,50 @@ package com.cleanroommc.groovyscript.compat.mods.astralsorcery.starlightaltar;
 import com.cleanroommc.groovyscript.api.GroovyBlacklist;
 import com.cleanroommc.groovyscript.api.documentation.annotations.*;
 import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
-import com.cleanroommc.groovyscript.helper.recipe.RecipeName;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
-import com.google.common.collect.Lists;
-import hellfirepvp.astralsorcery.common.constellation.IConstellation;
-import hellfirepvp.astralsorcery.common.crafting.ItemHandle;
 import hellfirepvp.astralsorcery.common.crafting.altar.AbstractAltarRecipe;
 import hellfirepvp.astralsorcery.common.crafting.altar.AltarRecipeRegistry;
-import hellfirepvp.astralsorcery.common.crafting.altar.recipes.AttunementRecipe;
-import hellfirepvp.astralsorcery.common.crafting.altar.recipes.ConstellationRecipe;
-import hellfirepvp.astralsorcery.common.crafting.altar.recipes.DiscoveryRecipe;
-import hellfirepvp.astralsorcery.common.crafting.altar.recipes.TraitRecipe;
-import hellfirepvp.astralsorcery.common.crafting.helper.AccessibleRecipeAdapater;
-import hellfirepvp.astralsorcery.common.crafting.helper.ShapedRecipe;
-import hellfirepvp.astralsorcery.common.crafting.helper.ShapedRecipeSlot;
 import hellfirepvp.astralsorcery.common.tile.TileAltar;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.math.MathHelper;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.Nullable;
 
-import java.util.List;
 import java.util.stream.Collectors;
 
 @RegistryDescription
 public class StarlightAltar extends VirtualizedRegistry<AbstractAltarRecipe> {
 
-    @RecipeBuilderDescription(priority = 100, example = @Example(".output(item('minecraft:water_bucket')).row('   ').row(' B ').row('   ').key('B', item('minecraft:bucket')).starlight(1).craftTime(10)"))
-    @Property(property = "ingredientMatrix", valid = {@Comp(value = "0", type = Comp.Type.GT), @Comp(value = "9", type = Comp.Type.LTE)})
-    @Property(property = "outerIngredients", valid = @Comp("0"))
-    @Property(property = "starlightRequired", valid = {@Comp(value = "1", type = Comp.Type.GTE), @Comp(value = "1000", type = Comp.Type.LTE)})
-    public static AltarRecipeBuilder discoveryRecipeBuilder() {
-        return new AltarRecipeBuilder(3, 3, TileAltar.AltarLevel.DISCOVERY);
+    @RecipeBuilderDescription(priority = 100, requirement = {
+            @Property(property = "ingredientMatrix", valid = {@Comp(value = "1", type = Comp.Type.GTE), @Comp(value = "9", type = Comp.Type.LTE)}),
+            @Property(property = "starlightRequired", valid = {@Comp(value = "1", type = Comp.Type.GTE), @Comp(value = "1000", type = Comp.Type.LTE)})
+    }, example = @Example(".output(item('minecraft:water_bucket')).row('   ').row(' B ').row('   ').key('B', item('minecraft:bucket')).starlight(500).craftTime(10)"))
+    public static AltarRecipeBuilder.Shaped discoveryRecipeBuilder() {
+        return new AltarRecipeBuilder.Shaped(3, 3, TileAltar.AltarLevel.DISCOVERY);
     }
 
-    @RecipeBuilderDescription(priority = 200)
-    @Property(property = "ingredientMatrix", valid = {@Comp(value = "0", type = Comp.Type.GT), @Comp(value = "13", type = Comp.Type.LTE)})
-    @Property(property = "outerIngredients", valid = @Comp("0"))
-    @Property(property = "starlightRequired", valid = {@Comp(value = "1", type = Comp.Type.GTE), @Comp(value = "2000", type = Comp.Type.LTE)})
-    public static AltarRecipeBuilder attunementRecipeBuilder() {
-        return new AltarRecipeBuilder(5, 5, TileAltar.AltarLevel.ATTUNEMENT);
+    @RecipeBuilderDescription(priority = 200, requirement = {
+            @Property(property = "ingredientMatrix", valid = {@Comp(value = "1", type = Comp.Type.GTE), @Comp(value = "13", type = Comp.Type.LTE)}),
+            @Property(property = "starlightRequired", valid = {@Comp(value = "1", type = Comp.Type.GTE), @Comp(value = "2000", type = Comp.Type.LTE)})
+    })
+    public static AltarRecipeBuilder.Shaped attunementRecipeBuilder() {
+        return new AltarRecipeBuilder.Shaped(5, 5, TileAltar.AltarLevel.ATTUNEMENT);
     }
 
-    @RecipeBuilderDescription(priority = 300, example = @Example(".output(item('minecraft:pumpkin')).matrix('ss ss', 's   s', '  d  ', 's   s', 'ss ss').key('s', item('minecraft:pumpkin_seeds')).key('d', ore('dirt'))"))
-    @Property(property = "ingredientMatrix", valid = {@Comp(value = "0", type = Comp.Type.GT), @Comp(value = "21", type = Comp.Type.LTE)})
-    @Property(property = "outerIngredients", valid = @Comp("0"))
-    @Property(property = "starlightRequired", valid = {@Comp(value = "1", type = Comp.Type.GTE), @Comp(value = "4000", type = Comp.Type.LTE)})
-    public static AltarRecipeBuilder constellationRecipeBuilder() {
-        return new AltarRecipeBuilder(5, 5, TileAltar.AltarLevel.CONSTELLATION_CRAFT);
+    @RecipeBuilderDescription(priority = 300, requirement = {
+            @Property(property = "ingredientMatrix", valid = {@Comp(value = "1", type = Comp.Type.GTE), @Comp(value = "21", type = Comp.Type.LTE)}),
+            @Property(property = "starlightRequired", valid = {@Comp(value = "1", type = Comp.Type.GTE), @Comp(value = "4000", type = Comp.Type.LTE)})
+    }, example = @Example(".output(item('minecraft:pumpkin')).matrix('ss ss', 's   s', '  d  ', 's   s', 'ss ss').key('s', item('minecraft:pumpkin_seeds')).key('d', ore('dirt'))"))
+    public static AltarRecipeBuilder.Shaped constellationRecipeBuilder() {
+        return new AltarRecipeBuilder.Shaped(5, 5, TileAltar.AltarLevel.CONSTELLATION_CRAFT);
     }
 
-    @RecipeBuilderDescription(priority = 400, example = @Example(".output(item('astralsorcery:itemrockcrystalsimple').setSize(300).setPurity(50).setCutting(50)).matrix('sssss', 'sgggs', 'sgdgs', 'sgggs', 'sssss').key('s', item('minecraft:pumpkin')).key('g', ore('treeLeaves')).key('d', item('minecraft:diamond_block')).outerInput(item('astralsorcery:blockmarble')).outerInput(ore('ingotAstralStarmetal')).outerInput(fluid('astralsorcery.liquidstarlight') * 1000).outerInput(ore('treeSapling')).constellation(constellation('discidia'))"))
-    @Property(property = "ingredientMatrix", valid = {@Comp(value = "0", type = Comp.Type.GT), @Comp(value = "25", type = Comp.Type.LTE)})
-    @Property(property = "outerIngredients", valid = {@Comp(value = "0", type = Comp.Type.GTE), @Comp(value = "24", type = Comp.Type.LTE)})
-    @Property(property = "starlightRequired", valid = {@Comp(value = "1", type = Comp.Type.GTE), @Comp(value = "8000", type = Comp.Type.LTE)})
-    public static AltarRecipeBuilder traitRecipeBuilder() {
-        return new AltarRecipeBuilder(5, 5, TileAltar.AltarLevel.TRAIT_CRAFT);
+    @RecipeBuilderDescription(priority = 400, requirement = {
+            @Property(property = "ingredientMatrix", valid = {@Comp(value = "1", type = Comp.Type.GTE), @Comp(value = "25", type = Comp.Type.LTE)}),
+            @Property(property = "outerIngredients", valid = {@Comp(value = "0", type = Comp.Type.GTE), @Comp(value = "24", type = Comp.Type.LTE)}),
+            @Property(property = "starlightRequired", valid = {@Comp(value = "1", type = Comp.Type.GTE), @Comp(value = "8000", type = Comp.Type.LTE)}),
+            @Property(property = "requiredConstellation")
+    }, example = @Example(".output(item('astralsorcery:itemrockcrystalsimple').setSize(300).setPurity(50).setCutting(50)).matrix('sssss', 'sgggs', 'sgdgs', 'sgggs', 'sssss').key('s', item('minecraft:pumpkin')).key('g', ore('treeLeaves')).key('d', item('minecraft:diamond_block')).outerInput(item('astralsorcery:blockmarble')).outerInput(ore('ingotAstralStarmetal')).outerInput(fluid('astralsorcery.liquidstarlight') * 1000).outerInput(ore('treeSapling')).constellation(constellation('discidia'))"))
+    public static AltarRecipeBuilder.Shaped traitRecipeBuilder() {
+        return new AltarRecipeBuilder.Shaped(5, 5, TileAltar.AltarLevel.TRAIT_CRAFT);
     }
 
     @Override
@@ -69,171 +57,16 @@ public class StarlightAltar extends VirtualizedRegistry<AbstractAltarRecipe> {
         restoreFromBackup().forEach(r -> AltarRecipeRegistry.recipes.get(r.getNeededLevel()).add(r));
     }
 
+    @Override
     public void afterScriptLoad() {
         AltarRecipeRegistry.compileRecipes();
     }
 
-    public @Nullable AbstractAltarRecipe add(String name, ItemStack output, ItemHandle[] inputs, int starlightRequired, int craftingTickTime, TileAltar.AltarLevel altarLevel, IConstellation requiredConstellation, ItemHandle[] outerInputs) {
-        if (name == null || "".equals(name))
-            name = RecipeName.generate("starlight_altar_recipe");
-        final int starlightConsumed = MathHelper.clamp(starlightRequired, 1, altarLevel.getStarlightMaxStorage());
-        final List<Integer> fluidStacks = this.computeFluidConsumptionSlots(inputs);
-        switch (altarLevel) {
-            case DISCOVERY:
-                DiscoveryRecipe dRec = new DiscoveryRecipe(this.registerNative(name, output, inputs)) {
-                    public int getPassiveStarlightRequired() {
-                        return starlightConsumed;
-                    }
 
-                    public int craftingTickTime() {
-                        return craftingTickTime;
-                    }
-
-                    public boolean mayDecrement(TileAltar ta, ShapedRecipeSlot slot) {
-                        return !fluidStacks.contains(slot.getSlotID());
-                    }
-                };
-
-                return add(dRec);
-            case ATTUNEMENT:
-                AttunementRecipe aRec = new AttunementRecipe(this.registerNative(name, output, inputs)) {
-                    public int getPassiveStarlightRequired() {
-                        return starlightConsumed;
-                    }
-
-                    public int craftingTickTime() {
-                        return craftingTickTime;
-                    }
-
-                    public boolean mayDecrement(TileAltar ta, ShapedRecipeSlot slot) {
-                        return !fluidStacks.contains(slot.getSlotID());
-                    }
-
-                    public boolean mayDecrement(TileAltar ta, AttunementAltarSlot slot) {
-                        return !fluidStacks.contains(slot.getSlotId());
-                    }
-                };
-
-                for (AttunementRecipe.AttunementAltarSlot al : AttunementRecipe.AttunementAltarSlot.values()) {
-                    if (inputs[al.getSlotId()] != null) aRec.setAttItem(inputs[al.getSlotId()], al);
-                }
-
-                return add(aRec);
-            case CONSTELLATION_CRAFT:
-                ConstellationRecipe cRec = new ConstellationRecipe(this.registerNative(name, output, inputs)) {
-                    public int getPassiveStarlightRequired() {
-                        return starlightConsumed;
-                    }
-
-                    public int craftingTickTime() {
-                        return craftingTickTime;
-                    }
-
-                    public boolean mayDecrement(TileAltar ta, ShapedRecipeSlot slot) {
-                        return !fluidStacks.contains(slot.getSlotID());
-                    }
-
-                    public boolean mayDecrement(TileAltar ta, AttunementAltarSlot slot) {
-                        return !fluidStacks.contains(slot.getSlotId());
-                    }
-
-                    public boolean mayDecrement(TileAltar ta, ConstellationAtlarSlot slot) {
-                        return !fluidStacks.contains(slot.getSlotId());
-                    }
-                };
-
-                for (AttunementRecipe.AttunementAltarSlot al : AttunementRecipe.AttunementAltarSlot.values()) {
-                    if (inputs[al.getSlotId()] != null) cRec.setAttItem(inputs[al.getSlotId()], al);
-                }
-                for (ConstellationRecipe.ConstellationAtlarSlot al : ConstellationRecipe.ConstellationAtlarSlot.values()) {
-                    if (inputs[al.getSlotId()] != null) cRec.setCstItem(inputs[al.getSlotId()], al);
-                }
-
-                return add(cRec);
-            case TRAIT_CRAFT:
-                TraitRecipe rRec = new TraitRecipe(this.registerNative(name, output, inputs)) {
-                    public int getPassiveStarlightRequired() {
-                        return starlightConsumed;
-                    }
-
-                    public int craftingTickTime() {
-                        return craftingTickTime;
-                    }
-
-                    public boolean mayDecrement(TileAltar ta, ShapedRecipeSlot slot) {
-                        return !fluidStacks.contains(slot.getSlotID());
-                    }
-
-                    public boolean mayDecrement(TileAltar ta, AttunementAltarSlot slot) {
-                        return !fluidStacks.contains(slot.getSlotId());
-                    }
-
-                    public boolean mayDecrement(TileAltar ta, ConstellationAtlarSlot slot) {
-                        return !fluidStacks.contains(slot.getSlotId());
-                    }
-
-                    public boolean mayDecrement(TileAltar ta, TraitRecipeSlot slot) {
-                        return !fluidStacks.contains(slot.getSlotId());
-                    }
-                };
-
-                for (AttunementRecipe.AttunementAltarSlot al : AttunementRecipe.AttunementAltarSlot.values()) {
-                    if (inputs[al.getSlotId()] != null) rRec.setAttItem(inputs[al.getSlotId()], al);
-                }
-                for (ConstellationRecipe.ConstellationAtlarSlot al : ConstellationRecipe.ConstellationAtlarSlot.values()) {
-                    if (inputs[al.getSlotId()] != null) rRec.setCstItem(inputs[al.getSlotId()], al);
-                }
-                for (TraitRecipe.TraitRecipeSlot al : TraitRecipe.TraitRecipeSlot.values()) {
-                    if (inputs[al.getSlotId()] != null) rRec.setInnerTraitItem(inputs[al.getSlotId()], al);
-                }
-                for (int i = 25; i < inputs.length; i++) {
-                    if (inputs[i] != null) {
-                        rRec.addOuterTraitItem(inputs[i]);
-                    }
-                }
-
-                if (requiredConstellation != null)
-                    rRec.setRequiredConstellation(requiredConstellation);
-                for (ItemHandle item : outerInputs)
-                    rRec.addOuterTraitItem(item);
-
-                return add(rRec);
-            default:
-                return null;
-        }
-    }
-
-    private AccessibleRecipeAdapater registerNative(String name, ItemStack output, ItemHandle[] inputs) {
-        ShapedRecipe.Builder builder = ShapedRecipe.Builder.newShapedRecipe(name, output);
-
-        for (int i = 0; i < 9; ++i) {
-            ItemHandle itemHandle = inputs[i];
-            if (itemHandle != null) {
-                ShapedRecipeSlot srs = ShapedRecipeSlot.values()[i];
-                builder.addPart(inputs[i], srs);
-            }
-        }
-
-        return builder.unregisteredAccessibleShapedRecipe();
-    }
-
-    private AbstractAltarRecipe add(AbstractAltarRecipe recipe) {
+    public AbstractAltarRecipe add(AbstractAltarRecipe recipe) {
         addScripted(recipe);
         AltarRecipeRegistry.recipes.get(recipe.getNeededLevel()).add(recipe);
         return recipe;
-    }
-
-    private List<Integer> computeFluidConsumptionSlots(ItemHandle[] inputs) {
-        List<Integer> fluidInputs = Lists.newLinkedList();
-
-        for (int i = 0; i < inputs.length; ++i) {
-            ItemHandle handle = inputs[i];
-            if (handle != null && handle.handleType == ItemHandle.Type.FLUID) {
-                fluidInputs.add(i);
-            }
-        }
-
-        return fluidInputs;
     }
 
     @MethodDescription(description = "groovyscript.wiki.astralsorcery.starlight_altar.removeByOutput0")

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/avaritia/ExtremeCrafting.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/avaritia/ExtremeCrafting.java
@@ -37,7 +37,7 @@ public class ExtremeCrafting extends VirtualizedRegistry<IExtremeRecipe> {
 
     @MethodDescription(type = MethodDescription.Type.ADDITION)
     public IExtremeRecipe addShaped(ItemStack output, List<List<IIngredient>> input) {
-        return (IExtremeRecipe) shapedBuilder()
+        return shapedBuilder()
                 .matrix(input)
                 .output(output)
                 .register();
@@ -45,7 +45,7 @@ public class ExtremeCrafting extends VirtualizedRegistry<IExtremeRecipe> {
 
     @MethodDescription(type = MethodDescription.Type.ADDITION)
     public IExtremeRecipe addShapeless(ItemStack output, List<IIngredient> input) {
-        return (IExtremeRecipe) shapelessBuilder()
+        return shapelessBuilder()
                 .input(input)
                 .output(output)
                 .register();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/avaritia/ExtremeRecipeBuilder.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/avaritia/ExtremeRecipeBuilder.java
@@ -1,98 +1,26 @@
 package com.cleanroommc.groovyscript.compat.mods.avaritia;
 
 import com.cleanroommc.groovyscript.api.GroovyLog;
-import com.cleanroommc.groovyscript.api.IIngredient;
 import com.cleanroommc.groovyscript.api.documentation.annotations.Comp;
 import com.cleanroommc.groovyscript.api.documentation.annotations.Property;
-import com.cleanroommc.groovyscript.api.documentation.annotations.RecipeBuilderMethodDescription;
 import com.cleanroommc.groovyscript.api.documentation.annotations.RecipeBuilderRegistrationMethod;
 import com.cleanroommc.groovyscript.compat.mods.ModSupport;
-import com.cleanroommc.groovyscript.compat.vanilla.CraftingRecipeBuilder;
 import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
-import it.unimi.dsi.fastutil.chars.Char2ObjectOpenHashMap;
+import com.cleanroommc.groovyscript.registry.AbstractCraftingRecipeBuilder;
 import morph.avaritia.recipe.extreme.IExtremeRecipe;
-import org.apache.commons.lang3.ArrayUtils;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
+public interface ExtremeRecipeBuilder {
 
-public abstract class ExtremeRecipeBuilder extends CraftingRecipeBuilder {
-
-    public ExtremeRecipeBuilder() {
-        super(9, 9);
-    }
-
-    public static class Shaped extends ExtremeRecipeBuilder {
-
-        @Property(value = "groovyscript.wiki.craftingrecipe.keyMap.value", defaultValue = "' ' = IIngredient.EMPTY", priority = 210, hierarchy = 20)
-        private final Char2ObjectOpenHashMap<IIngredient> keyMap = new Char2ObjectOpenHashMap<>();
-        private final List<String> errors = new ArrayList<>();
-        @Property(value = "groovyscript.wiki.craftingrecipe.mirrored.value", hierarchy = 20)
-        protected boolean mirrored = false;
-        @Property(value = "groovyscript.wiki.craftingrecipe.keyBasedMatrix.value", requirement = "groovyscript.wiki.craftingrecipe.matrix.required", priority = 200, hierarchy = 20)
-        private String[] keyBasedMatrix;
-        @Property(value = "groovyscript.wiki.craftingrecipe.ingredientMatrix.value", requirement = "groovyscript.wiki.craftingrecipe.matrix.required", valid = {
-                @Comp(value = "1", type = Comp.Type.GTE), @Comp(value = "81", type = Comp.Type.LTE)}, priority = 200, hierarchy = 20)
-        private List<List<IIngredient>> ingredientMatrix;
+    @Property(property = "ingredientMatrix", valid = {@Comp(value = "1", type = Comp.Type.GTE), @Comp(value = "81", type = Comp.Type.LTE)})
+    class Shaped extends AbstractCraftingRecipeBuilder.AbstractShaped<IExtremeRecipe> {
 
         public Shaped() {
-            keyMap.put(' ', IIngredient.EMPTY);
+            super(9, 9);
         }
 
-        @RecipeBuilderMethodDescription
-        public ExtremeRecipeBuilder.Shaped mirrored(boolean mirrored) {
-            this.mirrored = mirrored;
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription
-        public ExtremeRecipeBuilder.Shaped mirrored() {
-            return mirrored(true);
-        }
-
-        @RecipeBuilderMethodDescription(field = "keyBasedMatrix")
-        public ExtremeRecipeBuilder.Shaped matrix(String... matrix) {
-            this.keyBasedMatrix = matrix;
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription(field = "keyBasedMatrix")
-        public ExtremeRecipeBuilder.Shaped shape(String... matrix) {
-            this.keyBasedMatrix = matrix;
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription(field = "keyBasedMatrix")
-        public ExtremeRecipeBuilder.Shaped row(String row) {
-            if (this.keyBasedMatrix == null) {
-                this.keyBasedMatrix = new String[]{row};
-            } else {
-                this.keyBasedMatrix = ArrayUtils.add(this.keyBasedMatrix, row);
-            }
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription(field = "keyMap")
-        public ExtremeRecipeBuilder.Shaped key(String c, IIngredient ingredient) {
-            if (c == null || c.length() != 1) {
-                errors.add("key must be a single char, but found '" + c + "'");
-                return this;
-            }
-            this.keyMap.put(c.charAt(0), ingredient);
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription(field = "ingredientMatrix")
-        public ExtremeRecipeBuilder.Shaped matrix(List<List<IIngredient>> matrix) {
-            this.ingredientMatrix = matrix;
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription(field = "ingredientMatrix")
-        public ExtremeRecipeBuilder.Shaped shape(List<List<IIngredient>> matrix) {
-            this.ingredientMatrix = matrix;
-            return this;
+        @Override
+        public String getRecipeNamePrefix() {
+            return "groovyscript_extreme_shaped_";
         }
 
         @Override
@@ -117,43 +45,18 @@ public abstract class ExtremeRecipeBuilder extends CraftingRecipeBuilder {
             }
             return recipe;
         }
+    }
+
+    @Property(property = "ingredients", valid = {@Comp(value = "1", type = Comp.Type.GTE), @Comp(value = "81", type = Comp.Type.LTE)})
+    class Shapeless extends AbstractCraftingRecipeBuilder.AbstractShapeless<IExtremeRecipe> {
+
+        public Shapeless() {
+            super(9, 9);
+        }
 
         @Override
         public String getRecipeNamePrefix() {
-            return "grs_extreme_shaped_";
-        }
-    }
-
-    public static class Shapeless extends ExtremeRecipeBuilder {
-
-        @Property(value = "groovyscript.wiki.craftingrecipe.ingredients.value", valid = {@Comp(value = "1", type = Comp.Type.GTE),
-                                                                                         @Comp(value = "81", type = Comp.Type.LTE)}, priority = 250, hierarchy = 20)
-        private final List<IIngredient> ingredients = new ArrayList<>();
-
-        @RecipeBuilderMethodDescription(field = "ingredients")
-        public ExtremeRecipeBuilder.Shapeless input(IIngredient ingredient) {
-            ingredients.add(ingredient);
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription(field = "ingredients")
-        public ExtremeRecipeBuilder.Shapeless input(IIngredient... ingredients) {
-            if (ingredients != null) {
-                for (IIngredient ingredient : ingredients) {
-                    input(ingredient);
-                }
-            }
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription(field = "ingredients")
-        public ExtremeRecipeBuilder.Shapeless input(Collection<IIngredient> ingredients) {
-            if (ingredients != null && !ingredients.isEmpty()) {
-                for (IIngredient ingredient : ingredients) {
-                    input(ingredient);
-                }
-            }
-            return this;
+            return "groovyscript_extreme_shapeless_";
         }
 
         public boolean validate() {
@@ -173,11 +76,6 @@ public abstract class ExtremeRecipeBuilder extends CraftingRecipeBuilder {
             recipe.setRegistryName(this.name);
             ModSupport.AVARITIA.get().extremeCrafting.add(recipe);
             return recipe;
-        }
-
-        @Override
-        public String getRecipeNamePrefix() {
-            return "grs_extreme_shapeless_";
         }
     }
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/AnvilRecipeBuilder.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/AnvilRecipeBuilder.java
@@ -3,113 +3,21 @@ package com.cleanroommc.groovyscript.compat.mods.betterwithmods;
 import betterwithmods.common.registry.anvil.ShapedAnvilRecipe;
 import betterwithmods.common.registry.anvil.ShapelessAnvilRecipe;
 import com.cleanroommc.groovyscript.api.GroovyLog;
-import com.cleanroommc.groovyscript.api.IIngredient;
 import com.cleanroommc.groovyscript.api.documentation.annotations.Comp;
 import com.cleanroommc.groovyscript.api.documentation.annotations.Property;
-import com.cleanroommc.groovyscript.api.documentation.annotations.RecipeBuilderMethodDescription;
 import com.cleanroommc.groovyscript.api.documentation.annotations.RecipeBuilderRegistrationMethod;
 import com.cleanroommc.groovyscript.compat.mods.ModSupport;
-import com.cleanroommc.groovyscript.compat.vanilla.CraftingRecipeBuilder;
 import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
-import it.unimi.dsi.fastutil.chars.Char2ObjectOpenHashMap;
+import com.cleanroommc.groovyscript.registry.AbstractCraftingRecipeBuilder;
 import net.minecraft.item.crafting.IRecipe;
-import org.apache.commons.lang3.ArrayUtils;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
+public interface AnvilRecipeBuilder {
 
-public abstract class AnvilRecipeBuilder extends CraftingRecipeBuilder {
-
-    public AnvilRecipeBuilder() {
-        super(4, 4);
-    }
-
-    public static class Shaped extends AnvilRecipeBuilder {
-
-        @Property(value = "groovyscript.wiki.craftingrecipe.keyMap.value", defaultValue = "' ' = IIngredient.EMPTY", priority = 200)
-        private final Char2ObjectOpenHashMap<IIngredient> keyMap = new Char2ObjectOpenHashMap<>();
-        private final List<String> errors = new ArrayList<>();
-        @Property("groovyscript.wiki.craftingrecipe.mirrored.value")
-        protected boolean mirrored = false;
-        @Property(value = "groovyscript.wiki.craftingrecipe.keyBasedMatrix.value", requirement = "groovyscript.wiki.craftingrecipe.matrix.required", priority = 210)
-        private String[] keyBasedMatrix;
-        @Property(value = "groovyscript.wiki.craftingrecipe.ingredientMatrix.value", requirement = "groovyscript.wiki.craftingrecipe.matrix.required", valid = {
-                @Comp(value = "1", type = Comp.Type.GTE), @Comp(value = "81", type = Comp.Type.LTE)}, priority = 250)
-        private List<List<IIngredient>> ingredientMatrix;
+    @Property(property = "ingredientMatrix", valid = {@Comp(value = "1", type = Comp.Type.GTE), @Comp(value = "16", type = Comp.Type.LTE)})
+    class Shaped extends AbstractCraftingRecipeBuilder.AbstractShaped<IRecipe> {
 
         public Shaped() {
-            keyMap.put(' ', IIngredient.EMPTY);
-        }
-
-        @RecipeBuilderMethodDescription
-        public AnvilRecipeBuilder.Shaped mirrored(boolean mirrored) {
-            this.mirrored = mirrored;
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription
-        public AnvilRecipeBuilder.Shaped mirrored() {
-            return mirrored(true);
-        }
-
-        @RecipeBuilderMethodDescription(field = "keyBasedMatrix")
-        public AnvilRecipeBuilder.Shaped matrix(String... matrix) {
-            this.keyBasedMatrix = matrix;
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription(field = "keyBasedMatrix")
-        public AnvilRecipeBuilder.Shaped shape(String... matrix) {
-            this.keyBasedMatrix = matrix;
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription(field = "keyBasedMatrix")
-        public AnvilRecipeBuilder.Shaped row(String row) {
-            if (this.keyBasedMatrix == null) {
-                this.keyBasedMatrix = new String[]{row};
-            } else {
-                this.keyBasedMatrix = ArrayUtils.add(this.keyBasedMatrix, row);
-            }
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription(field = "keyMap")
-        public AnvilRecipeBuilder.Shaped key(char c, IIngredient ingredient) {
-            this.keyMap.put(c, ingredient);
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription(field = "keyMap")
-        public AnvilRecipeBuilder.Shaped key(String c, IIngredient ingredient) {
-            if (c == null || c.length() != 1) {
-                errors.add("key must be a single char, but found '" + c + "'");
-                return this;
-            }
-            this.keyMap.put(c.charAt(0), ingredient);
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription(field = "keyMap")
-        public AnvilRecipeBuilder.Shaped key(Map<String, IIngredient> map) {
-            for (Map.Entry<String, IIngredient> x : map.entrySet()) {
-                key(x.getKey(), x.getValue());
-            }
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription(field = "ingredientMatrix")
-        public AnvilRecipeBuilder.Shaped matrix(List<List<IIngredient>> matrix) {
-            this.ingredientMatrix = matrix;
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription(field = "ingredientMatrix")
-        public AnvilRecipeBuilder.Shaped shape(List<List<IIngredient>> matrix) {
-            this.ingredientMatrix = matrix;
-            return this;
+            super(4, 4);
         }
 
         @Override
@@ -128,42 +36,18 @@ public abstract class AnvilRecipeBuilder extends CraftingRecipeBuilder {
             }
             if (msg.postIfNotEmpty()) return null;
             if (recipe != null) {
+                handleReplace();
                 ModSupport.BETTER_WITH_MODS.get().anvilCrafting.add(recipe);
             }
             return recipe;
         }
     }
 
-    public static class Shapeless extends AnvilRecipeBuilder {
+    @Property(property = "ingredients", valid = {@Comp(value = "1", type = Comp.Type.GTE), @Comp(value = "16", type = Comp.Type.LTE)})
+    class Shapeless extends AbstractCraftingRecipeBuilder.AbstractShapeless<IRecipe> {
 
-        @Property(value = "groovyscript.wiki.craftingrecipe.ingredients.value", valid = {@Comp(value = "1", type = Comp.Type.GTE),
-                                                                                         @Comp(value = "81", type = Comp.Type.LTE)}, priority = 250)
-        private final List<IIngredient> ingredients = new ArrayList<>();
-
-        @RecipeBuilderMethodDescription(field = "ingredients")
-        public AnvilRecipeBuilder.Shapeless input(IIngredient ingredient) {
-            ingredients.add(ingredient);
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription(field = "ingredients")
-        public AnvilRecipeBuilder.Shapeless input(IIngredient... ingredients) {
-            if (ingredients != null) {
-                for (IIngredient ingredient : ingredients) {
-                    input(ingredient);
-                }
-            }
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription(field = "ingredients")
-        public AnvilRecipeBuilder.Shapeless input(Collection<IIngredient> ingredients) {
-            if (ingredients != null && !ingredients.isEmpty()) {
-                for (IIngredient ingredient : ingredients) {
-                    input(ingredient);
-                }
-            }
-            return this;
+        public Shapeless() {
+            super(4, 4);
         }
 
         public boolean validate() {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/extendedcrafting/EnderCrafting.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/extendedcrafting/EnderCrafting.java
@@ -46,9 +46,9 @@ public class EnderCrafting extends VirtualizedRegistry<IRecipe> {
 
     @MethodDescription(description = "groovyscript.wiki.extendedcrafting.ender_crafting.addShaped1", type = MethodDescription.Type.ADDITION)
     public IRecipe addShaped(int time, ItemStack output, List<List<IIngredient>> input) {
-        return (IRecipe) shapedBuilder()
-                .matrix(input)
+        return shapedBuilder()
                 .time(time)
+                .matrix(input)
                 .output(output)
                 .register();
     }
@@ -60,9 +60,9 @@ public class EnderCrafting extends VirtualizedRegistry<IRecipe> {
 
     @MethodDescription(description = "groovyscript.wiki.extendedcrafting.ender_crafting.addShapeless1", type = MethodDescription.Type.ADDITION)
     public IRecipe addShapeless(int time, ItemStack output, List<IIngredient> input) {
-        return (IRecipe) shapelessBuilder()
-                .input(input)
+        return shapelessBuilder()
                 .time(time)
+                .input(input)
                 .output(output)
                 .register();
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/extendedcrafting/EnderRecipeBuilder.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/extendedcrafting/EnderRecipeBuilder.java
@@ -3,137 +3,48 @@ package com.cleanroommc.groovyscript.compat.mods.extendedcrafting;
 import com.blakebr0.extendedcrafting.config.ModConfig;
 import com.blakebr0.extendedcrafting.crafting.table.TableRecipeBase;
 import com.cleanroommc.groovyscript.api.GroovyLog;
-import com.cleanroommc.groovyscript.api.IIngredient;
 import com.cleanroommc.groovyscript.api.documentation.annotations.Comp;
 import com.cleanroommc.groovyscript.api.documentation.annotations.Property;
 import com.cleanroommc.groovyscript.api.documentation.annotations.RecipeBuilderMethodDescription;
 import com.cleanroommc.groovyscript.api.documentation.annotations.RecipeBuilderRegistrationMethod;
 import com.cleanroommc.groovyscript.compat.mods.ModSupport;
-import com.cleanroommc.groovyscript.compat.vanilla.CraftingRecipeBuilder;
 import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
-import it.unimi.dsi.fastutil.chars.Char2ObjectOpenHashMap;
+import com.cleanroommc.groovyscript.registry.AbstractCraftingRecipeBuilder;
 import net.minecraft.item.crafting.IRecipe;
-import org.apache.commons.lang3.ArrayUtils;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-
-public class EnderRecipeBuilder extends CraftingRecipeBuilder {
-
-    @Property(defaultValue = "ModConfig.confEnderTimeRequired", valid = @Comp(value = "0", type = Comp.Type.GTE))
-    protected int time = ModConfig.confEnderTimeRequired;
-
-    public EnderRecipeBuilder() {
-        super(3, 3);
-    }
+public interface EnderRecipeBuilder {
 
     @RecipeBuilderMethodDescription
-    public EnderRecipeBuilder time(int time) {
-        this.time = time;
-        return this;
+    EnderRecipeBuilder time(int time);
+
+    @RecipeBuilderMethodDescription(field = "time")
+    default EnderRecipeBuilder seconds(int seconds) {
+        return this.time(seconds);
     }
 
     @RecipeBuilderMethodDescription(field = "time")
-    public EnderRecipeBuilder seconds(int seconds) {
-        this.time = seconds;
-        return this;
+    default EnderRecipeBuilder ticks(int ticks) {
+        return this.time(ticks * 20);
     }
 
-    @RecipeBuilderMethodDescription(field = "time")
-    public EnderRecipeBuilder ticks(int ticks) {
-        this.time = ticks * 20;
-        return this;
-    }
+    class Shaped extends AbstractCraftingRecipeBuilder.AbstractShaped<IRecipe> implements EnderRecipeBuilder {
 
-    @Override
-    public IRecipe register() {
-        return null;
-    }
-
-    public static class Shaped extends EnderRecipeBuilder {
-
-        @Property(value = "groovyscript.wiki.craftingrecipe.keyMap.value", defaultValue = "' ' = IIngredient.EMPTY", priority = 200)
-        private final Char2ObjectOpenHashMap<IIngredient> keyMap = new Char2ObjectOpenHashMap<>();
-        private final List<String> errors = new ArrayList<>();
-        @Property("groovyscript.wiki.craftingrecipe.mirrored.value")
-        protected boolean mirrored = false;
-        @Property(value = "groovyscript.wiki.craftingrecipe.keyBasedMatrix.value", requirement = "groovyscript.wiki.craftingrecipe.matrix.required", priority = 210)
-        private String[] keyBasedMatrix;
-        @Property(value = "groovyscript.wiki.craftingrecipe.ingredientMatrix.value", requirement = "groovyscript.wiki.craftingrecipe.matrix.required", valid = {@Comp(value = "1", type = Comp.Type.GTE), @Comp(value = "9", type = Comp.Type.LTE)}, priority = 250)
-        private List<List<IIngredient>> ingredientMatrix;
+        @Property(defaultValue = "ModConfig.confEnderTimeRequired", valid = @Comp(value = "0", type = Comp.Type.GTE))
+        protected int time = ModConfig.confEnderTimeRequired;
 
         public Shaped() {
-            keyMap.put(' ', IIngredient.EMPTY);
+            super(3, 3);
         }
 
+        @Override
+        public String getRecipeNamePrefix() {
+            return "groovyscript_ender_shaped_";
+        }
+
+        @Override
         @RecipeBuilderMethodDescription
-        public EnderRecipeBuilder.Shaped mirrored(boolean mirrored) {
-            this.mirrored = mirrored;
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription
-        public EnderRecipeBuilder.Shaped mirrored() {
-            return mirrored(true);
-        }
-
-        @RecipeBuilderMethodDescription(field = "keyBasedMatrix")
-        public EnderRecipeBuilder.Shaped matrix(String... matrix) {
-            this.keyBasedMatrix = matrix;
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription(field = "keyBasedMatrix")
-        public EnderRecipeBuilder.Shaped shape(String... matrix) {
-            this.keyBasedMatrix = matrix;
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription(field = "keyBasedMatrix")
-        public EnderRecipeBuilder.Shaped row(String row) {
-            if (this.keyBasedMatrix == null) {
-                this.keyBasedMatrix = new String[]{row};
-            } else {
-                this.keyBasedMatrix = ArrayUtils.add(this.keyBasedMatrix, row);
-            }
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription(field = "keyMap")
-        public EnderRecipeBuilder.Shaped key(char c, IIngredient ingredient) {
-            this.keyMap.put(c, ingredient);
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription(field = "keyMap")
-        public EnderRecipeBuilder.Shaped key(String c, IIngredient ingredient) {
-            if (c == null || c.length() != 1) {
-                errors.add("key must be a single char, but found '" + c + "'");
-                return this;
-            }
-            this.keyMap.put(c.charAt(0), ingredient);
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription(field = "keyMap")
-        public EnderRecipeBuilder.Shaped key(Map<String, IIngredient> map) {
-            for (Map.Entry<String, IIngredient> x : map.entrySet()) {
-                key(x.getKey(), x.getValue());
-            }
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription(field = "ingredientMatrix")
-        public EnderRecipeBuilder.Shaped matrix(List<List<IIngredient>> matrix) {
-            this.ingredientMatrix = matrix;
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription(field = "ingredientMatrix")
-        public EnderRecipeBuilder.Shaped shape(List<List<IIngredient>> matrix) {
-            this.ingredientMatrix = matrix;
+        public Shaped time(int time) {
+            this.time = time;
             return this;
         }
 
@@ -170,34 +81,24 @@ public class EnderRecipeBuilder extends CraftingRecipeBuilder {
         }
     }
 
-    public static class Shapeless extends EnderRecipeBuilder {
+    class Shapeless extends AbstractCraftingRecipeBuilder.AbstractShapeless<IRecipe> implements EnderRecipeBuilder {
 
-        @Property(value = "groovyscript.wiki.craftingrecipe.ingredients.value", valid = {@Comp(value = "1", type = Comp.Type.GTE), @Comp(value = "9", type = Comp.Type.LTE)}, priority = 250)
-        private final List<IIngredient> ingredients = new ArrayList<>();
+        @Property(defaultValue = "ModConfig.confEnderTimeRequired", valid = @Comp(value = "0", type = Comp.Type.GTE))
+        protected int time = ModConfig.confEnderTimeRequired;
 
-        @RecipeBuilderMethodDescription(field = "ingredients")
-        public EnderRecipeBuilder.Shapeless input(IIngredient ingredient) {
-            ingredients.add(ingredient);
-            return this;
+        public Shapeless() {
+            super(3, 3);
         }
 
-        @RecipeBuilderMethodDescription(field = "ingredients")
-        public EnderRecipeBuilder.Shapeless input(IIngredient... ingredients) {
-            if (ingredients != null) {
-                for (IIngredient ingredient : ingredients) {
-                    input(ingredient);
-                }
-            }
-            return this;
+        @Override
+        public String getRecipeNamePrefix() {
+            return "groovyscript_ender_shapeless_";
         }
 
-        @RecipeBuilderMethodDescription(field = "ingredients")
-        public EnderRecipeBuilder.Shapeless input(Collection<IIngredient> ingredients) {
-            if (ingredients != null && !ingredients.isEmpty()) {
-                for (IIngredient ingredient : ingredients) {
-                    input(ingredient);
-                }
-            }
+        @Override
+        @RecipeBuilderMethodDescription
+        public Shapeless time(int time) {
+            this.time = time;
             return this;
         }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/extendedcrafting/TableCrafting.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/extendedcrafting/TableCrafting.java
@@ -45,9 +45,9 @@ public class TableCrafting extends VirtualizedRegistry<ITieredRecipe> {
 
     @MethodDescription(description = "groovyscript.wiki.extendedcrafting.table_crafting.addShaped1", type = MethodDescription.Type.ADDITION)
     public ITieredRecipe addShaped(int tier, ItemStack output, List<List<IIngredient>> input) {
-        return (ITieredRecipe) shapedBuilder()
-                .matrix(input)
+        return shapedBuilder()
                 .tier(tier)
+                .matrix(input)
                 .output(output)
                 .register();
     }
@@ -59,9 +59,9 @@ public class TableCrafting extends VirtualizedRegistry<ITieredRecipe> {
 
     @MethodDescription(description = "groovyscript.wiki.extendedcrafting.table_crafting.addShapeless1", type = MethodDescription.Type.ADDITION)
     public ITieredRecipe addShapeless(int tier, ItemStack output, List<IIngredient> input) {
-        return (ITieredRecipe) shapelessBuilder()
-                .input(input)
+        return shapelessBuilder()
                 .tier(tier)
+                .input(input)
                 .output(output)
                 .register();
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/extendedcrafting/TableRecipeBuilder.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/extendedcrafting/TableRecipeBuilder.java
@@ -1,156 +1,75 @@
 package com.cleanroommc.groovyscript.compat.mods.extendedcrafting;
 
+import com.blakebr0.extendedcrafting.crafting.table.ITieredRecipe;
 import com.blakebr0.extendedcrafting.crafting.table.TableRecipeShaped;
 import com.cleanroommc.groovyscript.api.GroovyLog;
-import com.cleanroommc.groovyscript.api.IIngredient;
 import com.cleanroommc.groovyscript.api.documentation.annotations.Comp;
 import com.cleanroommc.groovyscript.api.documentation.annotations.Property;
 import com.cleanroommc.groovyscript.api.documentation.annotations.RecipeBuilderMethodDescription;
 import com.cleanroommc.groovyscript.api.documentation.annotations.RecipeBuilderRegistrationMethod;
 import com.cleanroommc.groovyscript.compat.mods.ModSupport;
-import com.cleanroommc.groovyscript.compat.vanilla.CraftingRecipeBuilder;
 import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
-import it.unimi.dsi.fastutil.chars.Char2ObjectOpenHashMap;
-import net.minecraft.item.crafting.IRecipe;
-import org.apache.commons.lang3.ArrayUtils;
+import com.cleanroommc.groovyscript.registry.AbstractCraftingRecipeBuilder;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-
-public abstract class TableRecipeBuilder extends CraftingRecipeBuilder {
-
-    // 0 = any table it fits in, 1-4 specifically that tier of table
-    @Property(valid = {@Comp(value = "0", type = Comp.Type.GTE), @Comp(value = "4", type = Comp.Type.LTE)})
-    protected int tier = 0;
-
-    public TableRecipeBuilder() {
-        super(9, 9);
-    }
+public interface TableRecipeBuilder {
 
     @RecipeBuilderMethodDescription
-    public TableRecipeBuilder tier(int tier) {
-        this.tier = tier;
-        int size = this.tier == 0 ? 9 : this.tier * 2 + 1;
-        this.width = size;
-        this.height = size;
-        return this;
-    }
+    TableRecipeBuilder tier(int tier);
 
     @RecipeBuilderMethodDescription(field = "tier")
-    public TableRecipeBuilder tierAny() {
+    default TableRecipeBuilder tierAny() {
         return tier(0);
     }
 
     @RecipeBuilderMethodDescription(field = "tier")
-    public TableRecipeBuilder tierBasic() {
+    default TableRecipeBuilder tierBasic() {
         return tier(1);
     }
 
     @RecipeBuilderMethodDescription(field = "tier")
-    public TableRecipeBuilder tierAdvanced() {
+    default TableRecipeBuilder tierAdvanced() {
         return tier(2);
     }
 
     @RecipeBuilderMethodDescription(field = "tier")
-    public TableRecipeBuilder tierElite() {
+    default TableRecipeBuilder tierElite() {
         return tier(3);
     }
 
     @RecipeBuilderMethodDescription(field = "tier")
-    public TableRecipeBuilder tierUltimate() {
+    default TableRecipeBuilder tierUltimate() {
         return tier(4);
     }
 
-    public static class Shaped extends TableRecipeBuilder {
+    @Property(property = "ingredientMatrix", valid = {@Comp(value = "1", type = Comp.Type.GTE), @Comp(value = "81", type = Comp.Type.LTE)})
+    class Shaped extends AbstractCraftingRecipeBuilder.AbstractShaped<ITieredRecipe> implements TableRecipeBuilder {
 
-        @Property(value = "groovyscript.wiki.craftingrecipe.keyMap.value", defaultValue = "' ' = IIngredient.EMPTY", priority = 200)
-        private final Char2ObjectOpenHashMap<IIngredient> keyMap = new Char2ObjectOpenHashMap<>();
-        private final List<String> errors = new ArrayList<>();
-        @Property("groovyscript.wiki.craftingrecipe.mirrored.value")
-        protected boolean mirrored = false;
-        @Property(value = "groovyscript.wiki.craftingrecipe.keyBasedMatrix.value", requirement = "groovyscript.wiki.craftingrecipe.matrix.required", priority = 210)
-        private String[] keyBasedMatrix;
-        @Property(value = "groovyscript.wiki.craftingrecipe.ingredientMatrix.value", requirement = "groovyscript.wiki.craftingrecipe.matrix.required", valid = {@Comp(value = "1", type = Comp.Type.GTE), @Comp(value = "81", type = Comp.Type.LTE)}, priority = 250)
-        private List<List<IIngredient>> ingredientMatrix;
+        // 0 = any table it fits in, 1-4 specifically that tier of table
+        @Property(valid = {@Comp(value = "0", type = Comp.Type.GTE), @Comp(value = "4", type = Comp.Type.LTE)})
+        int tier;
 
         public Shaped() {
-            keyMap.put(' ', IIngredient.EMPTY);
+            super(9, 9);
         }
 
+        @Override
+        public String getRecipeNamePrefix() {
+            return "groovyscript_table_shaped_";
+        }
+
+        @Override
         @RecipeBuilderMethodDescription
-        public TableRecipeBuilder.Shaped mirrored(boolean mirrored) {
-            this.mirrored = mirrored;
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription
-        public TableRecipeBuilder.Shaped mirrored() {
-            return mirrored(true);
-        }
-
-        @RecipeBuilderMethodDescription(field = "keyBasedMatrix")
-        public TableRecipeBuilder.Shaped matrix(String... matrix) {
-            this.keyBasedMatrix = matrix;
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription(field = "keyBasedMatrix")
-        public TableRecipeBuilder.Shaped shape(String... matrix) {
-            this.keyBasedMatrix = matrix;
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription(field = "keyBasedMatrix")
-        public TableRecipeBuilder.Shaped row(String row) {
-            if (this.keyBasedMatrix == null) {
-                this.keyBasedMatrix = new String[]{row};
-            } else {
-                this.keyBasedMatrix = ArrayUtils.add(this.keyBasedMatrix, row);
-            }
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription(field = "keyMap")
-        public TableRecipeBuilder.Shaped key(char c, IIngredient ingredient) {
-            this.keyMap.put(c, ingredient);
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription(field = "keyMap")
-        public TableRecipeBuilder.Shaped key(String c, IIngredient ingredient) {
-            if (c == null || c.length() != 1) {
-                errors.add("key must be a single char, but found '" + c + "'");
-                return this;
-            }
-            this.keyMap.put(c.charAt(0), ingredient);
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription(field = "keyMap")
-        public TableRecipeBuilder.Shaped key(Map<String, IIngredient> map) {
-            for (Map.Entry<String, IIngredient> x : map.entrySet()) {
-                key(x.getKey(), x.getValue());
-            }
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription(field = "ingredientMatrix")
-        public TableRecipeBuilder.Shaped matrix(List<List<IIngredient>> matrix) {
-            this.ingredientMatrix = matrix;
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription(field = "ingredientMatrix")
-        public TableRecipeBuilder.Shaped shape(List<List<IIngredient>> matrix) {
-            this.ingredientMatrix = matrix;
+        public TableRecipeBuilder.Shaped tier(int tier) {
+            this.tier = tier;
+            int size = this.tier == 0 ? 9 : this.tier * 2 + 1;
+            this.width = size;
+            this.height = size;
             return this;
         }
 
         @Override
         @RecipeBuilderRegistrationMethod
-        public IRecipe register() {
+        public ITieredRecipe register() {
             GroovyLog.Msg msg = GroovyLog.msg("Error adding shaped Extended Crafting Table recipe").error()
                     .add((keyBasedMatrix == null || keyBasedMatrix.length == 0) && (ingredientMatrix == null || ingredientMatrix.isEmpty()), () -> "No matrix was defined")
                     .add(keyBasedMatrix != null && ingredientMatrix != null, () -> "A key based matrix AND a ingredient based matrix was defined. This is not allowed!");
@@ -170,34 +89,29 @@ public abstract class TableRecipeBuilder extends CraftingRecipeBuilder {
         }
     }
 
-    public static class Shapeless extends TableRecipeBuilder {
+    @Property(property = "ingredients", valid = {@Comp(value = "1", type = Comp.Type.GTE), @Comp(value = "81", type = Comp.Type.LTE)})
+    class Shapeless extends AbstractCraftingRecipeBuilder.AbstractShapeless<ITieredRecipe> implements TableRecipeBuilder {
 
-        @Property(value = "groovyscript.wiki.craftingrecipe.ingredients.value", valid = {@Comp(value = "1", type = Comp.Type.GTE), @Comp(value = "81", type = Comp.Type.LTE)}, priority = 250)
-        private final List<IIngredient> ingredients = new ArrayList<>();
+        // 0 = any table it fits in, 1-4 specifically that tier of table
+        @Property(valid = {@Comp(value = "0", type = Comp.Type.GTE), @Comp(value = "4", type = Comp.Type.LTE)})
+        int tier;
 
-        @RecipeBuilderMethodDescription(field = "ingredients")
-        public TableRecipeBuilder.Shapeless input(IIngredient ingredient) {
-            ingredients.add(ingredient);
-            return this;
+        public Shapeless() {
+            super(9, 9);
         }
 
-        @RecipeBuilderMethodDescription(field = "ingredients")
-        public TableRecipeBuilder.Shapeless input(IIngredient... ingredients) {
-            if (ingredients != null) {
-                for (IIngredient ingredient : ingredients) {
-                    input(ingredient);
-                }
-            }
-            return this;
+        @Override
+        public String getRecipeNamePrefix() {
+            return "groovyscript_table_shapeless_";
         }
 
-        @RecipeBuilderMethodDescription(field = "ingredients")
-        public TableRecipeBuilder.Shapeless input(Collection<IIngredient> ingredients) {
-            if (ingredients != null && !ingredients.isEmpty()) {
-                for (IIngredient ingredient : ingredients) {
-                    input(ingredient);
-                }
-            }
+        @Override
+        @RecipeBuilderMethodDescription
+        public TableRecipeBuilder.Shapeless tier(int tier) {
+            this.tier = tier;
+            int size = this.tier == 0 ? 9 : this.tier * 2 + 1;
+            this.width = size;
+            this.height = size;
             return this;
         }
 
@@ -212,7 +126,7 @@ public abstract class TableRecipeBuilder extends CraftingRecipeBuilder {
 
         @Override
         @RecipeBuilderRegistrationMethod
-        public IRecipe register() {
+        public ITieredRecipe register() {
             if (!validate()) return null;
             ShapelessTableRecipe recipe = ShapelessTableRecipe.make(tier, output.copy(), ingredients, recipeFunction, recipeAction);
             ModSupport.EXTENDED_CRAFTING.get().tableCrafting.add(recipe);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/arcane/ArcaneRecipeBuilder.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/arcane/ArcaneRecipeBuilder.java
@@ -1,160 +1,74 @@
 package com.cleanroommc.groovyscript.compat.mods.thaumcraft.arcane;
 
 import com.cleanroommc.groovyscript.api.GroovyLog;
-import com.cleanroommc.groovyscript.api.IIngredient;
-import com.cleanroommc.groovyscript.api.documentation.annotations.Comp;
 import com.cleanroommc.groovyscript.api.documentation.annotations.Property;
 import com.cleanroommc.groovyscript.api.documentation.annotations.RecipeBuilderMethodDescription;
 import com.cleanroommc.groovyscript.api.documentation.annotations.RecipeBuilderRegistrationMethod;
 import com.cleanroommc.groovyscript.compat.mods.thaumcraft.Thaumcraft;
 import com.cleanroommc.groovyscript.compat.mods.thaumcraft.aspect.AspectStack;
-import com.cleanroommc.groovyscript.compat.vanilla.CraftingRecipeBuilder;
 import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
+import com.cleanroommc.groovyscript.registry.AbstractCraftingRecipeBuilder;
 import com.cleanroommc.groovyscript.registry.ReloadableRegistryManager;
-import it.unimi.dsi.fastutil.chars.Char2ObjectOpenHashMap;
 import net.minecraft.item.crafting.IRecipe;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
-import org.apache.commons.lang3.ArrayUtils;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-
-public abstract class ArcaneRecipeBuilder extends CraftingRecipeBuilder {
-
-    @Property
-    protected String researchKey;
-    @Property(requirement = "groovyscript.wiki.thaumcraft.arcane_workbench.aspects.required")
-    protected final AspectList aspects = new AspectList();
-    @Property
-    protected int vis;
-
-    public ArcaneRecipeBuilder() {
-        super(3, 3);
-    }
+public interface ArcaneRecipeBuilder {
 
     @RecipeBuilderMethodDescription
-    public ArcaneRecipeBuilder researchKey(String researchKey) {
-        this.researchKey = researchKey;
-        return this;
-    }
+    ArcaneRecipeBuilder researchKey(String researchKey);
 
     @RecipeBuilderMethodDescription(field = "aspects")
-    public ArcaneRecipeBuilder aspect(AspectStack aspect) {
-        this.aspects.add(aspect.getAspect(), aspect.getAmount());
-        return this;
-    }
+    ArcaneRecipeBuilder aspect(AspectStack aspect);
 
     @RecipeBuilderMethodDescription(field = "aspects")
-    public ArcaneRecipeBuilder aspect(String tag) {
+    default ArcaneRecipeBuilder aspect(String tag) {
         return aspect(tag, 1);
     }
 
     @RecipeBuilderMethodDescription(field = "aspects")
-    public ArcaneRecipeBuilder aspect(String tag, int amount) {
+    default ArcaneRecipeBuilder aspect(String tag, int amount) {
         Aspect a = Thaumcraft.validateAspect(tag);
-        if (a != null) this.aspects.add(a, amount);
+        if (a != null) aspect(new AspectStack(a, amount));
         return this;
     }
 
     @RecipeBuilderMethodDescription
-    public ArcaneRecipeBuilder vis(int vis) {
-        this.vis = vis;
-        return this;
-    }
+    ArcaneRecipeBuilder vis(int vis);
 
-    protected void validateArcane(GroovyLog.Msg msg) {
-        if (researchKey == null) researchKey = "";
-    }
+    @Property(property = "replace")
+    class Shaped extends AbstractCraftingRecipeBuilder.AbstractShaped<IRecipe> implements ArcaneRecipeBuilder {
 
-    public static class Shaped extends ArcaneRecipeBuilder {
-
-        @Property("groovyscript.wiki.craftingrecipe.mirrored.value")
-        protected boolean mirrored = false;
-        @Property(value = "groovyscript.wiki.craftingrecipe.keyBasedMatrix.value", requirement = "groovyscript.wiki.craftingrecipe.matrix.required", priority = 200)
-        private String[] keyBasedMatrix;
-        @Property(value = "groovyscript.wiki.craftingrecipe.keyMap.value", defaultValue = "' ' = IIngredient.EMPTY", priority = 210)
-        private final Char2ObjectOpenHashMap<IIngredient> keyMap = new Char2ObjectOpenHashMap<>();
-
-        @Property(value = "groovyscript.wiki.craftingrecipe.ingredientMatrix.value", requirement = "groovyscript.wiki.craftingrecipe.matrix.required", valid = {@Comp(value = "1", type = Comp.Type.GTE), @Comp(value = "9", type = Comp.Type.LTE)}, priority = 200)
-        private List<List<IIngredient>> ingredientMatrix;
-
-        private final List<String> errors = new ArrayList<>();
+        @Property(requirement = "groovyscript.wiki.thaumcraft.arcane_workbench.aspects.required")
+        protected final AspectList aspects = new AspectList();
+        @Property
+        protected String researchKey = "";
+        @Property
+        protected int vis;
 
         public Shaped() {
-            keyMap.put(' ', IIngredient.EMPTY);
+            super(3, 3);
         }
 
+        @Override
         @RecipeBuilderMethodDescription
-        public ArcaneRecipeBuilder.Shaped mirrored(boolean mirrored) {
-            this.mirrored = mirrored;
+        public ArcaneRecipeBuilder researchKey(String researchKey) {
+            this.researchKey = researchKey;
             return this;
         }
 
+        @Override
+        @RecipeBuilderMethodDescription(field = "aspects")
+        public ArcaneRecipeBuilder aspect(AspectStack aspect) {
+            this.aspects.add(aspect.getAspect(), aspect.getAmount());
+            return this;
+        }
+
+        @Override
         @RecipeBuilderMethodDescription
-        public ArcaneRecipeBuilder.Shaped mirrored() {
-            return mirrored(true);
-        }
-
-        @RecipeBuilderMethodDescription(field = "keyBasedMatrix")
-        public ArcaneRecipeBuilder.Shaped matrix(String... matrix) {
-            this.keyBasedMatrix = matrix;
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription(field = "keyBasedMatrix")
-        public ArcaneRecipeBuilder.Shaped shape(String... matrix) {
-            this.keyBasedMatrix = matrix;
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription(field = "keyBasedMatrix")
-        public ArcaneRecipeBuilder.Shaped row(String row) {
-            if (this.keyBasedMatrix == null) {
-                this.keyBasedMatrix = new String[]{row};
-            } else {
-                this.keyBasedMatrix = ArrayUtils.add(this.keyBasedMatrix, row);
-            }
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription(field = "keyMap")
-        public ArcaneRecipeBuilder.Shaped key(char c, IIngredient ingredient) {
-            this.keyMap.put(c, ingredient);
-            return this;
-        }
-
-        // groovy doesn't have char literals
-        @RecipeBuilderMethodDescription(field = "keyMap")
-        public ArcaneRecipeBuilder.Shaped key(String c, IIngredient ingredient) {
-            if (c == null || c.length() != 1) {
-                errors.add("key must be a single char, but found '" + c + "'");
-                return this;
-            }
-            this.keyMap.put(c.charAt(0), ingredient);
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription(field = "keyMap")
-        public ArcaneRecipeBuilder.Shaped key(Map<String, IIngredient> map) {
-            for (Map.Entry<String, IIngredient> x : map.entrySet()) {
-                key(x.getKey(), x.getValue());
-            }
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription(field = "ingredientMatrix")
-        public ArcaneRecipeBuilder.Shaped matrix(List<List<IIngredient>> matrix) {
-            this.ingredientMatrix = matrix;
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription(field = "ingredientMatrix")
-        public ArcaneRecipeBuilder.Shaped shape(List<List<IIngredient>> matrix) {
-            this.ingredientMatrix = matrix;
+        public ArcaneRecipeBuilder vis(int vis) {
+            this.vis = vis;
             return this;
         }
 
@@ -169,7 +83,6 @@ public abstract class ArcaneRecipeBuilder extends CraftingRecipeBuilder {
             GroovyLog.Msg msg = GroovyLog.msg("Error creating Thaumcraft Arcane Workbench recipe").error()
                     .add((keyBasedMatrix == null || keyBasedMatrix.length == 0) && (ingredientMatrix == null || ingredientMatrix.isEmpty()), () -> "No matrix was defined")
                     .add(keyBasedMatrix != null && ingredientMatrix != null, () -> "A key based matrix AND a ingredient based matrix was defined. This is not allowed!");
-            validateArcane(msg);
             if (msg.postIfNotEmpty()) return null;
             msg.add(IngredientHelper.isEmpty(this.output), () -> "Output must not be empty");
 
@@ -190,30 +103,39 @@ public abstract class ArcaneRecipeBuilder extends CraftingRecipeBuilder {
         }
     }
 
-    public static class Shapeless extends ArcaneRecipeBuilder {
+    @Property(property = "replace")
+    class Shapeless extends AbstractCraftingRecipeBuilder.AbstractShapeless<IRecipe> implements ArcaneRecipeBuilder {
 
-        @Property(value = "groovyscript.wiki.craftingrecipe.ingredients.value", valid = {@Comp(value = "1", type = Comp.Type.GTE), @Comp(value = "9", type = Comp.Type.LTE)}, priority = 250, hierarchy = 20)
-        private final List<IIngredient> ingredients = new ArrayList<>();
 
-        @RecipeBuilderMethodDescription(field = "ingredients")
-        public ArcaneRecipeBuilder.Shapeless input(IIngredient ingredient) {
-            ingredients.add(ingredient);
+        @Property(requirement = "groovyscript.wiki.thaumcraft.arcane_workbench.aspects.required")
+        protected final AspectList aspects = new AspectList();
+        @Property
+        protected String researchKey = "";
+        @Property
+        protected int vis;
+
+        public Shapeless() {
+            super(3, 3);
+        }
+
+        @Override
+        @RecipeBuilderMethodDescription
+        public ArcaneRecipeBuilder researchKey(String researchKey) {
+            this.researchKey = researchKey;
             return this;
         }
 
-        @RecipeBuilderMethodDescription(field = "ingredients")
-        public ArcaneRecipeBuilder.Shapeless input(IIngredient... ingredients) {
-            if (ingredients != null)
-                for (IIngredient ingredient : ingredients)
-                    input(ingredient);
+        @Override
+        @RecipeBuilderMethodDescription(field = "aspects")
+        public ArcaneRecipeBuilder aspect(AspectStack aspect) {
+            this.aspects.add(aspect.getAspect(), aspect.getAmount());
             return this;
         }
 
-        @RecipeBuilderMethodDescription(field = "ingredients")
-        public ArcaneRecipeBuilder.Shapeless input(Collection<IIngredient> ingredients) {
-            if (ingredients != null && !ingredients.isEmpty())
-                for (IIngredient ingredient : ingredients)
-                    input(ingredient);
+        @Override
+        @RecipeBuilderMethodDescription
+        public ArcaneRecipeBuilder vis(int vis) {
+            this.vis = vis;
             return this;
         }
 
@@ -231,7 +153,6 @@ public abstract class ArcaneRecipeBuilder extends CraftingRecipeBuilder {
                     .add(ingredients.isEmpty(), () -> "inputs must not be empty")
                     .add(ingredients.size() > width * height, () -> "maximum inputs are " + (width * height) + " but found " + ingredients.size())
                     .error();
-            validateArcane(msg);
             if (msg.postIfNotEmpty()) {
                 return null;
             }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/Crafting.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/Crafting.java
@@ -207,10 +207,10 @@ public class Crafting extends ForgeRegistryWrapper<IRecipe> {
     }
 
     public CraftingRecipeBuilder.Shaped shapedBuilder() {
-        return new CraftingRecipeBuilder.Shaped(3, 3);
+        return new CraftingRecipeBuilder.Shaped();
     }
 
     public CraftingRecipeBuilder.Shapeless shapelessBuilder() {
-        return new CraftingRecipeBuilder.Shapeless(3, 3);
+        return new CraftingRecipeBuilder.Shapeless();
     }
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/CraftingRecipeBuilder.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/CraftingRecipeBuilder.java
@@ -1,216 +1,21 @@
 package com.cleanroommc.groovyscript.compat.vanilla;
 
-import com.cleanroommc.groovyscript.GroovyScript;
-import com.cleanroommc.groovyscript.api.GroovyBlacklist;
 import com.cleanroommc.groovyscript.api.GroovyLog;
-import com.cleanroommc.groovyscript.api.IIngredient;
-import com.cleanroommc.groovyscript.api.documentation.annotations.Comp;
 import com.cleanroommc.groovyscript.api.documentation.annotations.Property;
-import com.cleanroommc.groovyscript.api.documentation.annotations.RecipeBuilderMethodDescription;
 import com.cleanroommc.groovyscript.api.documentation.annotations.RecipeBuilderRegistrationMethod;
 import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
-import com.cleanroommc.groovyscript.helper.recipe.RecipeName;
+import com.cleanroommc.groovyscript.registry.AbstractCraftingRecipeBuilder;
 import com.cleanroommc.groovyscript.registry.ReloadableRegistryManager;
-import groovy.lang.Closure;
-import it.unimi.dsi.fastutil.chars.Char2ObjectMap;
-import it.unimi.dsi.fastutil.chars.Char2ObjectOpenHashMap;
-import it.unimi.dsi.fastutil.chars.CharOpenHashSet;
-import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.IRecipe;
-import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
-import org.apache.commons.lang3.ArrayUtils;
-import org.jetbrains.annotations.Nullable;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
 
 public abstract class CraftingRecipeBuilder {
 
-    @Property(value = "groovyscript.wiki.craftingrecipe.output.value", valid = @Comp(value = "null", type = Comp.Type.NOT), priority = 700, hierarchy = 20)
-    protected ItemStack output;
-    @Property(value = "groovyscript.wiki.name.value", priority = 100, hierarchy = 20)
-    protected ResourceLocation name;
-    @Property(value = "groovyscript.wiki.craftingrecipe.recipeFunction.value", priority = 1500, hierarchy = 20)
-    protected Closure<ItemStack> recipeFunction;
-    @Property(value = "groovyscript.wiki.craftingrecipe.recipeAction.value", priority = 1550, hierarchy = 20)
-    protected Closure<Void> recipeAction;
-    @Property(value = "groovyscript.wiki.craftingrecipe.replace.value", hierarchy = 20)
-    protected byte replace = 0;
+    @Property(property = "replace")
+    public static class Shaped extends AbstractCraftingRecipeBuilder.AbstractShaped<IRecipe> {
 
-    protected int width, height;
-
-    public CraftingRecipeBuilder(int width, int height) {
-        this.width = width;
-        this.height = height;
-    }
-
-    @RecipeBuilderMethodDescription
-    public CraftingRecipeBuilder name(String name) {
-        if (name.contains(":")) {
-            this.name = new ResourceLocation(name);
-        } else {
-            this.name = new ResourceLocation(GroovyScript.getRunConfig().getPackId(), name);
-        }
-        return this;
-    }
-
-    @RecipeBuilderMethodDescription
-    public CraftingRecipeBuilder name(ResourceLocation name) {
-        this.name = name;
-        return this;
-    }
-
-    @RecipeBuilderMethodDescription
-    public CraftingRecipeBuilder output(ItemStack item) {
-        this.output = item;
-        return this;
-    }
-
-    @RecipeBuilderMethodDescription
-    public CraftingRecipeBuilder recipeFunction(Closure<ItemStack> recipeFunction) {
-        this.recipeFunction = recipeFunction;
-        return this;
-    }
-
-    @RecipeBuilderMethodDescription
-    public CraftingRecipeBuilder recipeAction(Closure<Void> recipeAction) {
-        this.recipeAction = recipeAction;
-        return this;
-    }
-
-    @RecipeBuilderMethodDescription
-    public CraftingRecipeBuilder replace() {
-        this.replace = 1;
-        return this;
-    }
-
-    @RecipeBuilderMethodDescription
-    public CraftingRecipeBuilder replaceByName() {
-        this.replace = 2;
-        return this;
-    }
-
-    @RecipeBuilderRegistrationMethod
-    public abstract Object register();
-
-    @GroovyBlacklist
-    protected void handleReplace() {
-        if (replace == 1) {
-            VanillaModule.crafting.removeByOutput(IngredientHelper.toIIngredient(output), false);
-        } else if (replace == 2) {
-            if (name == null) {
-                GroovyLog.msg("Error replacing Minecraft Crafting recipe")
-                        .add("Name must not be null when replacing by name")
-                        .error()
-                        .post();
-                return;
-            }
-            ReloadableRegistryManager.removeRegistryEntry(ForgeRegistries.RECIPES, name);
-        }
-    }
-
-    @GroovyBlacklist
-    public String getRecipeNamePrefix() {
-        return "groovyscript_";
-    }
-
-    @GroovyBlacklist
-    public void validateName() {
-        if (name == null) {
-            name = RecipeName.generateRl(getRecipeNamePrefix());
-        }
-    }
-
-    public static class Shaped extends CraftingRecipeBuilder {
-
-        @Property(value = "groovyscript.wiki.craftingrecipe.mirrored.value", hierarchy = 20)
-        protected boolean mirrored = false;
-        @Property(value = "groovyscript.wiki.craftingrecipe.keyBasedMatrix.value", requirement = "groovyscript.wiki.craftingrecipe.matrix.required", priority = 200, hierarchy = 20)
-        protected String[] keyBasedMatrix;
-        @Property(value = "groovyscript.wiki.craftingrecipe.keyMap.value", defaultValue = "' ' = IIngredient.EMPTY", priority = 210, hierarchy = 20)
-        protected final Char2ObjectOpenHashMap<IIngredient> keyMap = new Char2ObjectOpenHashMap<>();
-
-        @Property(value = "groovyscript.wiki.craftingrecipe.ingredientMatrix.value", requirement = "groovyscript.wiki.craftingrecipe.matrix.required", valid = {@Comp(value = "1", type = Comp.Type.GTE), @Comp(value = "9", type = Comp.Type.LTE)}, priority = 200, hierarchy = 20)
-        protected List<List<IIngredient>> ingredientMatrix;
-
-        protected final List<String> errors = new ArrayList<>();
-
-        public Shaped(int width, int height) {
-            super(width, height);
-            keyMap.put(' ', IIngredient.EMPTY);
-        }
-
-        @RecipeBuilderMethodDescription
-        public Shaped mirrored(boolean mirrored) {
-            this.mirrored = mirrored;
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription
-        public Shaped mirrored() {
-            return mirrored(true);
-        }
-
-        @RecipeBuilderMethodDescription(field = "keyBasedMatrix")
-        public Shaped matrix(String... matrix) {
-            this.keyBasedMatrix = matrix;
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription(field = "keyBasedMatrix")
-        public Shaped shape(String... matrix) {
-            this.keyBasedMatrix = matrix;
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription(field = "keyBasedMatrix")
-        public Shaped row(String row) {
-            if (this.keyBasedMatrix == null) {
-                this.keyBasedMatrix = new String[]{row};
-            } else {
-                this.keyBasedMatrix = ArrayUtils.add(this.keyBasedMatrix, row);
-            }
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription(field = "keyMap")
-        public Shaped key(char c, IIngredient ingredient) {
-            this.keyMap.put(c, ingredient);
-            return this;
-        }
-
-        // groovy doesn't have char literals
-        @RecipeBuilderMethodDescription(field = "keyMap")
-        public Shaped key(String c, IIngredient ingredient) {
-            if (c == null || c.length() != 1) {
-                errors.add("key must be a single char, but found '" + c + "'");
-                return this;
-            }
-            this.keyMap.put(c.charAt(0), ingredient);
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription(field = "keyMap")
-        public Shaped key(Map<String, IIngredient> map) {
-            for (Map.Entry<String, IIngredient> x : map.entrySet()) {
-                key(x.getKey(), x.getValue());
-            }
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription(field = "ingredientMatrix")
-        public Shaped matrix(List<List<IIngredient>> matrix) {
-            this.ingredientMatrix = matrix;
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription(field = "ingredientMatrix")
-        public Shaped shape(List<List<IIngredient>> matrix) {
-            this.ingredientMatrix = matrix;
-            return this;
+        public Shaped() {
+            super(3, 3);
         }
 
         @Override
@@ -246,35 +51,11 @@ public abstract class CraftingRecipeBuilder {
         }
     }
 
-    public static class Shapeless extends CraftingRecipeBuilder {
+    @Property(property = "replace")
+    public static class Shapeless extends AbstractCraftingRecipeBuilder.AbstractShapeless<IRecipe> {
 
-        @Property(value = "groovyscript.wiki.craftingrecipe.ingredients.value", valid = {@Comp(value = "1", type = Comp.Type.GTE), @Comp(value = "9", type = Comp.Type.LTE)}, priority = 250, hierarchy = 20)
-        private final List<IIngredient> ingredients = new ArrayList<>();
-
-        public Shapeless(int width, int height) {
-            super(width, height);
-        }
-
-        @RecipeBuilderMethodDescription(field = "ingredients")
-        public Shapeless input(IIngredient ingredient) {
-            ingredients.add(ingredient);
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription(field = "ingredients")
-        public Shapeless input(IIngredient... ingredients) {
-            if (ingredients != null)
-                for (IIngredient ingredient : ingredients)
-                    input(ingredient);
-            return this;
-        }
-
-        @RecipeBuilderMethodDescription(field = "ingredients")
-        public Shapeless input(Collection<IIngredient> ingredients) {
-            if (ingredients != null && !ingredients.isEmpty())
-                for (IIngredient ingredient : ingredients)
-                    input(ingredient);
-            return this;
+        public Shapeless() {
+            super(3, 3);
         }
 
         @Override
@@ -302,92 +83,5 @@ public abstract class CraftingRecipeBuilder {
             ReloadableRegistryManager.addRegistryEntry(ForgeRegistries.RECIPES, name, recipe);
             return recipe;
         }
-    }
-
-    @GroovyBlacklist
-    @Nullable
-    protected <T> T validateShape(GroovyLog.Msg msg, List<String> errors, String[] keyBasedMatrix, Char2ObjectOpenHashMap<IIngredient> keyMap, IRecipeCreator<T> recipeCreator) {
-        List<IIngredient> ingredients = new ArrayList<>();
-        if (keyBasedMatrix.length > height) {
-            msg.add("Defined matrix has %d rows, but should only have %d rows", keyBasedMatrix.length, height);
-        }
-        for (String error : errors) {
-            msg.add(error);
-        }
-        boolean logged = false;
-        int rowWidth = keyBasedMatrix[0].length();
-        CharOpenHashSet checkedChars = new CharOpenHashSet();
-        for (int i = 0, n = Math.min(keyBasedMatrix.length, height); i < n; i++) {
-            String row = keyBasedMatrix[i];
-            if (!logged && row.length() != rowWidth) {
-                logged = true;
-                msg.add("All rows must have the same length!");
-            }
-            rowWidth = Math.max(rowWidth, row.length());
-            for (int j = 0; j < row.length(); j++) {
-                char c = row.charAt(j);
-                IIngredient ingredient = getIngredient(keyMap, c);
-                if (ingredient == null) {
-                    if (!checkedChars.contains(c)) {
-                        msg.add("Key '" + c + "' is not defined!");
-                        checkedChars.add(c);
-                    }
-                    continue;
-                }
-                checkedChars.add(c);
-                ingredients.add(ingredient);
-            }
-        }
-        int finalRowWidth = rowWidth;
-        msg.add(rowWidth > width, () -> "At least one row has a row length of " + finalRowWidth + ", but maximum is " + width);
-        if (checkedChars.isEmpty()) {
-            msg.add("Matrix must not be empty");
-        } else if (checkedChars.size() == 1) {
-            char c = checkedChars.toCharArray()[0];
-            if (!keyMap.containsKey(c) || IngredientHelper.isEmpty(keyMap.get(c))) {
-                msg.add("Matrix only contains empty ingredients!");
-            }
-        }
-        if (msg.postIfNotEmpty()) return null;
-        return recipeCreator.createRecipe(rowWidth, keyBasedMatrix.length, ingredients);
-    }
-
-    @GroovyBlacklist
-    @Nullable
-    protected <T> T validateShape(GroovyLog.Msg msg, List<List<IIngredient>> ingredientMatrix, IRecipeCreator<T> recipeCreator) {
-        List<IIngredient> ingredients = new ArrayList<>();
-        if (ingredientMatrix.size() > height) {
-            msg.add("defined matrix has %d rows, but should only have %d rows", ingredientMatrix.size(), height);
-        }
-        boolean logged = false;
-        boolean hasNonEmpty = false;
-        int rowWidth = ingredientMatrix.get(0).size();
-        for (int i = 0, n = Math.min(ingredientMatrix.size(), height); i < n; i++) {
-            List<IIngredient> row = ingredientMatrix.get(i);
-            if (!logged && row.size() != rowWidth) {
-                logged = true;
-                msg.add("All rows must have the same length!");
-            }
-            rowWidth = Math.max(rowWidth, row.size());
-            for (IIngredient ingredient : row) {
-                hasNonEmpty |= !IngredientHelper.isEmpty(ingredient);
-                ingredients.add(ingredient);
-            }
-        }
-        msg.add(!hasNonEmpty, () -> "Matrix must not be empty");
-        if (msg.postIfNotEmpty()) return null;
-        return recipeCreator.createRecipe(rowWidth, ingredientMatrix.size(), ingredients);
-    }
-
-    private static IIngredient getIngredient(Char2ObjectMap<IIngredient> keyMap, char c) {
-        if (keyMap.containsKey(c)) {
-            return keyMap.get(c);
-        }
-        return Crafting.getFallback(c);
-    }
-
-    public interface IRecipeCreator<T> {
-
-        T createRecipe(int width, int height, List<IIngredient> ingredients);
     }
 }

--- a/src/main/java/com/cleanroommc/groovyscript/registry/AbstractCraftingRecipeBuilder.java
+++ b/src/main/java/com/cleanroommc/groovyscript/registry/AbstractCraftingRecipeBuilder.java
@@ -1,0 +1,336 @@
+package com.cleanroommc.groovyscript.registry;
+
+import com.cleanroommc.groovyscript.GroovyScript;
+import com.cleanroommc.groovyscript.api.GroovyBlacklist;
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.Comp;
+import com.cleanroommc.groovyscript.api.documentation.annotations.Property;
+import com.cleanroommc.groovyscript.api.documentation.annotations.RecipeBuilderMethodDescription;
+import com.cleanroommc.groovyscript.api.documentation.annotations.RecipeBuilderRegistrationMethod;
+import com.cleanroommc.groovyscript.compat.vanilla.Crafting;
+import com.cleanroommc.groovyscript.compat.vanilla.VanillaModule;
+import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
+import com.cleanroommc.groovyscript.helper.recipe.RecipeName;
+import groovy.lang.Closure;
+import it.unimi.dsi.fastutil.chars.Char2ObjectMap;
+import it.unimi.dsi.fastutil.chars.Char2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.chars.CharOpenHashSet;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.common.registry.ForgeRegistries;
+import org.apache.commons.lang3.ArrayUtils;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+public abstract class AbstractCraftingRecipeBuilder<R> {
+
+    @Property(value = "groovyscript.wiki.craftingrecipe.output.value", valid = @Comp(value = "null", type = Comp.Type.NOT), priority = 700, hierarchy = 20)
+    protected ItemStack output;
+    @Property(value = "groovyscript.wiki.name.value", priority = 100, hierarchy = 20)
+    protected ResourceLocation name;
+    @Property(value = "groovyscript.wiki.craftingrecipe.recipeFunction.value", priority = 1500, hierarchy = 20)
+    protected Closure<ItemStack> recipeFunction;
+    @Property(value = "groovyscript.wiki.craftingrecipe.recipeAction.value", priority = 1550, hierarchy = 20)
+    protected Closure<Void> recipeAction;
+    @Property(value = "groovyscript.wiki.craftingrecipe.replace.value", needsOverride = true, hierarchy = 20)
+    protected byte replace;
+
+    protected int width;
+    protected int height;
+
+    public AbstractCraftingRecipeBuilder(int width, int height) {
+        this.width = width;
+        this.height = height;
+    }
+
+    private static IIngredient getIngredient(Char2ObjectMap<IIngredient> keyMap, char c) {
+        if (keyMap.containsKey(c)) {
+            return keyMap.get(c);
+        }
+        return Crafting.getFallback(c);
+    }
+
+    @RecipeBuilderMethodDescription
+    public AbstractCraftingRecipeBuilder<R> name(String name) {
+        if (name.contains(":")) {
+            this.name = new ResourceLocation(name);
+        } else {
+            this.name = new ResourceLocation(GroovyScript.getRunConfig().getPackId(), name);
+        }
+        return this;
+    }
+
+    @RecipeBuilderMethodDescription
+    public AbstractCraftingRecipeBuilder<R> name(ResourceLocation name) {
+        this.name = name;
+        return this;
+    }
+
+    @RecipeBuilderMethodDescription
+    public AbstractCraftingRecipeBuilder<R> output(ItemStack item) {
+        this.output = item;
+        return this;
+    }
+
+    @RecipeBuilderMethodDescription
+    public AbstractCraftingRecipeBuilder<R> recipeFunction(Closure<ItemStack> recipeFunction) {
+        this.recipeFunction = recipeFunction;
+        return this;
+    }
+
+    @RecipeBuilderMethodDescription
+    public AbstractCraftingRecipeBuilder<R> recipeAction(Closure<Void> recipeAction) {
+        this.recipeAction = recipeAction;
+        return this;
+    }
+
+    @RecipeBuilderMethodDescription
+    public AbstractCraftingRecipeBuilder<R> replace() {
+        this.replace = 1;
+        return this;
+    }
+
+    @RecipeBuilderMethodDescription
+    public AbstractCraftingRecipeBuilder<R> replaceByName() {
+        this.replace = 2;
+        return this;
+    }
+
+    @RecipeBuilderRegistrationMethod
+    public abstract R register();
+
+    @GroovyBlacklist
+    protected void handleReplace() {
+        if (replace == 1) {
+            VanillaModule.crafting.removeByOutput(IngredientHelper.toIIngredient(output), false);
+        } else if (replace == 2) {
+            if (name == null) {
+                GroovyLog.msg("Error replacing Minecraft Crafting recipe")
+                        .add("Name must not be null when replacing by name")
+                        .error()
+                        .post();
+                return;
+            }
+            ReloadableRegistryManager.removeRegistryEntry(ForgeRegistries.RECIPES, name);
+        }
+    }
+
+    @GroovyBlacklist
+    public String getRecipeNamePrefix() {
+        return "groovyscript_";
+    }
+
+    @GroovyBlacklist
+    public void validateName() {
+        if (name == null) {
+            name = RecipeName.generateRl(getRecipeNamePrefix());
+        }
+    }
+
+    @GroovyBlacklist
+    @Nullable
+    protected <T> T validateShape(GroovyLog.Msg msg, List<String> errors, String[] keyBasedMatrix, Char2ObjectOpenHashMap<IIngredient> keyMap, IRecipeCreator<T> recipeCreator) {
+        List<IIngredient> ingredients = new ArrayList<>();
+        if (keyBasedMatrix.length > height) {
+            msg.add("Defined matrix has %d rows, but should only have %d rows", keyBasedMatrix.length, height);
+        }
+        for (String error : errors) {
+            msg.add(error);
+        }
+        boolean logged = false;
+        int rowWidth = keyBasedMatrix[0].length();
+        CharOpenHashSet checkedChars = new CharOpenHashSet();
+        for (int i = 0, n = Math.min(keyBasedMatrix.length, height); i < n; i++) {
+            String row = keyBasedMatrix[i];
+            if (!logged && row.length() != rowWidth) {
+                logged = true;
+                msg.add("All rows must have the same length!");
+            }
+            rowWidth = Math.max(rowWidth, row.length());
+            for (int j = 0; j < row.length(); j++) {
+                char c = row.charAt(j);
+                IIngredient ingredient = getIngredient(keyMap, c);
+                if (ingredient == null) {
+                    if (!checkedChars.contains(c)) {
+                        msg.add("Key '" + c + "' is not defined!");
+                        checkedChars.add(c);
+                    }
+                    continue;
+                }
+                checkedChars.add(c);
+                ingredients.add(ingredient);
+            }
+        }
+        int finalRowWidth = rowWidth;
+        msg.add(rowWidth > width, () -> "At least one row has a row length of " + finalRowWidth + ", but maximum is " + width);
+        if (checkedChars.isEmpty()) {
+            msg.add("Matrix must not be empty");
+        } else if (checkedChars.size() == 1) {
+            char c = checkedChars.toCharArray()[0];
+            if (!keyMap.containsKey(c) || IngredientHelper.isEmpty(keyMap.get(c))) {
+                msg.add("Matrix only contains empty ingredients!");
+            }
+        }
+        if (msg.postIfNotEmpty()) return null;
+        return recipeCreator.createRecipe(rowWidth, keyBasedMatrix.length, ingredients);
+    }
+
+    @GroovyBlacklist
+    @Nullable
+    protected <T> T validateShape(GroovyLog.Msg msg, List<List<IIngredient>> ingredientMatrix, IRecipeCreator<T> recipeCreator) {
+        List<IIngredient> ingredients = new ArrayList<>();
+        if (ingredientMatrix.size() > height) {
+            msg.add("defined matrix has %d rows, but should only have %d rows", ingredientMatrix.size(), height);
+        }
+        boolean logged = false;
+        boolean hasNonEmpty = false;
+        int rowWidth = ingredientMatrix.get(0).size();
+        for (int i = 0, n = Math.min(ingredientMatrix.size(), height); i < n; i++) {
+            List<IIngredient> row = ingredientMatrix.get(i);
+            if (!logged && row.size() != rowWidth) {
+                logged = true;
+                msg.add("All rows must have the same length!");
+            }
+            rowWidth = Math.max(rowWidth, row.size());
+            for (IIngredient ingredient : row) {
+                hasNonEmpty |= !IngredientHelper.isEmpty(ingredient);
+                ingredients.add(ingredient);
+            }
+        }
+        msg.add(!hasNonEmpty, () -> "Matrix must not be empty");
+        if (msg.postIfNotEmpty()) return null;
+        return recipeCreator.createRecipe(rowWidth, ingredientMatrix.size(), ingredients);
+    }
+
+    public interface IRecipeCreator<T> {
+
+        T createRecipe(int width, int height, List<IIngredient> ingredients);
+    }
+
+    public abstract static class AbstractShaped<T> extends AbstractCraftingRecipeBuilder<T> {
+
+        @Property(value = "groovyscript.wiki.craftingrecipe.keyMap.value", defaultValue = "' ' = IIngredient.EMPTY", priority = 210, hierarchy = 20)
+        protected final Char2ObjectOpenHashMap<IIngredient> keyMap = new Char2ObjectOpenHashMap<>();
+        protected final List<String> errors = new ArrayList<>();
+        @Property(value = "groovyscript.wiki.craftingrecipe.mirrored.value", hierarchy = 20)
+        protected boolean mirrored;
+        @Property(value = "groovyscript.wiki.craftingrecipe.keyBasedMatrix.value", requirement = "groovyscript.wiki.craftingrecipe.matrix.required", priority = 200, hierarchy = 20)
+        protected String[] keyBasedMatrix;
+        @Property(value = "groovyscript.wiki.craftingrecipe.ingredientMatrix.value", requirement = "groovyscript.wiki.craftingrecipe.matrix.required", valid = {
+                @Comp(value = "1", type = Comp.Type.GTE), @Comp(value = "9", type = Comp.Type.LTE)}, priority = 200, hierarchy = 20)
+        protected List<List<IIngredient>> ingredientMatrix;
+
+        public AbstractShaped(int width, int height) {
+            super(width, height);
+            keyMap.put(' ', IIngredient.EMPTY);
+        }
+
+        @RecipeBuilderMethodDescription
+        public AbstractShaped<T> mirrored(boolean mirrored) {
+            this.mirrored = mirrored;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public AbstractShaped<T> mirrored() {
+            return mirrored(true);
+        }
+
+        @RecipeBuilderMethodDescription(field = "keyBasedMatrix")
+        public AbstractShaped<T> matrix(String... matrix) {
+            this.keyBasedMatrix = matrix;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription(field = "keyBasedMatrix")
+        public AbstractShaped<T> shape(String... matrix) {
+            this.keyBasedMatrix = matrix;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription(field = "keyBasedMatrix")
+        public AbstractShaped<T> row(String row) {
+            if (this.keyBasedMatrix == null) {
+                this.keyBasedMatrix = new String[]{row};
+            } else {
+                this.keyBasedMatrix = ArrayUtils.add(this.keyBasedMatrix, row);
+            }
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription(field = "keyMap")
+        public AbstractShaped<T> key(char c, IIngredient ingredient) {
+            this.keyMap.put(c, ingredient);
+            return this;
+        }
+
+        // groovy doesn't have char literals
+        @RecipeBuilderMethodDescription(field = "keyMap")
+        public AbstractShaped<T> key(String c, IIngredient ingredient) {
+            if (c == null || c.length() != 1) {
+                errors.add("key must be a single char, but found '" + c + "'");
+                return this;
+            }
+            this.keyMap.put(c.charAt(0), ingredient);
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription(field = "keyMap")
+        public AbstractShaped<T> key(Map<String, IIngredient> map) {
+            for (Map.Entry<String, IIngredient> x : map.entrySet()) {
+                key(x.getKey(), x.getValue());
+            }
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription(field = "ingredientMatrix")
+        public AbstractShaped<T> matrix(List<List<IIngredient>> matrix) {
+            this.ingredientMatrix = matrix;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription(field = "ingredientMatrix")
+        public AbstractShaped<T> shape(List<List<IIngredient>> matrix) {
+            this.ingredientMatrix = matrix;
+            return this;
+        }
+    }
+
+    public abstract static class AbstractShapeless<T> extends AbstractCraftingRecipeBuilder<T> {
+
+        @Property(value = "groovyscript.wiki.craftingrecipe.ingredients.value",
+                  valid = {@Comp(value = "1", type = Comp.Type.GTE), @Comp(value = "9", type = Comp.Type.LTE)}, priority = 250, hierarchy = 20)
+        protected final List<IIngredient> ingredients = new ArrayList<>();
+
+        public AbstractShapeless(int width, int height) {
+            super(width, height);
+        }
+
+        @RecipeBuilderMethodDescription(field = "ingredients")
+        public AbstractShapeless<T> input(IIngredient ingredient) {
+            ingredients.add(ingredient);
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription(field = "ingredients")
+        public AbstractShapeless<T> input(IIngredient... ingredients) {
+            if (ingredients != null)
+                for (IIngredient ingredient : ingredients)
+                    input(ingredient);
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription(field = "ingredients")
+        public AbstractShapeless<T> input(Collection<IIngredient> ingredients) {
+            if (ingredients != null && !ingredients.isEmpty())
+                for (IIngredient ingredient : ingredients)
+                    input(ingredient);
+            return this;
+        }
+    }
+}


### PR DESCRIPTION
changes in this PR:
- change Astral Sorcery Starlight Altar to always require 1 starlight, and update example to have 500 starlight
- improve description of `@Property` javadoc, and restrict its use so it always works (can no longer have `@Properties` on FIELD/METHOD, since those are either singleton or need to use `@RecipeBuilderDescription#requirements`)
- fixed Astral Sorcery Starlight Altar documentation generation not quite working correctly, and simplified internal code.
- adds `AbstractCraftingRecipeBuilder` and removes a huge amount of duplicate code relating to that.