### PR TITLE
make MethodDescription#description check for a global fallback

### DIFF
--- a/src/main/java/com/cleanroommc/groovyscript/api/documentation/annotations/MethodDescription.java
+++ b/src/main/java/com/cleanroommc/groovyscript/api/documentation/annotations/MethodDescription.java
@@ -29,10 +29,16 @@ import java.lang.reflect.Method;
 public @interface MethodDescription {
 
     /**
-     * The localization key for a description of the compat, will default to generating
-     * <code>
-     * groovyscript.wiki.{@link com.cleanroommc.groovyscript.compat.mods.GroovyContainer#getModId() GroovyContainer#getModId()}.{@link com.cleanroommc.groovyscript.registry.VirtualizedRegistry#getName() VirtualizedRegistry#getName()}.{@link Method#getName()}
-     * </code>
+     * The localization key for a description of the compat.
+     * <br>
+     * Generates a description via minecraft's localization files via
+     * <code>{@link net.minecraft.client.resources.I18n#format(String, Object...) I18n.format(description())}</code>
+     * <br>
+     * If this is empty, will fall back to generating a description based on
+     * <code>groovyscript.wiki.{@link com.cleanroommc.groovyscript.compat.mods.GroovyContainer#getModId() GroovyContainer#getModId()}.{@link com.cleanroommc.groovyscript.registry.VirtualizedRegistry#getName() VirtualizedRegistry#getName()}.{@link Method#getName()}</code>.
+     * Then, if that does not have a lang key defined, it will attempt to use a global lang key based on the method name
+     * <code>groovyscript.wiki.{@link Method#getName()}</code>
+     * if that also does not have a lang key defined, will log a missing key in the {@code groovy.log} file.
      *
      * @return localization key for method description
      */

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/actuallyadditions/AtomicReconstructor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/actuallyadditions/AtomicReconstructor.java
@@ -65,7 +65,7 @@ public class AtomicReconstructor extends VirtualizedRegistry<LensConversionRecip
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('actuallyadditions:block_crystal')"))
+    @MethodDescription(example = @Example("item('actuallyadditions:block_crystal')"))
     public boolean removeByOutput(ItemStack output) {
         return ActuallyAdditionsAPI.RECONSTRUCTOR_LENS_CONVERSION_RECIPES.removeIf(recipe -> {
             boolean matches = ItemStack.areItemStacksEqual(recipe.getOutput(), output);
@@ -76,13 +76,13 @@ public class AtomicReconstructor extends VirtualizedRegistry<LensConversionRecip
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         ActuallyAdditionsAPI.RECONSTRUCTOR_LENS_CONVERSION_RECIPES.forEach(this::addBackup);
         ActuallyAdditionsAPI.RECONSTRUCTOR_LENS_CONVERSION_RECIPES.clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<LensConversionRecipe> streamRecipes() {
         return new SimpleObjectStream<>(ActuallyAdditionsAPI.RECONSTRUCTOR_LENS_CONVERSION_RECIPES)
                 .setRemover(this::remove);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/actuallyadditions/BallOfFur.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/actuallyadditions/BallOfFur.java
@@ -46,7 +46,7 @@ public class BallOfFur extends VirtualizedRegistry<BallOfFurReturn> {
         return true;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('minecraft:feather')"))
+    @MethodDescription(example = @Example("item('minecraft:feather')"))
     public boolean removeByOutput(ItemStack output) {
         return ActuallyAdditionsAPI.BALL_OF_FUR_RETURN_ITEMS.removeIf(recipe -> {
             boolean found = ItemStack.areItemStacksEqual(recipe.returnItem, output);
@@ -57,13 +57,13 @@ public class BallOfFur extends VirtualizedRegistry<BallOfFurReturn> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         ActuallyAdditionsAPI.BALL_OF_FUR_RETURN_ITEMS.forEach(this::addBackup);
         ActuallyAdditionsAPI.BALL_OF_FUR_RETURN_ITEMS.clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<BallOfFurReturn> streamRecipes() {
         return new SimpleObjectStream<>(ActuallyAdditionsAPI.BALL_OF_FUR_RETURN_ITEMS)
                 .setRemover(this::remove);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/actuallyadditions/Compost.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/actuallyadditions/Compost.java
@@ -55,7 +55,7 @@ public class Compost extends VirtualizedRegistry<CompostRecipe> {
         return true;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('actuallyadditions:item_canola_seed')"))
+    @MethodDescription(example = @Example("item('actuallyadditions:item_canola_seed')"))
     public boolean removeByInput(IIngredient input) {
         return ActuallyAdditionsAPI.COMPOST_RECIPES.removeIf(recipe -> {
             boolean found = recipe.getInput().test(IngredientHelper.toItemStack(input));
@@ -66,7 +66,7 @@ public class Compost extends VirtualizedRegistry<CompostRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('actuallyadditions:item_fertilizer')"))
+    @MethodDescription(example = @Example("item('actuallyadditions:item_fertilizer')"))
     public boolean removeByOutput(ItemStack output) {
         return ActuallyAdditionsAPI.COMPOST_RECIPES.removeIf(recipe -> {
             boolean matches = ItemStack.areItemStacksEqual(recipe.getOutput(), output);
@@ -77,13 +77,13 @@ public class Compost extends VirtualizedRegistry<CompostRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         ActuallyAdditionsAPI.COMPOST_RECIPES.forEach(this::addBackup);
         ActuallyAdditionsAPI.COMPOST_RECIPES.clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<CompostRecipe> streamRecipes() {
         return new SimpleObjectStream<>(ActuallyAdditionsAPI.COMPOST_RECIPES)
                 .setRemover(this::remove);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/actuallyadditions/Crusher.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/actuallyadditions/Crusher.java
@@ -56,7 +56,7 @@ public class Crusher extends VirtualizedRegistry<CrusherRecipe> {
         return true;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:bone')"))
+    @MethodDescription(example = @Example("item('minecraft:bone')"))
     public boolean removeByInput(IIngredient input) {
         return ActuallyAdditionsAPI.CRUSHER_RECIPES.removeIf(recipe -> {
             boolean found = recipe.getInput().test(IngredientHelper.toItemStack(input));
@@ -67,7 +67,7 @@ public class Crusher extends VirtualizedRegistry<CrusherRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('minecraft:sugar')"))
+    @MethodDescription(example = @Example("item('minecraft:sugar')"))
     public boolean removeByOutput(ItemStack output) {
         return ActuallyAdditionsAPI.CRUSHER_RECIPES.removeIf(recipe -> {
             boolean matches = ItemStack.areItemStacksEqual(recipe.getOutputOne(), output);
@@ -78,13 +78,13 @@ public class Crusher extends VirtualizedRegistry<CrusherRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         ActuallyAdditionsAPI.CRUSHER_RECIPES.forEach(this::addBackup);
         ActuallyAdditionsAPI.CRUSHER_RECIPES.clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<CrusherRecipe> streamRecipes() {
         return new SimpleObjectStream<>(ActuallyAdditionsAPI.CRUSHER_RECIPES)
                 .setRemover(this::remove);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/actuallyadditions/Empowerer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/actuallyadditions/Empowerer.java
@@ -56,7 +56,7 @@ public class Empowerer extends VirtualizedRegistry<EmpowererRecipe> {
         return true;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('actuallyadditions:item_crystal')"))
+    @MethodDescription(example = @Example("item('actuallyadditions:item_crystal')"))
     public boolean removeByInput(IIngredient input) {
         return ActuallyAdditionsAPI.EMPOWERER_RECIPES.removeIf(recipe -> {
             boolean found = recipe.getInput().test(IngredientHelper.toItemStack(input));
@@ -67,7 +67,7 @@ public class Empowerer extends VirtualizedRegistry<EmpowererRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('actuallyadditions:item_misc:24')"))
+    @MethodDescription(example = @Example("item('actuallyadditions:item_misc:24')"))
     public boolean removeByOutput(ItemStack output) {
         return ActuallyAdditionsAPI.EMPOWERER_RECIPES.removeIf(recipe -> {
             boolean matches = ItemStack.areItemStacksEqual(recipe.getOutput(), output);
@@ -78,13 +78,13 @@ public class Empowerer extends VirtualizedRegistry<EmpowererRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         ActuallyAdditionsAPI.EMPOWERER_RECIPES.forEach(this::addBackup);
         ActuallyAdditionsAPI.EMPOWERER_RECIPES.clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<EmpowererRecipe> streamRecipes() {
         return new SimpleObjectStream<>(ActuallyAdditionsAPI.EMPOWERER_RECIPES)
                 .setRemover(this::remove);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/actuallyadditions/NetherMiningLens.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/actuallyadditions/NetherMiningLens.java
@@ -49,12 +49,12 @@ public class NetherMiningLens extends VirtualizedRegistry<WeightedOre> {
         return true;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOre", example = @Example("ore('oreQuartz')"))
+    @MethodDescription(example = @Example("ore('oreQuartz')"))
     public boolean removeByOre(OreDictIngredient ore) {
         return this.removeByOre(ore.getOreDict());
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOre", example = @Example("'oreQuartz'"))
+    @MethodDescription(example = @Example("'oreQuartz'"))
     public boolean removeByOre(String oreName) {
         return ActuallyAdditionsAPI.NETHERRACK_ORES.removeIf(recipe -> {
             boolean found = oreName.equals(recipe.name);
@@ -65,13 +65,13 @@ public class NetherMiningLens extends VirtualizedRegistry<WeightedOre> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         ActuallyAdditionsAPI.NETHERRACK_ORES.forEach(this::addBackup);
         ActuallyAdditionsAPI.NETHERRACK_ORES.clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<WeightedOre> streamRecipes() {
         return new SimpleObjectStream<>(ActuallyAdditionsAPI.NETHERRACK_ORES)
                 .setRemover(this::remove);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/actuallyadditions/OilGen.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/actuallyadditions/OilGen.java
@@ -54,17 +54,17 @@ public class OilGen extends VirtualizedRegistry<OilGenRecipe> {
         return true;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("fluid('canolaoil')"))
+    @MethodDescription(example = @Example("fluid('canolaoil')"))
     public boolean removeByInput(FluidStack fluid) {
         return this.removeByInput(fluid.getFluid());
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("fluid('canolaoil').getFluid()"))
+    @MethodDescription(example = @Example("fluid('canolaoil').getFluid()"))
     public boolean removeByInput(Fluid fluid) {
         return this.removeByInput(fluid.getName());
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("'refinedcanolaoil'"))
+    @MethodDescription(example = @Example("'refinedcanolaoil'"))
     public boolean removeByInput(String fluid) {
         return ActuallyAdditionsAPI.OIL_GENERATOR_RECIPES.removeIf(recipe -> {
             boolean found = fluid.equals(recipe.fluidName);
@@ -75,13 +75,13 @@ public class OilGen extends VirtualizedRegistry<OilGenRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         ActuallyAdditionsAPI.OIL_GENERATOR_RECIPES.forEach(this::addBackup);
         ActuallyAdditionsAPI.OIL_GENERATOR_RECIPES.clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<OilGenRecipe> streamRecipes() {
         return new SimpleObjectStream<>(ActuallyAdditionsAPI.OIL_GENERATOR_RECIPES)
                 .setRemover(this::remove);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/actuallyadditions/StoneMiningLens.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/actuallyadditions/StoneMiningLens.java
@@ -49,12 +49,12 @@ public class StoneMiningLens extends VirtualizedRegistry<WeightedOre> {
         return true;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOre", example = @Example("ore('oreCoal')"))
+    @MethodDescription(example = @Example("ore('oreCoal')"))
     public boolean removeByOre(OreDictIngredient ore) {
         return this.removeByOre(ore.getOreDict());
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOre", example = @Example("'oreLapis'"))
+    @MethodDescription(example = @Example("'oreLapis'"))
     public boolean removeByOre(String oreName) {
         return ActuallyAdditionsAPI.STONE_ORES.removeIf(recipe -> {
             boolean found = oreName.equals(recipe.name);
@@ -65,13 +65,13 @@ public class StoneMiningLens extends VirtualizedRegistry<WeightedOre> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         ActuallyAdditionsAPI.STONE_ORES.forEach(this::addBackup);
         ActuallyAdditionsAPI.STONE_ORES.clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<WeightedOre> streamRecipes() {
         return new SimpleObjectStream<>(ActuallyAdditionsAPI.STONE_ORES)
                 .setRemover(this::remove);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/actuallyadditions/TreasureChest.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/actuallyadditions/TreasureChest.java
@@ -46,7 +46,7 @@ public class TreasureChest extends VirtualizedRegistry<TreasureChestLoot> {
         return true;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('minecraft:iron_ingot')"))
+    @MethodDescription(example = @Example("item('minecraft:iron_ingot')"))
     public boolean removeByOutput(ItemStack output) {
         return ActuallyAdditionsAPI.TREASURE_CHEST_LOOT.removeIf(recipe -> {
             boolean matches = ItemStack.areItemStacksEqual(recipe.returnItem, output);
@@ -57,13 +57,13 @@ public class TreasureChest extends VirtualizedRegistry<TreasureChestLoot> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         ActuallyAdditionsAPI.TREASURE_CHEST_LOOT.forEach(this::addBackup);
         ActuallyAdditionsAPI.TREASURE_CHEST_LOOT.clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<TreasureChestLoot> streamRecipes() {
         return new SimpleObjectStream<>(ActuallyAdditionsAPI.TREASURE_CHEST_LOOT)
                 .setRemover(this::remove);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/aetherlegacy/Accessory.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/aetherlegacy/Accessory.java
@@ -35,7 +35,7 @@ public class Accessory extends ForgeRegistryWrapper<AetherAccessory> {
         add(accessory);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('aether_legacy:iron_pendant')"))
+    @MethodDescription(example = @Example("item('aether_legacy:iron_pendant')"))
     public void removeByInput(IIngredient input) {
         this.getRegistry().getValuesCollection().forEach(accessory -> {
             if (input.test(accessory.getAccessoryStack())) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/aetherlegacy/Enchanter.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/aetherlegacy/Enchanter.java
@@ -28,7 +28,7 @@ public class Enchanter extends ForgeRegistryWrapper<AetherEnchantment> {
         add(enchantment);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('aether_legacy:enchanted_gravitite')"))
+    @MethodDescription(example = @Example("item('aether_legacy:enchanted_gravitite')"))
     public void removeByOutput(IIngredient output) {
         this.getRegistry().getValuesCollection().forEach(enchantment -> {
             if (output.test(enchantment.getOutput())) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/aetherlegacy/Freezer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/aetherlegacy/Freezer.java
@@ -28,7 +28,7 @@ public class Freezer extends ForgeRegistryWrapper<AetherFreezable> {
         add(freezable);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('minecraft:obsidian')"))
+    @MethodDescription(example = @Example("item('minecraft:obsidian')"))
     public void removeByOutput(IIngredient output) {
         this.getRegistry().getValuesCollection().forEach(freezable -> {
             if (output.test(freezable.getOutput())) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Atomizer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Atomizer.java
@@ -52,7 +52,7 @@ public class Atomizer extends VirtualizedRegistry<AtomizerRecipe> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example(value = "item('alchemistry:compound:7')", commented = true))
+    @MethodDescription(example = @Example(value = "item('alchemistry:compound:7')", commented = true))
     public boolean removeByOutput(IIngredient output) {
         return ModRecipes.INSTANCE.getAtomizerRecipes().removeIf(r -> {
             if (output.test(r.getOutput())) {
@@ -63,7 +63,7 @@ public class Atomizer extends VirtualizedRegistry<AtomizerRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("fluid('water')"))
+    @MethodDescription(example = @Example("fluid('water')"))
     public boolean removeByInput(FluidStack input) {
         return ModRecipes.INSTANCE.getAtomizerRecipes().removeIf(r -> {
             if (r.getInput().isFluidEqual(input)) {
@@ -74,12 +74,12 @@ public class Atomizer extends VirtualizedRegistry<AtomizerRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<AtomizerRecipe> streamRecipes() {
         return new SimpleObjectStream<>(ModRecipes.INSTANCE.getAtomizerRecipes()).setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         ModRecipes.INSTANCE.getAtomizerRecipes().forEach(this::addBackup);
         ModRecipes.INSTANCE.getAtomizerRecipes().clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Combiner.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Combiner.java
@@ -54,7 +54,7 @@ public class Combiner extends VirtualizedRegistry<CombinerRecipe> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('minecraft:glowstone')"))
+    @MethodDescription(example = @Example("item('minecraft:glowstone')"))
     public boolean removeByOutput(IIngredient output) {
         return ModRecipes.INSTANCE.getCombinerRecipes().removeIf(r -> {
             if (output.test(r.getOutput())) {
@@ -65,7 +65,7 @@ public class Combiner extends VirtualizedRegistry<CombinerRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("element('carbon')"))
+    @MethodDescription(example = @Example("element('carbon')"))
     public boolean removeByInput(IIngredient input) {
         return ModRecipes.INSTANCE.getCombinerRecipes().removeIf(r -> {
             for (ItemStack itemstack : r.getInputs()) {
@@ -78,12 +78,12 @@ public class Combiner extends VirtualizedRegistry<CombinerRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<CombinerRecipe> streamRecipes() {
         return new SimpleObjectStream<>(ModRecipes.INSTANCE.getCombinerRecipes()).setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         ModRecipes.INSTANCE.getCombinerRecipes().forEach(this::addBackup);
         ModRecipes.INSTANCE.getCombinerRecipes().clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Dissolver.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Dissolver.java
@@ -55,7 +55,7 @@ public class Dissolver extends VirtualizedRegistry<DissolverRecipe> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('alchemistry:compound:1')"))
+    @MethodDescription(example = @Example("item('alchemistry:compound:1')"))
     public boolean removeByInput(IIngredient input) {
         return ModRecipes.INSTANCE.getDissolverRecipes().removeIf(r -> {
             for (ItemStack itemstack : r.getInputs()) {
@@ -68,12 +68,12 @@ public class Dissolver extends VirtualizedRegistry<DissolverRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<DissolverRecipe> streamRecipes() {
         return new SimpleObjectStream<>(ModRecipes.INSTANCE.getDissolverRecipes()).setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         ModRecipes.INSTANCE.getDissolverRecipes().forEach(this::addBackup);
         ModRecipes.INSTANCE.getDissolverRecipes().clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Electrolyzer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Electrolyzer.java
@@ -50,7 +50,7 @@ public class Electrolyzer extends VirtualizedRegistry<ElectrolyzerRecipe> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("element('chlorine')"))
+    @MethodDescription(example = @Example("element('chlorine')"))
     public boolean removeByOutput(IIngredient output) {
         return ModRecipes.INSTANCE.getElectrolyzerRecipes().removeIf(r -> {
             for (ItemStack itemstack : r.getOutputs()) {
@@ -63,7 +63,7 @@ public class Electrolyzer extends VirtualizedRegistry<ElectrolyzerRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example(value = "fluid('water')", commented = true))
+    @MethodDescription(example = @Example(value = "fluid('water')", commented = true))
     public boolean removeByInput(FluidStack input) {
         return ModRecipes.INSTANCE.getElectrolyzerRecipes().removeIf(r -> {
             if (r.getInput().isFluidEqual(input)) {
@@ -74,7 +74,7 @@ public class Electrolyzer extends VirtualizedRegistry<ElectrolyzerRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("element('calcium_carbonate')"))
+    @MethodDescription(example = @Example("element('calcium_carbonate')"))
     public boolean removeByInput(IIngredient input) {
         return ModRecipes.INSTANCE.getElectrolyzerRecipes().removeIf(r -> {
             for (ItemStack itemstack : r.getElectrolytes()) {
@@ -87,12 +87,12 @@ public class Electrolyzer extends VirtualizedRegistry<ElectrolyzerRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<ElectrolyzerRecipe> streamRecipes() {
         return new SimpleObjectStream<>(ModRecipes.INSTANCE.getElectrolyzerRecipes()).setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         ModRecipes.INSTANCE.getElectrolyzerRecipes().forEach(this::addBackup);
         ModRecipes.INSTANCE.getElectrolyzerRecipes().clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Evaporator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Evaporator.java
@@ -51,7 +51,7 @@ public class Evaporator extends VirtualizedRegistry<EvaporatorRecipe> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('alchemistry:mineral_salt')"))
+    @MethodDescription(example = @Example("item('alchemistry:mineral_salt')"))
     public boolean removeByOutput(IIngredient output) {
         return ModRecipes.INSTANCE.getEvaporatorRecipes().removeIf(r -> {
             if (output.test(r.getOutput())) {
@@ -62,7 +62,7 @@ public class Evaporator extends VirtualizedRegistry<EvaporatorRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("fluid('lava')"))
+    @MethodDescription(example = @Example("fluid('lava')"))
     public boolean removeByInput(FluidStack input) {
         return ModRecipes.INSTANCE.getEvaporatorRecipes().removeIf(r -> {
             if (r.getInput().isFluidEqual(input)) {
@@ -73,12 +73,12 @@ public class Evaporator extends VirtualizedRegistry<EvaporatorRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<EvaporatorRecipe> streamRecipes() {
         return new SimpleObjectStream<>(ModRecipes.INSTANCE.getEvaporatorRecipes()).setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         ModRecipes.INSTANCE.getEvaporatorRecipes().forEach(this::addBackup);
         ModRecipes.INSTANCE.getEvaporatorRecipes().clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Liquifier.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Liquifier.java
@@ -51,7 +51,7 @@ public class Liquifier extends VirtualizedRegistry<LiquifierRecipe> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example(value = "fluid('water')", commented = true))
+    @MethodDescription(example = @Example(value = "fluid('water')", commented = true))
     public boolean removeByOutput(FluidStack output) {
         return ModRecipes.INSTANCE.getLiquifierRecipes().removeIf(r -> {
             if (r.getOutput().isFluidEqual(output)) {
@@ -62,7 +62,7 @@ public class Liquifier extends VirtualizedRegistry<LiquifierRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("element('water')"))
+    @MethodDescription(example = @Example("element('water')"))
     public boolean removeByInput(IIngredient input) {
         return ModRecipes.INSTANCE.getLiquifierRecipes().removeIf(r -> {
             if (input.test(r.getInput())) {
@@ -73,12 +73,12 @@ public class Liquifier extends VirtualizedRegistry<LiquifierRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<LiquifierRecipe> streamRecipes() {
         return new SimpleObjectStream<>(ModRecipes.INSTANCE.getLiquifierRecipes()).setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         ModRecipes.INSTANCE.getLiquifierRecipes().forEach(this::addBackup);
         ModRecipes.INSTANCE.getLiquifierRecipes().clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/appliedenergistics2/Attunement.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/appliedenergistics2/Attunement.java
@@ -133,7 +133,7 @@ public class Attunement extends VirtualizedRegistry<Pair<Object, TunnelType>> {
         }
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         ((P2PTunnelRegistryAccessor) AEApi.instance().registries().p2pTunnel()).getTunnels().forEach((item, value) -> addBackup(Pair.of(item, value)));
         ((P2PTunnelRegistryAccessor) AEApi.instance().registries().p2pTunnel()).getTunnels().clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/appliedenergistics2/CannonAmmo.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/appliedenergistics2/CannonAmmo.java
@@ -37,7 +37,7 @@ public class CannonAmmo extends VirtualizedRegistry<Pair<ItemStack, Double>> {
         ((MatterCannonAmmoRegistryAccessor) AEApi.instance().registries().matterCannon()).getDamageModifiers().entrySet().removeIf(x -> ItemStack.areItemStacksEqual(x.getKey(), item));
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         ((MatterCannonAmmoRegistryAccessor) AEApi.instance().registries().matterCannon()).getDamageModifiers().forEach((item, value) -> addBackup(Pair.of(item, value)));
         ((MatterCannonAmmoRegistryAccessor) AEApi.instance().registries().matterCannon()).getDamageModifiers().clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/appliedenergistics2/Grinder.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/appliedenergistics2/Grinder.java
@@ -44,7 +44,7 @@ public class Grinder extends VirtualizedRegistry<IGrinderRecipe> {
         addBackup(recipe);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:gold_ingot')"))
+    @MethodDescription(example = @Example("item('minecraft:gold_ingot')"))
     public void removeByInput(ItemStack input) {
         List<IGrinderRecipe> recipes = AEApi.instance().registries().grinder().getRecipes().stream().filter(x -> ItemStack.areItemStacksEqual(x.getInput(), input)).collect(Collectors.toList());
         for (IGrinderRecipe recipe : recipes) {
@@ -53,7 +53,7 @@ public class Grinder extends VirtualizedRegistry<IGrinderRecipe> {
         }
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('minecraft:quartz')"))
+    @MethodDescription(example = @Example("item('minecraft:quartz')"))
     public void removeByOutput(ItemStack output) {
         List<IGrinderRecipe> recipes = AEApi.instance().registries().grinder().getRecipes().stream().filter(x -> ItemStack.areItemStacksEqual(x.getOutput(), output)).collect(Collectors.toList());
         for (IGrinderRecipe recipe : recipes) {
@@ -62,7 +62,7 @@ public class Grinder extends VirtualizedRegistry<IGrinderRecipe> {
         }
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         Collection<IGrinderRecipe> recipes = new ArrayList<>(AEApi.instance().registries().grinder().getRecipes());
         for (IGrinderRecipe recipe : recipes) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/appliedenergistics2/Inscriber.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/appliedenergistics2/Inscriber.java
@@ -43,7 +43,7 @@ public class Inscriber extends VirtualizedRegistry<IInscriberRecipe> {
         addBackup(recipe);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('appliedenergistics2:material:59')"))
+    @MethodDescription(example = @Example("item('appliedenergistics2:material:59')"))
     public void removeByOutput(ItemStack output) {
         List<IInscriberRecipe> recipes = AEApi.instance().registries().inscriber().getRecipes().stream().filter(x -> ItemStack.areItemStacksEqual(x.getOutput(), output)).collect(Collectors.toList());
         for (IInscriberRecipe recipe : recipes) {
@@ -52,7 +52,7 @@ public class Inscriber extends VirtualizedRegistry<IInscriberRecipe> {
         }
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         Collection<IInscriberRecipe> recipes = new ArrayList<>(AEApi.instance().registries().inscriber().getRecipes());
         for (IInscriberRecipe recipe : recipes) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/appliedenergistics2/Spatial.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/appliedenergistics2/Spatial.java
@@ -46,7 +46,7 @@ public class Spatial extends VirtualizedRegistry<Class<? extends TileEntity>> {
         ((MovableTileRegistryAccessor) AEApi.instance().registries().movable()).getTest().remove(clazz);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         ((MovableTileRegistryAccessor) AEApi.instance().registries().movable()).getTest().forEach(this::addBackup);
         ((MovableTileRegistryAccessor) AEApi.instance().registries().movable()).getTest().clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/arcanearchives/GemCuttingTable.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/arcanearchives/GemCuttingTable.java
@@ -52,7 +52,7 @@ public class GemCuttingTable extends VirtualizedRegistry<IGCTRecipe> {
         return true;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:gold_nugget')"))
+    @MethodDescription(example = @Example("item('minecraft:gold_nugget')"))
     public boolean removeByInput(IIngredient input) {
         return GCTRecipeList.instance.getRecipes().values().removeIf(recipe -> {
             boolean found = recipe.getIngredients().stream()
@@ -67,7 +67,7 @@ public class GemCuttingTable extends VirtualizedRegistry<IGCTRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('arcanearchives:shaped_quartz')"))
+    @MethodDescription(example = @Example("item('arcanearchives:shaped_quartz')"))
     public boolean removeByOutput(IIngredient output) {
         return GCTRecipeList.instance.getRecipes().values().removeIf(recipe -> {
             boolean matches = output.test(recipe.getRecipeOutput());
@@ -78,13 +78,13 @@ public class GemCuttingTable extends VirtualizedRegistry<IGCTRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<IGCTRecipe> streamRecipes() {
         return new SimpleObjectStream<>(GCTRecipeList.instance.getRecipeList())
                 .setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         for (IGCTRecipe recipe : GCTRecipeList.instance.getRecipeList()) {
             addBackup(recipe);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/ChaliceInteraction.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/ChaliceInteraction.java
@@ -58,7 +58,7 @@ public class ChaliceInteraction extends VirtualizedRegistry<LiquidInteraction> {
         return getRegistry().removeIf(rec -> rec.equals(recipe));
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput")
+    @MethodDescription
     public void removeByInput(Fluid fluid1, Fluid fluid2) {
         getRegistry().removeIf(rec -> {
             if ((rec.getComponent1().getFluid().equals(fluid1) && rec.getComponent2().getFluid().equals(fluid2)) ||
@@ -70,12 +70,12 @@ public class ChaliceInteraction extends VirtualizedRegistry<LiquidInteraction> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("fluid('water'), fluid('lava')"))
+    @MethodDescription(example = @Example("fluid('water'), fluid('lava')"))
     public void removeByInput(FluidStack fluid1, FluidStack fluid2) {
         this.removeByInput(fluid1.getFluid(), fluid2.getFluid());
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput")
+    @MethodDescription
     public void removeByInput(Fluid fluid) {
         getRegistry().removeIf(rec -> {
             if ((rec.getComponent1().getFluid().equals(fluid) || rec.getComponent2().getFluid().equals(fluid))) {
@@ -86,12 +86,12 @@ public class ChaliceInteraction extends VirtualizedRegistry<LiquidInteraction> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example(value = "fluid('astralsorcery.liquidstarlight')", commented = true))
+    @MethodDescription(example = @Example(value = "fluid('astralsorcery.liquidstarlight')", commented = true))
     public void removeByInput(FluidStack fluid) {
         this.removeByInput(fluid.getFluid());
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('minecraft:ice')"))
+    @MethodDescription(example = @Example("item('minecraft:ice')"))
     public void removeByOutput(ItemStack output) {
         getRegistry().removeIf(rec -> {
             if (((LiquidInteractionAccessor) rec).getFluidInteractionAction().getOutputForMatching().isItemEqual(output)) {
@@ -102,13 +102,13 @@ public class ChaliceInteraction extends VirtualizedRegistry<LiquidInteraction> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<LiquidInteraction> streamRecipes() {
         return new SimpleObjectStream<>(getRegistry())
                 .setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         getRegistry().forEach(this::addBackup);
         getRegistry().clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/Constellation.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/Constellation.java
@@ -114,7 +114,7 @@ public class Constellation extends VirtualizedRegistry<IConstellation> {
                 .setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         ConstellationRegistryAccessor.getConstellationList().forEach(this::addBackup);
         ConstellationRegistryAccessor.getConstellationList().clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/Fountain.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/Fountain.java
@@ -79,13 +79,13 @@ public class Fountain extends VirtualizedRegistry<FluidRarityRegistry.FluidRarit
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<FluidRarityRegistry.FluidRarityEntry> streamRecipes() {
         return new SimpleObjectStream<>(((FluidRarityRegistryAccessor) FluidRarityRegistry.INSTANCE).getRarityList())
                 .setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         ((FluidRarityRegistryAccessor) FluidRarityRegistry.INSTANCE).getRarityList().forEach(this::addBackup);
         ((FluidRarityRegistryAccessor) FluidRarityRegistry.INSTANCE).getRarityList().clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/Grindstone.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/Grindstone.java
@@ -55,7 +55,7 @@ public class Grindstone extends VirtualizedRegistry<GrindstoneRecipe> {
         return GrindstoneRecipeRegistry.recipes.remove(recipe);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:redstone_ore')"))
+    @MethodDescription(example = @Example("item('minecraft:redstone_ore')"))
     public void removeByInput(ItemStack item) {
         GrindstoneRecipeRegistry.recipes.removeIf(recipe -> {
             if (recipe.isValid() && recipe.matches(item)) {
@@ -66,13 +66,13 @@ public class Grindstone extends VirtualizedRegistry<GrindstoneRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("ore('dustIron')"))
+    @MethodDescription(example = @Example("ore('dustIron')"))
     public void removeByOutput(OreDictIngredient ore) {
         for (ItemStack item : ore.getMatchingStacks())
             this.removeByOutput(item);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput")
+    @MethodDescription
     public void removeByOutput(ItemStack item) {
         GrindstoneRecipeRegistry.recipes.removeIf(recipe -> {
             if (recipe.isValid() && recipe.getOutputForMatching().isItemEqual(item)) {
@@ -83,13 +83,13 @@ public class Grindstone extends VirtualizedRegistry<GrindstoneRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<GrindstoneRecipe> streamRecipes() {
         return new SimpleObjectStream<>(GrindstoneRecipeRegistry.recipes)
                 .setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         GrindstoneRecipeRegistry.recipes.forEach(this::addBackup);
         GrindstoneRecipeRegistry.recipes.clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/InfusionAltar.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/InfusionAltar.java
@@ -63,7 +63,7 @@ public class InfusionAltar extends VirtualizedRegistry<BasicInfusionRecipe> {
         return InfusionRecipeRegistry.recipes.removeIf(rec -> rec.getUniqueRecipeId() == recipe.getUniqueRecipeId());
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:diamond_ore')"))
+    @MethodDescription(example = @Example("item('minecraft:diamond_ore')"))
     public void removeByInput(ItemStack input) {
         InfusionRecipeRegistry.recipes.removeIf(r -> {
             if (r instanceof BasicInfusionRecipe && r.getInput().matchCrafting(input)) {
@@ -74,18 +74,18 @@ public class InfusionAltar extends VirtualizedRegistry<BasicInfusionRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('minecraft:iron_ingot')"))
+    @MethodDescription(example = @Example("item('minecraft:iron_ingot')"))
     public void removeByOutput(ItemStack output) {
         addBackup((BasicInfusionRecipe) InfusionRecipeRegistry.removeFindRecipeByOutput(output));
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<AbstractInfusionRecipe> streamRecipes() {
         return new SimpleObjectStream<>(InfusionRecipeRegistry.recipes)
                 .setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         InfusionRecipeRegistry.recipes.removeIf(r -> {
             if (r instanceof BasicInfusionRecipe) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/LightTransmutation.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/LightTransmutation.java
@@ -69,7 +69,7 @@ public class LightTransmutation extends VirtualizedRegistry<LightOreTransmutatio
         return getRegistry().removeIf(rec -> rec.equals(recipe));
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("blockstate('minecraft:sandstone')"))
+    @MethodDescription(example = @Example("blockstate('minecraft:sandstone')"))
     public void removeByInput(IBlockState block) {
         getRegistry().removeIf(rec -> {
             if (rec.matchesInput(block)) {
@@ -80,12 +80,12 @@ public class LightTransmutation extends VirtualizedRegistry<LightOreTransmutatio
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("block('minecraft:netherrack')"))
+    @MethodDescription(example = @Example("block('minecraft:netherrack')"))
     public void removeByInput(Block block) {
         removeByInput(block.getDefaultState());
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("blockstate('minecraft:cake')"))
+    @MethodDescription(example = @Example("blockstate('minecraft:cake')"))
     public void removeByOutput(IBlockState block) {
         getRegistry().removeIf(rec -> {
             if (rec.matchesOutput(block)) {
@@ -96,18 +96,18 @@ public class LightTransmutation extends VirtualizedRegistry<LightOreTransmutatio
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("block('minecraft:lapis_block')"))
+    @MethodDescription(example = @Example("block('minecraft:lapis_block')"))
     public void removeByOutput(Block block) {
         removeByOutput(block.getDefaultState());
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<LightOreTransmutations.Transmutation> streamRecipes() {
         return new SimpleObjectStream<>(getRegistry())
                 .setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         getRegistry().forEach(this::addBackup);
         getRegistry().clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/Lightwell.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/Lightwell.java
@@ -65,7 +65,7 @@ public class Lightwell extends VirtualizedRegistry<WellLiquefaction.Liquefaction
         return getRegistry().remove(recipe.catalyst) != null;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByCatalyst", example = @Example("item('minecraft:ice')"))
+    @MethodDescription(example = @Example("item('minecraft:ice')"))
     public void removeByCatalyst(ItemStack catalyst) {
         WellLiquefaction.getRegisteredLiquefactions().forEach(le -> {
             if (le.catalyst.isItemEqual(catalyst)) {
@@ -79,7 +79,7 @@ public class Lightwell extends VirtualizedRegistry<WellLiquefaction.Liquefaction
         removeByCatalyst(input);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("fluid('lava')"))
+    @MethodDescription(example = @Example("fluid('lava')"))
     public void removeByOutput(FluidStack fluid) {
         getRegistry().entrySet().removeIf(entry -> {
             if (entry.getValue().producing.equals(fluid.getFluid())) {
@@ -90,13 +90,13 @@ public class Lightwell extends VirtualizedRegistry<WellLiquefaction.Liquefaction
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<WellLiquefaction.LiquefactionEntry> streamRecipes() {
         return new SimpleObjectStream<>(WellLiquefaction.getRegisteredLiquefactions())
                 .setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         getRegistry().values().forEach(this::addBackup);
         getRegistry().clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/OreChance.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/OreChance.java
@@ -104,13 +104,13 @@ public class OreChance extends VirtualizedRegistry<OreEntry> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<OreEntry> streamRecipes() {
         return new SimpleObjectStream<>(REGISTRY.getEntries())
                 .setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         REGISTRY.getEntries().forEach(this::addBackup);
         REGISTRY.getEntries().clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/starlightaltar/StarlightAltar.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/starlightaltar/StarlightAltar.java
@@ -259,13 +259,13 @@ public class StarlightAltar extends VirtualizedRegistry<AbstractAltarRecipe> {
         return AltarRecipeRegistry.recipes.get(recipe.getNeededLevel()).removeIf(rec -> rec.equals(recipe));
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<AbstractAltarRecipe> streamRecipes() {
         return new SimpleObjectStream<>(AltarRecipeRegistry.recipes.entrySet().stream().flatMap(r -> r.getValue().stream()).collect(Collectors.toList()))
                 .setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         AltarRecipeRegistry.recipes.forEach((level, recipes) -> {
             recipes.forEach(this::addBackup);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/avaritia/Compressor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/avaritia/Compressor.java
@@ -33,7 +33,7 @@ public class Compressor extends VirtualizedRegistry<ICompressorRecipe> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('avaritia:singularity', 0)"))
+    @MethodDescription(example = @Example("item('avaritia:singularity', 0)"))
     public boolean removeByOutput(ItemStack output) {
         if (IngredientHelper.isEmpty(output)) {
             GroovyLog.msg("Error removing avaritia compressor recipe")
@@ -51,13 +51,13 @@ public class Compressor extends VirtualizedRegistry<ICompressorRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         AvaritiaRecipeManager.COMPRESSOR_RECIPES.values().forEach(this::addBackup);
         AvaritiaRecipeManager.COMPRESSOR_RECIPES.values().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<ICompressorRecipe> streamRecipes() {
         return new SimpleObjectStream<>(AvaritiaRecipeManager.COMPRESSOR_RECIPES.values()).setRemover(this::remove);
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/avaritia/ExtremeCrafting.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/avaritia/ExtremeCrafting.java
@@ -59,7 +59,7 @@ public class ExtremeCrafting extends VirtualizedRegistry<IExtremeRecipe> {
         return recipe;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('avaritia:resource', 6)"))
+    @MethodDescription(example = @Example("item('avaritia:resource', 6)"))
     public boolean removeByOutput(ItemStack stack) {
         return AvaritiaRecipeManager.EXTREME_RECIPES.values().removeIf(recipe -> {
             if (recipe != null && recipe.getRecipeOutput().isItemEqual(stack)) {
@@ -78,12 +78,12 @@ public class ExtremeCrafting extends VirtualizedRegistry<IExtremeRecipe> {
         return recipe != null;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<IExtremeRecipe> streamRecipes() {
         return new SimpleObjectStream<>(AvaritiaRecipeManager.EXTREME_RECIPES.values()).setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         AvaritiaRecipeManager.EXTREME_RECIPES.values().forEach(this::addBackup);
         AvaritiaRecipeManager.EXTREME_RECIPES.values().clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/AnvilCrafting.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/AnvilCrafting.java
@@ -56,7 +56,7 @@ public class AnvilCrafting extends VirtualizedRegistry<IRecipe> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('betterwithmods:steel_block')"))
+    @MethodDescription(example = @Example("item('betterwithmods:steel_block')"))
     public boolean removeByOutput(IIngredient output) {
         return AnvilCraftingManager.ANVIL_CRAFTING.removeIf(r -> {
             if (output.test(r.getRecipeOutput())) {
@@ -67,7 +67,7 @@ public class AnvilCrafting extends VirtualizedRegistry<IRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:redstone')"))
+    @MethodDescription(example = @Example("item('minecraft:redstone')"))
     public boolean removeByInput(IIngredient input) {
         return AnvilCraftingManager.ANVIL_CRAFTING.removeIf(r -> {
             for (Ingredient ingredient : r.getIngredients()) {
@@ -82,12 +82,12 @@ public class AnvilCrafting extends VirtualizedRegistry<IRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<IRecipe> streamRecipes() {
         return new SimpleObjectStream<>(AnvilCraftingManager.ANVIL_CRAFTING).setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         AnvilCraftingManager.ANVIL_CRAFTING.forEach(this::addBackup);
         AnvilCraftingManager.ANVIL_CRAFTING.clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/Cauldron.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/Cauldron.java
@@ -49,7 +49,7 @@ public class Cauldron extends VirtualizedRegistry<CookingPotRecipe> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('minecraft:gunpowder')"))
+    @MethodDescription(example = @Example("item('minecraft:gunpowder')"))
     public boolean removeByOutput(IIngredient output) {
         return BWRegistry.CAULDRON.getRecipes().removeIf(r -> {
             for (ItemStack itemstack : r.getOutputs()) {
@@ -62,7 +62,7 @@ public class Cauldron extends VirtualizedRegistry<CookingPotRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:gunpowder')"))
+    @MethodDescription(example = @Example("item('minecraft:gunpowder')"))
     public boolean removeByInput(IIngredient input) {
         return BWRegistry.CAULDRON.getRecipes().removeIf(r -> {
             for (Ingredient ingredient : r.getInputs()) {
@@ -77,12 +77,12 @@ public class Cauldron extends VirtualizedRegistry<CookingPotRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<CookingPotRecipe> streamRecipes() {
         return new SimpleObjectStream<>(BWRegistry.CAULDRON.getRecipes()).setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         BWRegistry.CAULDRON.getRecipes().forEach(this::addBackup);
         BWRegistry.CAULDRON.getRecipes().clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/Crucible.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/Crucible.java
@@ -51,7 +51,7 @@ public class Crucible extends VirtualizedRegistry<CookingPotRecipe> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('minecraft:gunpowder')"))
+    @MethodDescription(example = @Example("item('minecraft:gunpowder')"))
     public boolean removeByOutput(ItemStack output) {
         return BWRegistry.CRUCIBLE.getRecipes().removeIf(r -> {
             for (ItemStack itemstack : r.getOutputs()) {
@@ -64,7 +64,7 @@ public class Crucible extends VirtualizedRegistry<CookingPotRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:gunpowder')"))
+    @MethodDescription(example = @Example("item('minecraft:gunpowder')"))
     public boolean removeByInput(ItemStack input) {
         return BWRegistry.CRUCIBLE.getRecipes().removeIf(r -> {
             for (Ingredient ingredient : r.getInputs()) {
@@ -77,17 +77,17 @@ public class Crucible extends VirtualizedRegistry<CookingPotRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput")
+    @MethodDescription
     public boolean removeByInput(IIngredient input) {
         return removeByInput(IngredientHelper.toItemStack(input));
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<CookingPotRecipe> streamRecipes() {
         return new SimpleObjectStream<>(BWRegistry.CRUCIBLE.getRecipes()).setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         BWRegistry.CRUCIBLE.getRecipes().forEach(this::addBackup);
         BWRegistry.CRUCIBLE.getRecipes().clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/Hopper.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/Hopper.java
@@ -47,7 +47,7 @@ public class Hopper extends VirtualizedRegistry<HopperInteractions.HopperRecipe>
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('minecraft:gunpowder')"))
+    @MethodDescription(example = @Example("item('minecraft:gunpowder')"))
     public boolean removeByOutput(IIngredient output) {
         return HopperInteractions.RECIPES.removeIf(r -> {
             for (ItemStack itemstack : r.getOutputs()) {
@@ -60,7 +60,7 @@ public class Hopper extends VirtualizedRegistry<HopperInteractions.HopperRecipe>
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:gunpowder')"))
+    @MethodDescription(example = @Example("item('minecraft:gunpowder')"))
     public boolean removeByInput(IIngredient input) {
         return HopperInteractions.RECIPES.removeIf(r -> {
             for (ItemStack item : r.getInputs().getMatchingStacks()) {
@@ -73,12 +73,12 @@ public class Hopper extends VirtualizedRegistry<HopperInteractions.HopperRecipe>
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<HopperInteractions.HopperRecipe> streamRecipes() {
         return new SimpleObjectStream<>(HopperInteractions.RECIPES).setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         HopperInteractions.RECIPES.forEach(this::addBackup);
         HopperInteractions.RECIPES.clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/HopperFilters.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/HopperFilters.java
@@ -85,13 +85,13 @@ public class HopperFilters extends VirtualizedRegistry<IHopperFilter> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<IHopperFilter> streamRecipes() {
         return new SimpleObjectStream<>(((HopperFiltersAccessor) BWRegistry.HOPPER_FILTERS).getFILTERS().values())
                 .setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         ((HopperFiltersAccessor) BWRegistry.HOPPER_FILTERS).getFILTERS().values().forEach(this::addBackup);
         ((HopperFiltersAccessor) BWRegistry.HOPPER_FILTERS).getFILTERS().values().clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/Kiln.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/Kiln.java
@@ -48,7 +48,7 @@ public class Kiln extends VirtualizedRegistry<KilnRecipe> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('minecraft:brick')"))
+    @MethodDescription(example = @Example("item('minecraft:brick')"))
     public boolean removeByOutput(IIngredient output) {
         return BWRegistry.KILN.getRecipes().removeIf(r -> {
             for (ItemStack itemstack : r.getOutputs()) {
@@ -61,7 +61,7 @@ public class Kiln extends VirtualizedRegistry<KilnRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:end_stone')"))
+    @MethodDescription(example = @Example("item('minecraft:end_stone')"))
     public boolean removeByInput(IIngredient input) {
         return BWRegistry.KILN.getRecipes().removeIf(r -> {
             for (ItemStack itemstack : r.getInput().getMatchingStacks()) {
@@ -74,12 +74,12 @@ public class Kiln extends VirtualizedRegistry<KilnRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<KilnRecipe> streamRecipes() {
         return new SimpleObjectStream<>(BWRegistry.KILN.getRecipes()).setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         BWRegistry.KILN.getRecipes().forEach(this::addBackup);
         BWRegistry.KILN.getRecipes().clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/MillStone.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/MillStone.java
@@ -54,7 +54,7 @@ public class MillStone extends VirtualizedRegistry<MillRecipe> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('minecraft:blaze_powder')"))
+    @MethodDescription(example = @Example("item('minecraft:blaze_powder')"))
     public boolean removeByOutput(IIngredient output) {
         return BWRegistry.MILLSTONE.getRecipes().removeIf(r -> {
             for (ItemStack itemstack : r.getOutputs()) {
@@ -67,7 +67,7 @@ public class MillStone extends VirtualizedRegistry<MillRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:netherrack')"))
+    @MethodDescription(example = @Example("item('minecraft:netherrack')"))
     public boolean removeByInput(IIngredient input) {
         return BWRegistry.MILLSTONE.getRecipes().removeIf(r -> {
             for (Ingredient ingredient : r.getInputs()) {
@@ -82,12 +82,12 @@ public class MillStone extends VirtualizedRegistry<MillRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<MillRecipe> streamRecipes() {
         return new SimpleObjectStream<>(BWRegistry.MILLSTONE.getRecipes()).setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         BWRegistry.MILLSTONE.getRecipes().forEach(this::addBackup);
         BWRegistry.MILLSTONE.getRecipes().clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/Saw.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/Saw.java
@@ -46,7 +46,7 @@ public class Saw extends VirtualizedRegistry<SawRecipe> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('minecraft:pumpkin')"))
+    @MethodDescription(example = @Example("item('minecraft:pumpkin')"))
     public boolean removeByOutput(IIngredient output) {
         return BWRegistry.WOOD_SAW.getRecipes().removeIf(r -> {
             for (ItemStack itemstack : r.getOutputs()) {
@@ -59,7 +59,7 @@ public class Saw extends VirtualizedRegistry<SawRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:vine')"))
+    @MethodDescription(example = @Example("item('minecraft:vine')"))
     public boolean removeByInput(IIngredient input) {
         return BWRegistry.WOOD_SAW.getRecipes().removeIf(r -> {
             for (ItemStack itemstack : r.getInput().getMatchingStacks()) {
@@ -72,12 +72,12 @@ public class Saw extends VirtualizedRegistry<SawRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<SawRecipe> streamRecipes() {
         return new SimpleObjectStream<>(BWRegistry.WOOD_SAW.getRecipes()).setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         BWRegistry.WOOD_SAW.getRecipes().forEach(this::addBackup);
         BWRegistry.WOOD_SAW.getRecipes().clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/Turntable.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/Turntable.java
@@ -51,7 +51,7 @@ public class Turntable extends VirtualizedRegistry<TurntableRecipe> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('minecraft:clay_ball')"))
+    @MethodDescription(example = @Example("item('minecraft:clay_ball')"))
     public boolean removeByOutput(IIngredient output) {
         return BWRegistry.TURNTABLE.getRecipes().removeIf(r -> {
             for (ItemStack itemstack : r.getOutputs()) {
@@ -64,7 +64,7 @@ public class Turntable extends VirtualizedRegistry<TurntableRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('betterwithmods:unfired_pottery')"))
+    @MethodDescription(example = @Example("item('betterwithmods:unfired_pottery')"))
     public boolean removeByInput(IIngredient input) {
         return BWRegistry.TURNTABLE.getRecipes().removeIf(r -> {
             for (ItemStack itemstack : r.getInput().getMatchingStacks()) {
@@ -77,12 +77,12 @@ public class Turntable extends VirtualizedRegistry<TurntableRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<TurntableRecipe> streamRecipes() {
         return new SimpleObjectStream<>(BWRegistry.TURNTABLE.getRecipes()).setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         BWRegistry.TURNTABLE.getRecipes().forEach(this::addBackup);
         BWRegistry.TURNTABLE.getRecipes().clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/bloodmagic/AlchemyArray.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/bloodmagic/AlchemyArray.java
@@ -67,7 +67,7 @@ public class AlchemyArray extends VirtualizedRegistry<RecipeAlchemyArray> {
         return true;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('bloodmagic:component:13')"))
+    @MethodDescription(example = @Example("item('bloodmagic:component:13')"))
     public boolean removeByInput(IIngredient input) {
         if (((BloodMagicRecipeRegistrarAccessor) BloodMagicAPI.INSTANCE.getRecipeRegistrar()).getAlchemyArrayRecipes().removeIf(recipe -> {
             boolean found = recipe.getInput().test(IngredientHelper.toItemStack(input));
@@ -86,7 +86,7 @@ public class AlchemyArray extends VirtualizedRegistry<RecipeAlchemyArray> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByCatalyst", example = @Example("item('bloodmagic:slate:2')"))
+    @MethodDescription(example = @Example("item('bloodmagic:slate:2')"))
     public boolean removeByCatalyst(IIngredient catalyst) {
         if (((BloodMagicRecipeRegistrarAccessor) BloodMagicAPI.INSTANCE.getRecipeRegistrar()).getAlchemyArrayRecipes().removeIf(recipe -> {
             boolean found = recipe.getCatalyst().test(IngredientHelper.toItemStack(catalyst));
@@ -105,7 +105,7 @@ public class AlchemyArray extends VirtualizedRegistry<RecipeAlchemyArray> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInputAndCatalyst", example = @Example("item('bloodmagic:component:7'), item('bloodmagic:slate:1')"))
+    @MethodDescription(example = @Example("item('bloodmagic:component:7'), item('bloodmagic:slate:1')"))
     public boolean removeByInputAndCatalyst(IIngredient input, IIngredient catalyst) {
         if (((BloodMagicRecipeRegistrarAccessor) BloodMagicAPI.INSTANCE.getRecipeRegistrar()).getAlchemyArrayRecipes().removeIf(recipe -> {
             boolean removeRecipe = recipe.getInput().test(IngredientHelper.toItemStack(input)) && recipe.getCatalyst().test(IngredientHelper.toItemStack(catalyst));
@@ -124,7 +124,7 @@ public class AlchemyArray extends VirtualizedRegistry<RecipeAlchemyArray> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('bloodmagic:sigil_void')"))
+    @MethodDescription(example = @Example("item('bloodmagic:sigil_void')"))
     public boolean removeByOutput(ItemStack output) {
         if (((BloodMagicRecipeRegistrarAccessor) BloodMagicAPI.INSTANCE.getRecipeRegistrar()).getAlchemyArrayRecipes().removeIf(recipe -> {
             boolean matches = recipe.getOutput().isItemEqual(output);
@@ -143,13 +143,13 @@ public class AlchemyArray extends VirtualizedRegistry<RecipeAlchemyArray> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         ((BloodMagicRecipeRegistrarAccessor) BloodMagicAPI.INSTANCE.getRecipeRegistrar()).getAlchemyArrayRecipes().forEach(this::addBackup);
         ((BloodMagicRecipeRegistrarAccessor) BloodMagicAPI.INSTANCE.getRecipeRegistrar()).getAlchemyArrayRecipes().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<RecipeAlchemyArray> streamRecipes() {
         return new SimpleObjectStream<>(((BloodMagicRecipeRegistrarAccessor) BloodMagicAPI.INSTANCE.getRecipeRegistrar()).getAlchemyArrayRecipes())
                 .setRemover(this::remove);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/bloodmagic/AlchemyTable.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/bloodmagic/AlchemyTable.java
@@ -62,15 +62,14 @@ public class AlchemyTable extends VirtualizedRegistry<RecipeAlchemyTable> {
         return true;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput")
+    @MethodDescription
     public boolean removeByInput(IIngredient... input) {
         NonNullList<IIngredient> inputs = NonNullList.create();
         Collections.addAll(inputs, input);
         return removeByInput(inputs);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput",
-                       example = @Example("item('minecraft:nether_wart'), item('minecraft:gunpowder')"))
+    @MethodDescription(example = @Example("item('minecraft:nether_wart'), item('minecraft:gunpowder')"))
     public boolean removeByInput(NonNullList<IIngredient> input) {
         // Filters down to only recipes which have inputs that match all the input IIngredients (NOTE: a recipe with ABCD would match an input of AB)
         if (((BloodMagicRecipeRegistrarAccessor) BloodMagicAPI.INSTANCE.getRecipeRegistrar()).getAlchemyRecipes().removeIf(recipe -> {
@@ -97,7 +96,7 @@ public class AlchemyTable extends VirtualizedRegistry<RecipeAlchemyTable> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('minecraft:sand')"))
+    @MethodDescription(example = @Example("item('minecraft:sand')"))
     public boolean removeByOutput(ItemStack output) {
         if (((BloodMagicRecipeRegistrarAccessor) BloodMagicAPI.INSTANCE.getRecipeRegistrar()).getAlchemyRecipes().removeIf(recipe -> {
             boolean matches = ItemStack.areItemStacksEqual(recipe.getOutput(), output);
@@ -115,13 +114,13 @@ public class AlchemyTable extends VirtualizedRegistry<RecipeAlchemyTable> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         ((BloodMagicRecipeRegistrarAccessor) BloodMagicAPI.INSTANCE.getRecipeRegistrar()).getAlchemyRecipes().forEach(this::addBackup);
         ((BloodMagicRecipeRegistrarAccessor) BloodMagicAPI.INSTANCE.getRecipeRegistrar()).getAlchemyRecipes().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<RecipeAlchemyTable> streamRecipes() {
         return new SimpleObjectStream<>(((BloodMagicRecipeRegistrarAccessor) BloodMagicAPI.INSTANCE.getRecipeRegistrar()).getAlchemyRecipes())
                 .setRemover(this::remove);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/bloodmagic/BloodAltar.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/bloodmagic/BloodAltar.java
@@ -63,7 +63,7 @@ public class BloodAltar extends VirtualizedRegistry<RecipeBloodAltar> {
         return true;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:ender_pearl')"))
+    @MethodDescription(example = @Example("item('minecraft:ender_pearl')"))
     public boolean removeByInput(IIngredient input) {
         if (((BloodMagicRecipeRegistrarAccessor) BloodMagicAPI.INSTANCE.getRecipeRegistrar()).getAltarRecipes().removeIf(recipe -> {
             boolean removeRecipe = recipe.getInput().test(IngredientHelper.toItemStack(input));
@@ -82,7 +82,7 @@ public class BloodAltar extends VirtualizedRegistry<RecipeBloodAltar> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('bloodmagic:slate:4')"))
+    @MethodDescription(example = @Example("item('bloodmagic:slate:4')"))
     public boolean removeByOutput(ItemStack output) {
         if (((BloodMagicRecipeRegistrarAccessor) BloodMagicAPI.INSTANCE.getRecipeRegistrar()).getAltarRecipes().removeIf(recipe -> {
             boolean matches = ItemStack.areItemStacksEqual(recipe.getOutput(), output);
@@ -101,13 +101,13 @@ public class BloodAltar extends VirtualizedRegistry<RecipeBloodAltar> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         ((BloodMagicRecipeRegistrarAccessor) BloodMagicAPI.INSTANCE.getRecipeRegistrar()).getAltarRecipes().forEach(this::addBackup);
         ((BloodMagicRecipeRegistrarAccessor) BloodMagicAPI.INSTANCE.getRecipeRegistrar()).getAltarRecipes().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<RecipeBloodAltar> streamRecipes() {
         return new SimpleObjectStream<>(((BloodMagicRecipeRegistrarAccessor) BloodMagicAPI.INSTANCE.getRecipeRegistrar()).getAltarRecipes())
                 .setRemover(this::remove);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/bloodmagic/Meteor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/bloodmagic/Meteor.java
@@ -61,7 +61,7 @@ public class Meteor extends VirtualizedRegistry<WayofTime.bloodmagic.meteor.Mete
         return remove(MeteorRegistry.getMeteorForItem(input));
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:gold_block')"))
+    @MethodDescription(example = @Example("item('minecraft:gold_block')"))
     public boolean removeByInput(ItemStack input) {
         return remove(MeteorRegistry.getMeteorForItem(input));
     }
@@ -71,13 +71,13 @@ public class Meteor extends VirtualizedRegistry<WayofTime.bloodmagic.meteor.Mete
         return removeByInput(catalyst);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         MeteorRegistry.meteorMap.forEach((i, x) -> addBackup(x));
         MeteorRegistry.meteorMap.clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<Map.Entry<ItemStack, WayofTime.bloodmagic.meteor.Meteor>> streamRecipes() {
         return new SimpleObjectStream<>(MeteorRegistry.meteorMap.entrySet())
                 .setRemover(x -> this.remove(x.getKey()));

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/bloodmagic/Sacrificial.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/bloodmagic/Sacrificial.java
@@ -76,13 +76,13 @@ public class Sacrificial extends VirtualizedRegistry<Pair<ResourceLocation, Inte
         return remove(entity.getName());
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         ((BloodMagicValueManagerAccessor) BloodMagicAPI.INSTANCE.getValueManager()).getSacrificial().forEach((l, r) -> this.addBackup(Pair.of(l, r)));
         ((BloodMagicValueManagerAccessor) BloodMagicAPI.INSTANCE.getValueManager()).getSacrificial().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<Map.Entry<ResourceLocation, Integer>> streamRecipes() {
         return new SimpleObjectStream<>(((BloodMagicValueManagerAccessor) BloodMagicAPI.INSTANCE.getValueManager()).getSacrificial().entrySet())
                 .setRemover(r -> this.remove(r.getKey()));

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/bloodmagic/TartaricForge.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/bloodmagic/TartaricForge.java
@@ -68,7 +68,7 @@ public class TartaricForge extends VirtualizedRegistry<RecipeTartaricForge> {
         return true;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = {
+    @MethodDescription(example = {
             @Example("item('minecraft:cauldron'), item('minecraft:stone'), item('minecraft:dye:4'), item('minecraft:diamond')"),
             @Example("item('minecraft:gunpowder'), item('minecraft:redstone')")
     })
@@ -78,7 +78,7 @@ public class TartaricForge extends VirtualizedRegistry<RecipeTartaricForge> {
         return removeByInput(inputs);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput")
+    @MethodDescription
     public boolean removeByInput(NonNullList<IIngredient> input) {
         // Filters down to only recipes which have inputs that match all the input IIngredients (NOTE: a recipe with ABCD would match an input of AB)
         if (((BloodMagicRecipeRegistrarAccessor) BloodMagicAPI.INSTANCE.getRecipeRegistrar()).getTartaricForgeRecipes().removeIf(recipe -> {
@@ -105,7 +105,7 @@ public class TartaricForge extends VirtualizedRegistry<RecipeTartaricForge> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('bloodmagic:demon_crystal')"))
+    @MethodDescription(example = @Example("item('bloodmagic:demon_crystal')"))
     public boolean removeByOutput(ItemStack output) {
         if (((BloodMagicRecipeRegistrarAccessor) BloodMagicAPI.INSTANCE.getRecipeRegistrar()).getTartaricForgeRecipes().removeIf(recipe -> {
             boolean matches = ItemStack.areItemStacksEqual(recipe.getOutput(), output);
@@ -123,13 +123,13 @@ public class TartaricForge extends VirtualizedRegistry<RecipeTartaricForge> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         ((BloodMagicRecipeRegistrarAccessor) BloodMagicAPI.INSTANCE.getRecipeRegistrar()).getTartaricForgeRecipes().forEach(this::addBackup);
         ((BloodMagicRecipeRegistrarAccessor) BloodMagicAPI.INSTANCE.getRecipeRegistrar()).getTartaricForgeRecipes().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<RecipeTartaricForge> streamRecipes() {
         return new SimpleObjectStream<>(((BloodMagicRecipeRegistrarAccessor) BloodMagicAPI.INSTANCE.getRecipeRegistrar()).getTartaricForgeRecipes())
                 .setRemover(this::remove);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/bloodmagic/Tranquility.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/bloodmagic/Tranquility.java
@@ -117,13 +117,13 @@ public class Tranquility extends VirtualizedRegistry<Pair<IBlockState, Tranquili
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         ((BloodMagicValueManagerAccessor) BloodMagicAPI.INSTANCE.getValueManager()).getTranquility().forEach((l, r) -> this.addBackup(Pair.of(l, r)));
         ((BloodMagicValueManagerAccessor) BloodMagicAPI.INSTANCE.getValueManager()).getTranquility().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<Map.Entry<IBlockState, TranquilityStack>> streamRecipes() {
         return new SimpleObjectStream<>(((BloodMagicValueManagerAccessor) BloodMagicAPI.INSTANCE.getValueManager()).getTranquility().entrySet())
                 .setRemover(r -> this.remove(r.getKey(), r.getValue().type));

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/Apothecary.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/Apothecary.java
@@ -57,7 +57,7 @@ public class Apothecary extends VirtualizedRegistry<RecipePetals> {
         return BotaniaAPI.petalRecipes.remove(recipe);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('botania:specialflower').withNbt(['type': 'puredaisy'])"))
+    @MethodDescription(example = @Example("item('botania:specialflower').withNbt(['type': 'puredaisy'])"))
     public boolean removeByOutput(IIngredient output) {
         if (BotaniaAPI.petalRecipes.removeIf(recipe -> {
             boolean found = output.test(recipe.getOutput());
@@ -72,7 +72,7 @@ public class Apothecary extends VirtualizedRegistry<RecipePetals> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("ore('runeFireB')"))
+    @MethodDescription(example = @Example("ore('runeFireB')"))
     public boolean removeByInput(IIngredient... inputs) {
         List<Object> converted = Arrays.stream(inputs).map(i -> i instanceof OreDictIngredient ? ((OreDictIngredient) i).getOreDict()
                                                                                                : i.getMatchingStacks()[0]).collect(Collectors.toList());
@@ -95,13 +95,13 @@ public class Apothecary extends VirtualizedRegistry<RecipePetals> {
         return removeByInput(inputs);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         BotaniaAPI.petalRecipes.forEach(this::addBackup);
         BotaniaAPI.petalRecipes.clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<RecipePetals> streamRecipes() {
         return new SimpleObjectStream<>(BotaniaAPI.petalRecipes).setRemover(this::remove);
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/Brew.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/Brew.java
@@ -51,7 +51,7 @@ public class Brew extends VirtualizedRegistry<vazkii.botania.api.brew.Brew> {
         return BotaniaAPI.brewMap.remove(brew) != null;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         BotaniaAPI.brewMap.forEach((l, r) -> this.addBackup(r));
         BotaniaAPI.brewMap.clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/BrewRecipe.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/BrewRecipe.java
@@ -44,7 +44,7 @@ public class BrewRecipe extends VirtualizedRegistry<RecipeBrew> {
         return BotaniaAPI.brewRecipes.remove(recipe);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("'speed'"))
+    @MethodDescription(example = @Example("'speed'"))
     public boolean removeByOutput(String brew) {
         if (BotaniaAPI.brewRecipes.removeIf(recipe -> {
             boolean found = recipe.getBrew().getKey().equals(brew);
@@ -59,12 +59,12 @@ public class BrewRecipe extends VirtualizedRegistry<RecipeBrew> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("brew('allure')"))
+    @MethodDescription(example = @Example("brew('allure')"))
     public boolean removeByOutput(vazkii.botania.api.brew.Brew brew) {
         return removeByOutput(brew.getKey());
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:iron_ingot')"))
+    @MethodDescription(example = @Example("item('minecraft:iron_ingot')"))
     public boolean removeByInput(IIngredient... inputs) {
         List<Object> converted = Arrays.stream(inputs).map(i -> i instanceof OreDictIngredient ? ((OreDictIngredient) i).getOreDict()
                                                                                                : i.getMatchingStacks()[0]).collect(Collectors.toList());
@@ -88,13 +88,13 @@ public class BrewRecipe extends VirtualizedRegistry<RecipeBrew> {
         return removeByInput(inputs);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         BotaniaAPI.brewRecipes.forEach(this::addBackup);
         BotaniaAPI.brewRecipes.clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<RecipeBrew> streamRecipes() {
         return new SimpleObjectStream<>(BotaniaAPI.brewRecipes).setRemover(this::remove);
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/ElvenTrade.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/ElvenTrade.java
@@ -93,13 +93,13 @@ public class ElvenTrade extends VirtualizedRegistry<RecipeElvenTrade> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         BotaniaAPI.elvenTradeRecipes.forEach(this::addBackup);
         BotaniaAPI.elvenTradeRecipes.clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<RecipeElvenTrade> streamRecipes() {
         return new SimpleObjectStream<>(BotaniaAPI.elvenTradeRecipes).setRemover(this::remove);
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/Lexicon.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/Lexicon.java
@@ -91,7 +91,7 @@ public class Lexicon {
             return new SimpleObjectStream<>(BotaniaAPI.getAllCategories()).setRemover(this::remove);
         }
 
-        @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+        @MethodDescription(priority = 2000, example = @Example(commented = true))
         public void removeAll() {
             BotaniaAPI.getAllCategories().forEach(this::addBackup);
             BotaniaAPI.getAllCategories().clear();
@@ -159,7 +159,7 @@ public class Lexicon {
         }
 
 
-        @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+        @MethodDescription(priority = 2000, example = @Example(commented = true))
         public void removeAll() {
             for (LexiconEntry entry : BotaniaAPI.getAllEntries()) {
                 entry.pages.forEach(x -> addBackup(new PageChange(x, entry, entry.pages.indexOf(x))));
@@ -321,7 +321,7 @@ public class Lexicon {
             removeByCategory(category);
         }
 
-        @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+        @MethodDescription(priority = 2000, example = @Example(commented = true))
         public void removeAll() {
             BotaniaAPI.getAllEntries().forEach(this::addBackup);
             BotaniaAPI.getAllEntries().clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/ManaInfusion.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/ManaInfusion.java
@@ -51,7 +51,7 @@ public class ManaInfusion extends VirtualizedRegistry<RecipeManaInfusion> {
         return BotaniaAPI.manaInfusionRecipes.remove(recipe);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('botania:managlass')"))
+    @MethodDescription(example = @Example("item('botania:managlass')"))
     public boolean removeByOutput(ItemStack output) {
         if (BotaniaAPI.manaInfusionRecipes.removeIf(recipe -> {
             boolean found = ItemStack.areItemStacksEqual(recipe.getOutput(), output);
@@ -66,7 +66,7 @@ public class ManaInfusion extends VirtualizedRegistry<RecipeManaInfusion> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:ender_pearl')"))
+    @MethodDescription(example = @Example("item('minecraft:ender_pearl')"))
     public boolean removeByInput(IIngredient input) {
         if (BotaniaAPI.manaInfusionRecipes.removeIf(recipe -> {
             boolean found = recipe.getInput() instanceof ItemStack ? input.test((ItemStack) recipe.getInput())
@@ -98,13 +98,13 @@ public class ManaInfusion extends VirtualizedRegistry<RecipeManaInfusion> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         BotaniaAPI.manaInfusionRecipes.forEach(this::addBackup);
         BotaniaAPI.manaInfusionRecipes.clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<RecipeManaInfusion> streamRecipes() {
         return new SimpleObjectStream<>(BotaniaAPI.manaInfusionRecipes).setRemover(this::remove);
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/Orechid.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/Orechid.java
@@ -58,7 +58,7 @@ public class Orechid extends VirtualizedRegistry<OrechidRecipe> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("'oreCoal'"))
+    @MethodDescription(example = @Example("'oreCoal'"))
     public boolean removeByOutput(String output) {
         if (BotaniaAPI.oreWeights.containsKey(output)) {
             addBackup(new OrechidRecipe(output, BotaniaAPI.getOreWeight(output)));
@@ -73,18 +73,18 @@ public class Orechid extends VirtualizedRegistry<OrechidRecipe> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = {@Example(value = "ore('oreEmerald')", commented = true), @Example(value = "ore('oreQuartz')", commented = true)})
+    @MethodDescription(example = {@Example(value = "ore('oreEmerald')", commented = true), @Example(value = "ore('oreQuartz')", commented = true)})
     public boolean removeByOutput(OreDictIngredient output) {
         return removeByOutput(output.getOreDict());
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         getAllRecipes().forEach(this::addBackup);
         BotaniaAPI.oreWeights.clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<OrechidRecipe> streamRecipes() {
         return new SimpleObjectStream<>(getAllRecipes(), false).setRemover(this::remove);
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/OrechidIgnem.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/OrechidIgnem.java
@@ -47,7 +47,7 @@ public class OrechidIgnem extends Orechid {
     }
 
     @Override
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("'oreQuartz'"))
+    @MethodDescription(example = @Example("'oreQuartz'"))
     public boolean removeByOutput(String output) {
         if (BotaniaAPI.oreWeightsNether.containsKey(output)) {
             addBackup(new OrechidRecipe(output, BotaniaAPI.getOreWeightNether(output)));
@@ -63,7 +63,7 @@ public class OrechidIgnem extends Orechid {
     }
 
     @Override
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         getAllRecipes().forEach(this::addBackup);
         BotaniaAPI.oreWeightsNether.clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/PureDaisy.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/PureDaisy.java
@@ -52,7 +52,7 @@ public class PureDaisy extends VirtualizedRegistry<RecipePureDaisy> {
         return BotaniaAPI.pureDaisyRecipes.remove(recipe);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("blockstate('botania:livingrock')"))
+    @MethodDescription(example = @Example("blockstate('botania:livingrock')"))
     public boolean removeByOutput(IBlockState output) {
         if (BotaniaAPI.pureDaisyRecipes.removeIf(recipe -> {
             boolean found = recipe.getOutputState().equals(output);
@@ -67,7 +67,7 @@ public class PureDaisy extends VirtualizedRegistry<RecipePureDaisy> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput")
+    @MethodDescription
     public boolean removeByInput(String input) {
         if (BotaniaAPI.pureDaisyRecipes.removeIf(recipe -> {
             boolean found = recipe.getInput() instanceof String && recipe.getInput().equals(input);
@@ -82,12 +82,12 @@ public class PureDaisy extends VirtualizedRegistry<RecipePureDaisy> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("ore('logWood')"))
+    @MethodDescription(example = @Example("ore('logWood')"))
     public boolean removeByInput(OreDictIngredient input) {
         return removeByInput(input.getOreDict());
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("blockstate('minecraft:water')"))
+    @MethodDescription(example = @Example("blockstate('minecraft:water')"))
     public boolean removeByInput(IBlockState input) {
         if (BotaniaAPI.pureDaisyRecipes.removeIf(recipe -> {
             boolean found = (recipe.getInput() instanceof IBlockState && recipe.getInput().equals(input)) || (recipe.getInput() instanceof Block && recipe.getInput() == input.getBlock());
@@ -102,18 +102,18 @@ public class PureDaisy extends VirtualizedRegistry<RecipePureDaisy> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput")
+    @MethodDescription
     public boolean removeByInput(Block input) {
         return removeByInput(input.getDefaultState());
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         BotaniaAPI.pureDaisyRecipes.forEach(this::addBackup);
         BotaniaAPI.pureDaisyRecipes.clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<RecipePureDaisy> streamRecipes() {
         return new SimpleObjectStream<>(BotaniaAPI.pureDaisyRecipes).setRemover(this::remove);
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/RuneAltar.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/RuneAltar.java
@@ -55,7 +55,7 @@ public class RuneAltar extends VirtualizedRegistry<RecipeRuneAltar> {
         return BotaniaAPI.runeAltarRecipes.remove(recipe);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('botania:rune:1')"))
+    @MethodDescription(example = @Example("item('botania:rune:1')"))
     public boolean removeByOutput(IIngredient output) {
         if (BotaniaAPI.runeAltarRecipes.removeIf(recipe -> {
             boolean found = output.test(recipe.getOutput());
@@ -70,7 +70,7 @@ public class RuneAltar extends VirtualizedRegistry<RecipeRuneAltar> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("ore('runeEarthB')"))
+    @MethodDescription(example = @Example("ore('runeEarthB')"))
     public boolean removeByInput(IIngredient... inputs) {
         List<Object> converted = Arrays.stream(inputs).map(i -> i instanceof OreDictIngredient ? ((OreDictIngredient) i).getOreDict()
                                                                                                : i.getMatchingStacks()[0]).collect(Collectors.toList());
@@ -94,13 +94,13 @@ public class RuneAltar extends VirtualizedRegistry<RecipeRuneAltar> {
         return removeByInput(inputs);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         BotaniaAPI.runeAltarRecipes.forEach(this::addBackup);
         BotaniaAPI.runeAltarRecipes.clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<RecipeRuneAltar> streamRecipes() {
         return new SimpleObjectStream<>(BotaniaAPI.runeAltarRecipes).setRemover(this::remove);
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/calculator/AlgorithmSeparator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/calculator/AlgorithmSeparator.java
@@ -42,7 +42,7 @@ public class AlgorithmSeparator extends VirtualizedRegistry<CalculatorRecipe> {
         return true;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('calculator:tanzaniteleaves')"))
+    @MethodDescription(example = @Example("item('calculator:tanzaniteleaves')"))
     public boolean removeByInput(IIngredient input) {
         return AlgorithmSeparatorRecipes.instance().getRecipes().removeIf(recipe -> {
             for (ISonarRecipeObject recipeInput : recipe.inputs()) {
@@ -57,7 +57,7 @@ public class AlgorithmSeparator extends VirtualizedRegistry<CalculatorRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('calculator:weakeneddiamond')"))
+    @MethodDescription(example = @Example("item('calculator:weakeneddiamond')"))
     public boolean removeByOutput(IIngredient output) {
         return AlgorithmSeparatorRecipes.instance().getRecipes().removeIf(r -> {
             for (ISonarRecipeObject recipeOutput : r.recipeOutputs) {
@@ -72,13 +72,13 @@ public class AlgorithmSeparator extends VirtualizedRegistry<CalculatorRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         AlgorithmSeparatorRecipes.instance().getRecipes().forEach(this::addBackup);
         AlgorithmSeparatorRecipes.instance().getRecipes().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<CalculatorRecipe> streamRecipes() {
         return new SimpleObjectStream<>(AlgorithmSeparatorRecipes.instance().getRecipes())
                 .setRemover(this::remove);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/calculator/AnalysingChamber.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/calculator/AnalysingChamber.java
@@ -74,7 +74,7 @@ public class AnalysingChamber extends VirtualizedRegistry<CalculatorRecipe> {
         return true;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('sonarcore:reinforceddirtblock')"))
+    @MethodDescription(example = @Example("item('sonarcore:reinforceddirtblock')"))
     public boolean removeByInput(IIngredient input) {
         return AnalysingChamberRecipes.instance().getRecipes().removeIf(r -> {
             for (ISonarRecipeObject recipeInput : r.recipeInputs) {
@@ -89,13 +89,13 @@ public class AnalysingChamber extends VirtualizedRegistry<CalculatorRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         AnalysingChamberRecipes.instance().getRecipes().forEach(this::addBackup);
         AnalysingChamberRecipes.instance().getRecipes().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<CalculatorRecipe> streamRecipes() {
         return new SimpleObjectStream<>(AnalysingChamberRecipes.instance().getRecipes())
                 .setRemover(this::remove);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/calculator/AtomicCalculator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/calculator/AtomicCalculator.java
@@ -42,7 +42,7 @@ public class AtomicCalculator extends VirtualizedRegistry<CalculatorRecipe> {
         return true;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:end_stone')"))
+    @MethodDescription(example = @Example("item('minecraft:end_stone')"))
     public boolean removeByInput(IIngredient input) {
         return AtomicCalculatorRecipes.instance().getRecipes().removeIf(r -> {
             for (ISonarRecipeObject recipeInput : r.recipeInputs) {
@@ -57,7 +57,7 @@ public class AtomicCalculator extends VirtualizedRegistry<CalculatorRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('calculator:firediamond')"))
+    @MethodDescription(example = @Example("item('calculator:firediamond')"))
     public boolean removeByOutput(IIngredient output) {
         return AtomicCalculatorRecipes.instance().getRecipes().removeIf(r -> {
             for (ISonarRecipeObject recipeOutput : r.recipeOutputs) {
@@ -72,13 +72,13 @@ public class AtomicCalculator extends VirtualizedRegistry<CalculatorRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         AtomicCalculatorRecipes.instance().getRecipes().forEach(this::addBackup);
         AtomicCalculatorRecipes.instance().getRecipes().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<CalculatorRecipe> streamRecipes() {
         return new SimpleObjectStream<>(AtomicCalculatorRecipes.instance().getRecipes())
                 .setRemover(this::remove);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/calculator/BasicCalculator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/calculator/BasicCalculator.java
@@ -47,7 +47,7 @@ public class BasicCalculator extends VirtualizedRegistry<CalculatorRecipe> {
         return true;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:cobblestone')"))
+    @MethodDescription(example = @Example("item('minecraft:cobblestone')"))
     public boolean removeByInput(IIngredient input) {
         return CalculatorRecipes.instance().getRecipes().removeIf(r -> {
             for (ISonarRecipeObject recipeInput : r.recipeInputs) {
@@ -62,7 +62,7 @@ public class BasicCalculator extends VirtualizedRegistry<CalculatorRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('calculator:reinforcedironingot')"))
+    @MethodDescription(example = @Example("item('calculator:reinforcedironingot')"))
     public boolean removeByOutput(IIngredient output) {
         return CalculatorRecipes.instance().getRecipes().removeIf(r -> {
             for (ISonarRecipeObject recipeOutput : r.recipeOutputs) {
@@ -77,13 +77,13 @@ public class BasicCalculator extends VirtualizedRegistry<CalculatorRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         CalculatorRecipes.instance().getRecipes().forEach(this::addBackup);
         CalculatorRecipes.instance().getRecipes().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<CalculatorRecipe> streamRecipes() {
         return new SimpleObjectStream<>(CalculatorRecipes.instance().getRecipes())
                 .setRemover(this::remove);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/calculator/ConductorMast.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/calculator/ConductorMast.java
@@ -42,7 +42,7 @@ public class ConductorMast extends VirtualizedRegistry<DefaultSonarRecipe.Value>
         return true;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('calculator:firediamond')"))
+    @MethodDescription(example = @Example("item('calculator:firediamond')"))
     public boolean removeByInput(IIngredient input) {
         return ConductorMastRecipes.instance().getRecipes().removeIf(r -> {
             for (ISonarRecipeObject recipeInput : r.recipeInputs) {
@@ -57,7 +57,7 @@ public class ConductorMast extends VirtualizedRegistry<DefaultSonarRecipe.Value>
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('calculator:material:7')"))
+    @MethodDescription(example = @Example("item('calculator:material:7')"))
     public boolean removeByOutput(IIngredient output) {
         return ConductorMastRecipes.instance().getRecipes().removeIf(r -> {
             for (ISonarRecipeObject recipeOutput : r.recipeOutputs) {
@@ -72,13 +72,13 @@ public class ConductorMast extends VirtualizedRegistry<DefaultSonarRecipe.Value>
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         ConductorMastRecipes.instance().getRecipes().forEach(this::addBackup);
         ConductorMastRecipes.instance().getRecipes().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<DefaultSonarRecipe.Value> streamRecipes() {
         return new SimpleObjectStream<>(ConductorMastRecipes.instance().getRecipes())
                 .setRemover(this::remove);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/calculator/ExtractionChamber.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/calculator/ExtractionChamber.java
@@ -46,7 +46,7 @@ public class ExtractionChamber extends VirtualizedRegistry<CalculatorRecipe> {
         return true;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:dirt')"))
+    @MethodDescription(example = @Example("item('minecraft:dirt')"))
     public boolean removeByInput(IIngredient input) {
         return ExtractionChamberRecipes.instance().getRecipes().removeIf(r -> {
             for (ISonarRecipeObject recipeInput : r.recipeInputs) {
@@ -61,7 +61,7 @@ public class ExtractionChamber extends VirtualizedRegistry<CalculatorRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('calculator:smallstone')"))
+    @MethodDescription(example = @Example("item('calculator:smallstone')"))
     public boolean removeByOutput(IIngredient output) {
         return ExtractionChamberRecipes.instance().getRecipes().removeIf(r -> {
             for (ISonarRecipeObject recipeOutput : r.recipeOutputs) {
@@ -76,13 +76,13 @@ public class ExtractionChamber extends VirtualizedRegistry<CalculatorRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         ExtractionChamberRecipes.instance().getRecipes().forEach(this::addBackup);
         ExtractionChamberRecipes.instance().getRecipes().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<CalculatorRecipe> streamRecipes() {
         return new SimpleObjectStream<>(ExtractionChamberRecipes.instance().getRecipes())
                 .setRemover(this::remove);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/calculator/FabricationChamber.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/calculator/FabricationChamber.java
@@ -51,7 +51,7 @@ public class FabricationChamber extends VirtualizedRegistry<FabricationSonarReci
         return true;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('calculator:circuitboard:8').withNbt([Stable: 0, Analysed: 1])"))
+    @MethodDescription(example = @Example("item('calculator:circuitboard:8').withNbt([Stable: 0, Analysed: 1])"))
     public boolean removeByInput(IIngredient input) {
         return FabricationChamberRecipes.instance().getRecipes().removeIf(r -> {
             for (ISonarRecipeObject recipeInput : r.recipeInputs) {
@@ -66,7 +66,7 @@ public class FabricationChamber extends VirtualizedRegistry<FabricationSonarReci
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('calculator:calculatorassembly')"))
+    @MethodDescription(example = @Example("item('calculator:calculatorassembly')"))
     public boolean removeByOutput(IIngredient output) {
         return FabricationChamberRecipes.instance().getRecipes().removeIf(r -> {
             for (ISonarRecipeObject recipeOutput : r.recipeOutputs) {
@@ -81,13 +81,13 @@ public class FabricationChamber extends VirtualizedRegistry<FabricationSonarReci
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         FabricationChamberRecipes.instance().getRecipes().forEach(this::addBackup);
         FabricationChamberRecipes.instance().getRecipes().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<FabricationSonarRecipe> streamRecipes() {
         return new SimpleObjectStream<>(FabricationChamberRecipes.instance().getRecipes())
                 .setRemover(this::remove);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/calculator/FlawlessCalculator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/calculator/FlawlessCalculator.java
@@ -42,7 +42,7 @@ public class FlawlessCalculator extends VirtualizedRegistry<CalculatorRecipe> {
         return true;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:obsidian')"))
+    @MethodDescription(example = @Example("item('minecraft:obsidian')"))
     public boolean removeByInput(IIngredient input) {
         return FlawlessCalculatorRecipes.instance().getRecipes().removeIf(r -> {
             for (ISonarRecipeObject recipeInput : r.recipeInputs) {
@@ -57,7 +57,7 @@ public class FlawlessCalculator extends VirtualizedRegistry<CalculatorRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('minecraft:ender_pearl')"))
+    @MethodDescription(example = @Example("item('minecraft:ender_pearl')"))
     public boolean removeByOutput(IIngredient output) {
         return FlawlessCalculatorRecipes.instance().getRecipes().removeIf(r -> {
             for (ISonarRecipeObject recipeOutput : r.recipeOutputs) {
@@ -72,13 +72,13 @@ public class FlawlessCalculator extends VirtualizedRegistry<CalculatorRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         FlawlessCalculatorRecipes.instance().getRecipes().forEach(this::addBackup);
         FlawlessCalculatorRecipes.instance().getRecipes().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<CalculatorRecipe> streamRecipes() {
         return new SimpleObjectStream<>(FlawlessCalculatorRecipes.instance().getRecipes())
                 .setRemover(this::remove);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/calculator/GlowstoneExtractor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/calculator/GlowstoneExtractor.java
@@ -42,7 +42,7 @@ public class GlowstoneExtractor extends VirtualizedRegistry<DefaultSonarRecipe.V
         return true;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:glowstone')"))
+    @MethodDescription(example = @Example("item('minecraft:glowstone')"))
     public boolean removeByInput(IIngredient input) {
         return GlowstoneExtractorRecipes.instance().getRecipes().removeIf(r -> {
             for (ISonarRecipeObject recipeInput : r.recipeInputs) {
@@ -57,13 +57,13 @@ public class GlowstoneExtractor extends VirtualizedRegistry<DefaultSonarRecipe.V
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         GlowstoneExtractorRecipes.instance().getRecipes().forEach(this::addBackup);
         GlowstoneExtractorRecipes.instance().getRecipes().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<DefaultSonarRecipe.Value> streamRecipes() {
         return new SimpleObjectStream<>(GlowstoneExtractorRecipes.instance().getRecipes())
                 .setRemover(this::remove);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/calculator/HealthProcessor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/calculator/HealthProcessor.java
@@ -42,7 +42,7 @@ public class HealthProcessor extends VirtualizedRegistry<DefaultSonarRecipe.Valu
         return true;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:blaze_rod')"))
+    @MethodDescription(example = @Example("item('minecraft:blaze_rod')"))
     public boolean removeByInput(IIngredient input) {
         return HealthProcessorRecipes.instance().getRecipes().removeIf(r -> {
             for (ISonarRecipeObject recipeInput : r.recipeInputs) {
@@ -57,13 +57,13 @@ public class HealthProcessor extends VirtualizedRegistry<DefaultSonarRecipe.Valu
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         HealthProcessorRecipes.instance().getRecipes().forEach(this::addBackup);
         HealthProcessorRecipes.instance().getRecipes().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<DefaultSonarRecipe.Value> streamRecipes() {
         return new SimpleObjectStream<>(HealthProcessorRecipes.instance().getRecipes())
                 .setRemover(this::remove);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/calculator/PrecisionChamber.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/calculator/PrecisionChamber.java
@@ -45,7 +45,7 @@ public class PrecisionChamber extends VirtualizedRegistry<CalculatorRecipe> {
         return true;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:clay')"))
+    @MethodDescription(example = @Example("item('minecraft:clay')"))
     public boolean removeByInput(IIngredient input) {
         return PrecisionChamberRecipes.instance().getRecipes().removeIf(r -> {
             for (ISonarRecipeObject recipeInput : r.recipeInputs) {
@@ -60,7 +60,7 @@ public class PrecisionChamber extends VirtualizedRegistry<CalculatorRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('calculator:soil')"))
+    @MethodDescription(example = @Example("item('calculator:soil')"))
     public boolean removeByOutput(IIngredient output) {
         return PrecisionChamberRecipes.instance().getRecipes().removeIf(r -> {
             for (ISonarRecipeObject recipeOutput : r.recipeOutputs) {
@@ -75,13 +75,13 @@ public class PrecisionChamber extends VirtualizedRegistry<CalculatorRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         PrecisionChamberRecipes.instance().getRecipes().forEach(this::addBackup);
         PrecisionChamberRecipes.instance().getRecipes().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<CalculatorRecipe> streamRecipes() {
         return new SimpleObjectStream<>(PrecisionChamberRecipes.instance().getRecipes())
                 .setRemover(this::remove);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/calculator/ProcessingChamber.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/calculator/ProcessingChamber.java
@@ -42,7 +42,7 @@ public class ProcessingChamber extends VirtualizedRegistry<CalculatorRecipe> {
         return true;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('calculator:circuitdamaged:4')"))
+    @MethodDescription(example = @Example("item('calculator:circuitdamaged:4')"))
     public boolean removeByInput(IIngredient input) {
         return ProcessingChamberRecipes.instance().getRecipes().removeIf(r -> {
             for (ISonarRecipeObject recipeInput : r.recipeInputs) {
@@ -57,7 +57,7 @@ public class ProcessingChamber extends VirtualizedRegistry<CalculatorRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('calculator:circuitboard:1')"))
+    @MethodDescription(example = @Example("item('calculator:circuitboard:1')"))
     public boolean removeByOutput(IIngredient output) {
         return ProcessingChamberRecipes.instance().getRecipes().removeIf(r -> {
             for (ISonarRecipeObject recipeOutput : r.recipeOutputs) {
@@ -72,13 +72,13 @@ public class ProcessingChamber extends VirtualizedRegistry<CalculatorRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         ProcessingChamberRecipes.instance().getRecipes().forEach(this::addBackup);
         ProcessingChamberRecipes.instance().getRecipes().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<CalculatorRecipe> streamRecipes() {
         return new SimpleObjectStream<>(ProcessingChamberRecipes.instance().getRecipes())
                 .setRemover(this::remove);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/calculator/ReassemblyChamber.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/calculator/ReassemblyChamber.java
@@ -42,7 +42,7 @@ public class ReassemblyChamber extends VirtualizedRegistry<CalculatorRecipe> {
         return true;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('calculator:circuitdamaged:12')"))
+    @MethodDescription(example = @Example("item('calculator:circuitdamaged:12')"))
     public boolean removeByInput(IIngredient input) {
         return ReassemblyChamberRecipes.instance().getRecipes().removeIf(r -> {
             for (ISonarRecipeObject recipeInput : r.recipeInputs) {
@@ -57,7 +57,7 @@ public class ReassemblyChamber extends VirtualizedRegistry<CalculatorRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('calculator:circuitboard:13')"))
+    @MethodDescription(example = @Example("item('calculator:circuitboard:13')"))
     public boolean removeByOutput(IIngredient output) {
         return ReassemblyChamberRecipes.instance().getRecipes().removeIf(r -> {
             for (ISonarRecipeObject recipeOutput : r.recipeOutputs) {
@@ -72,13 +72,13 @@ public class ReassemblyChamber extends VirtualizedRegistry<CalculatorRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         ReassemblyChamberRecipes.instance().getRecipes().forEach(this::addBackup);
         ReassemblyChamberRecipes.instance().getRecipes().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<CalculatorRecipe> streamRecipes() {
         return new SimpleObjectStream<>(ReassemblyChamberRecipes.instance().getRecipes())
                 .setRemover(this::remove);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/calculator/RedstoneExtractor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/calculator/RedstoneExtractor.java
@@ -42,7 +42,7 @@ public class RedstoneExtractor extends VirtualizedRegistry<DefaultSonarRecipe.Va
         return true;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:redstone_block')"))
+    @MethodDescription(example = @Example("item('minecraft:redstone_block')"))
     public boolean removeByInput(IIngredient input) {
         return RedstoneExtractorRecipes.instance().getRecipes().removeIf(r -> {
             for (ISonarRecipeObject recipeInput : r.recipeInputs) {
@@ -57,13 +57,13 @@ public class RedstoneExtractor extends VirtualizedRegistry<DefaultSonarRecipe.Va
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         RedstoneExtractorRecipes.instance().getRecipes().forEach(this::addBackup);
         RedstoneExtractorRecipes.instance().getRecipes().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<DefaultSonarRecipe.Value> streamRecipes() {
         return new SimpleObjectStream<>(RedstoneExtractorRecipes.instance().getRecipes())
                 .setRemover(this::remove);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/calculator/RestorationChamber.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/calculator/RestorationChamber.java
@@ -42,7 +42,7 @@ public class RestorationChamber extends VirtualizedRegistry<CalculatorRecipe> {
         return true;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('calculator:circuitdirty:5')"))
+    @MethodDescription(example = @Example("item('calculator:circuitdirty:5')"))
     public boolean removeByInput(IIngredient input) {
         return RestorationChamberRecipes.instance().getRecipes().removeIf(r -> {
             for (ISonarRecipeObject recipeInput : r.recipeInputs) {
@@ -57,7 +57,7 @@ public class RestorationChamber extends VirtualizedRegistry<CalculatorRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('calculator:circuitboard:3')"))
+    @MethodDescription(example = @Example("item('calculator:circuitboard:3')"))
     public boolean removeByOutput(IIngredient output) {
         return RestorationChamberRecipes.instance().getRecipes().removeIf(r -> {
             for (ISonarRecipeObject recipeOutput : r.recipeOutputs) {
@@ -72,13 +72,13 @@ public class RestorationChamber extends VirtualizedRegistry<CalculatorRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         RestorationChamberRecipes.instance().getRecipes().forEach(this::addBackup);
         RestorationChamberRecipes.instance().getRecipes().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<CalculatorRecipe> streamRecipes() {
         return new SimpleObjectStream<>(RestorationChamberRecipes.instance().getRecipes())
                 .setRemover(this::remove);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/calculator/ScientificCalculator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/calculator/ScientificCalculator.java
@@ -42,7 +42,7 @@ public class ScientificCalculator extends VirtualizedRegistry<CalculatorRecipe> 
         return true;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('calculator:smallamethyst')"))
+    @MethodDescription(example = @Example("item('calculator:smallamethyst')"))
     public boolean removeByInput(IIngredient input) {
         return ScientificRecipes.instance().getRecipes().removeIf(r -> {
             for (ISonarRecipeObject recipeInput : r.recipeInputs) {
@@ -57,7 +57,7 @@ public class ScientificCalculator extends VirtualizedRegistry<CalculatorRecipe> 
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('calculator:redstoneingot')"))
+    @MethodDescription(example = @Example("item('calculator:redstoneingot')"))
     public boolean removeByOutput(IIngredient output) {
         return ScientificRecipes.instance().getRecipes().removeIf(r -> {
             for (ISonarRecipeObject recipeOutput : r.recipeOutputs) {
@@ -72,13 +72,13 @@ public class ScientificCalculator extends VirtualizedRegistry<CalculatorRecipe> 
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         ScientificRecipes.instance().getRecipes().forEach(this::addBackup);
         ScientificRecipes.instance().getRecipes().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<CalculatorRecipe> streamRecipes() {
         return new SimpleObjectStream<>(ScientificRecipes.instance().getRecipes())
                 .setRemover(this::remove);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/calculator/StarchExtractor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/calculator/StarchExtractor.java
@@ -42,7 +42,7 @@ public class StarchExtractor extends VirtualizedRegistry<DefaultSonarRecipe.Valu
         return true;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:apple')"))
+    @MethodDescription(example = @Example("item('minecraft:apple')"))
     public boolean removeByInput(IIngredient input) {
         return StarchExtractorRecipes.instance().getRecipes().removeIf(r -> {
             for (ISonarRecipeObject recipeInput : r.recipeInputs) {
@@ -57,13 +57,13 @@ public class StarchExtractor extends VirtualizedRegistry<DefaultSonarRecipe.Valu
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         StarchExtractorRecipes.instance().getRecipes().forEach(this::addBackup);
         StarchExtractorRecipes.instance().getRecipes().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<DefaultSonarRecipe.Value> streamRecipes() {
         return new SimpleObjectStream<>(StarchExtractorRecipes.instance().getRecipes())
                 .setRemover(this::remove);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/calculator/StoneSeparator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/calculator/StoneSeparator.java
@@ -42,7 +42,7 @@ public class StoneSeparator extends VirtualizedRegistry<CalculatorRecipe> {
         return true;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:gold_ore')"))
+    @MethodDescription(example = @Example("item('minecraft:gold_ore')"))
     public boolean removeByInput(IIngredient input) {
         return StoneSeparatorRecipes.instance().getRecipes().removeIf(r -> {
             for (ISonarRecipeObject recipeInput : r.recipeInputs) {
@@ -57,7 +57,7 @@ public class StoneSeparator extends VirtualizedRegistry<CalculatorRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('calculator:reinforcedironingot')"))
+    @MethodDescription(example = @Example("item('calculator:reinforcedironingot')"))
     public boolean removeByOutput(IIngredient output) {
         return StoneSeparatorRecipes.instance().getRecipes().removeIf(r -> {
             for (ISonarRecipeObject recipeOutput : r.recipeOutputs) {
@@ -72,13 +72,13 @@ public class StoneSeparator extends VirtualizedRegistry<CalculatorRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         StoneSeparatorRecipes.instance().getRecipes().forEach(this::addBackup);
         StoneSeparatorRecipes.instance().getRecipes().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<CalculatorRecipe> streamRecipes() {
         return new SimpleObjectStream<>(StoneSeparatorRecipes.instance().getRecipes())
                 .setRemover(this::remove);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/compactmachines/Miniaturization.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/compactmachines/Miniaturization.java
@@ -45,7 +45,7 @@ public class Miniaturization extends VirtualizedRegistry<org.dave.compactmachine
         return MultiblockRecipes.getRecipes().removeIf(r -> r == recipe);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:ender_pearl')"))
+    @MethodDescription(example = @Example("item('minecraft:ender_pearl')"))
     public void removeByInput(ItemStack input) {
         for (org.dave.compactmachines3.miniaturization.MultiblockRecipe recipe : MultiblockRecipes.getRecipes().stream().filter(r -> r.getCatalystStack().isItemEqual(input)).collect(Collectors.toList())) {
             addBackup(recipe);
@@ -58,7 +58,7 @@ public class Miniaturization extends VirtualizedRegistry<org.dave.compactmachine
         removeByInput(catalyst);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('compactmachines3:machine:3')"))
+    @MethodDescription(example = @Example("item('compactmachines3:machine:3')"))
     public void removeByOutput(ItemStack output) {
         for (org.dave.compactmachines3.miniaturization.MultiblockRecipe recipe : MultiblockRecipes.getRecipes().stream().filter(r -> r.getTargetStack().isItemEqual(output)).collect(Collectors.toList())) {
             addBackup(recipe);
@@ -66,13 +66,13 @@ public class Miniaturization extends VirtualizedRegistry<org.dave.compactmachine
         }
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         MultiblockRecipes.getRecipes().forEach(this::addBackup);
         MultiblockRecipes.getRecipes().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<org.dave.compactmachines3.miniaturization.MultiblockRecipe> streamRecipes() {
         return new SimpleObjectStream<>(MultiblockRecipes.getRecipes()).setRemover(this::remove);
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/draconicevolution/Fusion.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/draconicevolution/Fusion.java
@@ -46,20 +46,20 @@ public class Fusion extends VirtualizedRegistry<IFusionRecipe> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByCatalyst", example = @Example("item('draconicevolution:chaos_shard')"))
+    @MethodDescription(example = @Example("item('draconicevolution:chaos_shard')"))
     public void removeByCatalyst(ItemStack item) {
         for (IFusionRecipe recipe : RecipeManager.FUSION_REGISTRY.getRecipes().stream().filter(x -> x.getRecipeCatalyst().isItemEqual(item)).collect(Collectors.toList())) {
             remove(recipe);
         }
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         ((FusionRegistryAccessor) RecipeManager.FUSION_REGISTRY).getREGISTRY().forEach(this::addBackup);
         ((FusionRegistryAccessor) RecipeManager.FUSION_REGISTRY).getREGISTRY().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<IFusionRecipe> streamRecipes() {
         return new SimpleObjectStream<>(((FusionRegistryAccessor) RecipeManager.FUSION_REGISTRY).getREGISTRY())
                 .setRemover(this::remove);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/AlloySmelter.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/AlloySmelter.java
@@ -145,7 +145,7 @@ public class AlloySmelter extends VirtualizedRegistry<IManyToOneRecipe> {
         }
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<IManyToOneRecipe> streamRecipes() {
         List<IManyToOneRecipe> list = MachineRecipeRegistry.instance.getRecipesForMachine(MachineRecipeRegistry.ALLOYSMELTER).values().stream()
                 .filter(r -> r instanceof IManyToOneRecipe)
@@ -154,7 +154,7 @@ public class AlloySmelter extends VirtualizedRegistry<IManyToOneRecipe> {
                 .setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         AlloyRecipeManagerAccessor accessor = (AlloyRecipeManagerAccessor) AlloyRecipeManager.getInstance();
         @SuppressWarnings("unchecked")

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/Enchanter.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/Enchanter.java
@@ -83,13 +83,13 @@ public class Enchanter extends VirtualizedRegistry<EnchanterRecipe> {
         }
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<EnchanterRecipe> streamRecipes() {
         return new SimpleObjectStream<>((Collection<EnchanterRecipe>) MachineRecipeRegistry.instance.getRecipesForMachine(MachineRecipeRegistry.ENCHANTER).values())
                 .setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         MachineRecipeRegistry.instance.getRecipesForMachine(MachineRecipeRegistry.ENCHANTER).forEach((r, l) -> addBackup((EnchanterRecipe) l));
         ((SimpleRecipeGroupHolderAccessor) MachineRecipeRegistry.instance.getRecipeHolderssForMachine(MachineRecipeRegistry.ENCHANTER)).getRecipes().clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/FluidCoolant.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/FluidCoolant.java
@@ -97,13 +97,13 @@ public class FluidCoolant extends VirtualizedRegistry<IFluidCoolant> {
         restoreFromBackup().forEach(c -> accessor.getCoolants().put(c.getFluid().getName(), c));
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<Map.Entry<String, IFluidCoolant>> streamRecipes() {
         return new SimpleObjectStream<>(((FluidFuelRegisterAccessor) FluidFuelRegister.instance).getCoolants().entrySet())
                 .setRemover(r -> remove(r.getValue()));
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         ((FluidFuelRegisterAccessor) FluidFuelRegister.instance).getCoolants().forEach((r, l) -> {
             if (l == null) return;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/FluidFuel.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/FluidFuel.java
@@ -92,13 +92,13 @@ public class FluidFuel extends VirtualizedRegistry<IFluidFuel> {
         restoreFromBackup().forEach(c -> accessor.getFuels().put(c.getFluid().getName(), c));
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<Map.Entry<String, IFluidFuel>> streamRecipes() {
         return new SimpleObjectStream<>(((FluidFuelRegisterAccessor) FluidFuelRegister.instance).getFuels().entrySet())
                 .setRemover(r -> remove(r.getValue()));
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         ((FluidFuelRegisterAccessor) FluidFuelRegister.instance).getFuels().forEach((r, l) -> {
             if (l == null) return;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/SagMill.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/SagMill.java
@@ -50,7 +50,7 @@ public class SagMill extends VirtualizedRegistry<Recipe> {
         return true;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:wheat')"))
+    @MethodDescription(example = @Example("item('minecraft:wheat')"))
     public void removeByInput(ItemStack input) {
         Recipe recipe = (Recipe) SagMillRecipeManager.getInstance().getRecipeForInput(RecipeLevel.IGNORE, input);
         if (recipe == null) {
@@ -67,13 +67,13 @@ public class SagMill extends VirtualizedRegistry<Recipe> {
         restoreFromBackup().forEach(SagMillRecipeManager.getInstance().getRecipes()::add);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<Recipe> streamRecipes() {
         return new SimpleObjectStream<>(SagMillRecipeManager.getInstance().getRecipes())
                 .setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         SagMillRecipeManager.getInstance().getRecipes().forEach(this::addBackup);
         SagMillRecipeManager.getInstance().getRecipes().clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/SagMillGrinding.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/SagMillGrinding.java
@@ -55,13 +55,13 @@ public class SagMillGrinding extends VirtualizedRegistry<GrindingBall> {
         restoreFromBackup().forEach(SagMillRecipeManager.getInstance().getBalls()::add);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<GrindingBall> streamRecipes() {
         return new SimpleObjectStream<>(SagMillRecipeManager.getInstance().getBalls())
                 .setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         SagMillRecipeManager.getInstance().getBalls().forEach(this::addBackup);
         SagMillRecipeManager.getInstance().getBalls().clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/SliceNSplice.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/SliceNSplice.java
@@ -80,7 +80,7 @@ public class SliceNSplice extends VirtualizedRegistry<IManyToOneRecipe> {
         }
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("[item('enderio:item_alloy_ingot:7'), item('enderio:block_enderman_skull'), item('enderio:item_alloy_ingot:7'), item('minecraft:potion').withNbt(['Potion': 'minecraft:water']), item('enderio:item_basic_capacitor'), item('minecraft:potion').withNbt(['Potion': 'minecraft:water'])]"))
+    @MethodDescription(example = @Example("[item('enderio:item_alloy_ingot:7'), item('enderio:block_enderman_skull'), item('enderio:item_alloy_ingot:7'), item('minecraft:potion').withNbt(['Potion': 'minecraft:water']), item('enderio:item_basic_capacitor'), item('minecraft:potion').withNbt(['Potion': 'minecraft:water'])]"))
     public void removeByInput(List<ItemStack> input) {
         IRecipe recipe = SliceAndSpliceRecipeManager.getInstance().getRecipeForInputs(RecipeLevel.IGNORE, RecipeUtils.getMachineInputs(input));
         if (recipe instanceof IManyToOneRecipe) {
@@ -97,13 +97,13 @@ public class SliceNSplice extends VirtualizedRegistry<IManyToOneRecipe> {
         restoreFromBackup().forEach(SliceAndSpliceRecipeManager.getInstance().getRecipes()::add);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<IManyToOneRecipe> streamRecipes() {
         return new SimpleObjectStream<>(SliceAndSpliceRecipeManager.getInstance().getRecipes())
                 .setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         SliceAndSpliceRecipeManager.getInstance().getRecipes().forEach(this::addBackup);
         SliceAndSpliceRecipeManager.getInstance().getRecipes().clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/SoulBinder.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/SoulBinder.java
@@ -70,13 +70,13 @@ public class SoulBinder extends VirtualizedRegistry<ISoulBinderRecipe> {
         restoreFromBackup().forEach(MachineRecipeRegistry.instance::registerRecipe);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<ISoulBinderRecipe> streamRecipes() {
         return new SimpleObjectStream<>((Collection<ISoulBinderRecipe>) MachineRecipeRegistry.instance.getRecipesForMachine(MachineRecipeRegistry.SOULBINDER).values())
                 .setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         MachineRecipeRegistry.instance.getRecipesForMachine(MachineRecipeRegistry.SOULBINDER).forEach((r, l) -> addBackup((ISoulBinderRecipe) l));
         ((SimpleRecipeGroupHolderAccessor) MachineRecipeRegistry.instance.getRecipeHolderssForMachine(MachineRecipeRegistry.SOULBINDER)).getRecipes().clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/Tank.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/Tank.java
@@ -183,7 +183,7 @@ public class Tank extends VirtualizedRegistry<TankMachineRecipe> {
         restoreFromBackup().forEach(MachineRecipeRegistry.instance::registerRecipe);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<TankMachineRecipe> streamRecipes() {
         List<TankMachineRecipe> list = new ArrayList<>();
         list.addAll((Collection<? extends TankMachineRecipe>) MachineRecipeRegistry.instance.getRecipesForMachine(MachineRecipeRegistry.TANK_FILLING).values());
@@ -191,7 +191,7 @@ public class Tank extends VirtualizedRegistry<TankMachineRecipe> {
         return new SimpleObjectStream<>(list).setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         MachineRecipeRegistry.instance.getRecipesForMachine(MachineRecipeRegistry.TANK_FILLING).forEach((r, l) -> addBackup((TankMachineRecipe) l));
         ((SimpleRecipeGroupHolderAccessor) MachineRecipeRegistry.instance.getRecipeHolderssForMachine(MachineRecipeRegistry.TANK_FILLING)).getRecipes().clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/Vat.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/Vat.java
@@ -73,13 +73,13 @@ public class Vat extends VirtualizedRegistry<VatRecipe> {
         recipes.addAll(restoreFromBackup());
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<VatRecipe> streamRecipes() {
         return new SimpleObjectStream<>(VatRecipeManager.getInstance().getRecipes().stream().map(r -> (VatRecipe) r).collect(Collectors.toList()))
                 .setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         VatRecipeManager.getInstance().getRecipes().forEach(r -> addBackup((VatRecipe) r));
         VatRecipeManager.getInstance().getRecipes().clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/evilcraft/BloodInfuser.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/evilcraft/BloodInfuser.java
@@ -58,7 +58,7 @@ public class BloodInfuser extends VirtualizedRegistry<IRecipe<IngredientFluidSta
         return true;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('evilcraft:dark_gem')"))
+    @MethodDescription(example = @Example("item('evilcraft:dark_gem')"))
     public boolean removeByInput(ItemStack input) {
         return org.cyclops.evilcraft.block.BloodInfuser.getInstance().getRecipeRegistry().allRecipes().removeIf(r -> {
             if (r.getInput().getIngredient().test(input)) {
@@ -69,7 +69,7 @@ public class BloodInfuser extends VirtualizedRegistry<IRecipe<IngredientFluidSta
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('minecraft:leather')"))
+    @MethodDescription(example = @Example("item('minecraft:leather')"))
     public boolean removeByOutput(ItemStack input) {
         return org.cyclops.evilcraft.block.BloodInfuser.getInstance().getRecipeRegistry().allRecipes().removeIf(r -> {
             if (r.getOutput().getIngredient().test(input)) {
@@ -80,13 +80,13 @@ public class BloodInfuser extends VirtualizedRegistry<IRecipe<IngredientFluidSta
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         org.cyclops.evilcraft.block.BloodInfuser.getInstance().getRecipeRegistry().allRecipes().forEach(this::addBackup);
         org.cyclops.evilcraft.block.BloodInfuser.getInstance().getRecipeRegistry().allRecipes().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<IRecipe<IngredientFluidStackAndTierRecipeComponent, IngredientRecipeComponent, DurationXpRecipeProperties>> streamRecipes() {
         return new SimpleObjectStream<>(org.cyclops.evilcraft.block.BloodInfuser.getInstance().getRecipeRegistry().allRecipes())
                 .setRemover(this::remove);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/evilcraft/EnvironmentalAccumulator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/evilcraft/EnvironmentalAccumulator.java
@@ -57,7 +57,7 @@ public class EnvironmentalAccumulator extends VirtualizedRegistry<IRecipe<Enviro
         return true;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('evilcraft:exalted_crafter:1')"))
+    @MethodDescription(example = @Example("item('evilcraft:exalted_crafter:1')"))
     public boolean removeByInput(ItemStack input) {
         return org.cyclops.evilcraft.block.EnvironmentalAccumulator.getInstance().getRecipeRegistry().allRecipes().removeIf(r -> {
             if (r.getInput().getIngredient().test(input)) {
@@ -68,7 +68,7 @@ public class EnvironmentalAccumulator extends VirtualizedRegistry<IRecipe<Enviro
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('evilcraft:exalted_crafter:2')"))
+    @MethodDescription(example = @Example("item('evilcraft:exalted_crafter:2')"))
     public boolean removeByOutput(ItemStack input) {
         return org.cyclops.evilcraft.block.EnvironmentalAccumulator.getInstance().getRecipeRegistry().allRecipes().removeIf(r -> {
             if (r.getOutput().getIngredient().test(input)) {
@@ -79,13 +79,13 @@ public class EnvironmentalAccumulator extends VirtualizedRegistry<IRecipe<Enviro
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         org.cyclops.evilcraft.block.EnvironmentalAccumulator.getInstance().getRecipeRegistry().allRecipes().forEach(this::addBackup);
         org.cyclops.evilcraft.block.EnvironmentalAccumulator.getInstance().getRecipeRegistry().allRecipes().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<IRecipe<EnvironmentalAccumulatorRecipeComponent, EnvironmentalAccumulatorRecipeComponent, EnvironmentalAccumulatorRecipeProperties>> streamRecipes() {
         return new SimpleObjectStream<>(org.cyclops.evilcraft.block.EnvironmentalAccumulator.getInstance().getRecipeRegistry().allRecipes())
                 .setRemover(this::remove);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/extendedcrafting/CombinationCrafting.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/extendedcrafting/CombinationCrafting.java
@@ -52,7 +52,7 @@ public class CombinationCrafting extends VirtualizedRegistry<CombinationRecipe> 
         return add(new CombinationRecipe(output, cost, perTick, input, pedestals));
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example(value = "item('minecraft:gold_ingot')", commented = true))
+    @MethodDescription(example = @Example(value = "item('minecraft:gold_ingot')", commented = true))
     public boolean removeByOutput(ItemStack output) {
         return CombinationRecipeManager.getInstance().getRecipes().removeIf(r -> {
             if (r.getOutput().equals(output)) {
@@ -63,7 +63,7 @@ public class CombinationCrafting extends VirtualizedRegistry<CombinationRecipe> 
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example(value = "item('minecraft:pumpkin')", commented = true))
+    @MethodDescription(example = @Example(value = "item('minecraft:pumpkin')", commented = true))
     public boolean removeByInput(ItemStack input) {
         return CombinationRecipeManager.getInstance().getRecipes().removeIf(r -> {
             if (r.getInput().equals(input)) {
@@ -74,7 +74,7 @@ public class CombinationCrafting extends VirtualizedRegistry<CombinationRecipe> 
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput")
+    @MethodDescription
     public boolean removeByInput(IIngredient input) {
         return removeByInput(IngredientHelper.toItemStack(input));
     }
@@ -88,12 +88,12 @@ public class CombinationCrafting extends VirtualizedRegistry<CombinationRecipe> 
     }
 
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<CombinationRecipe> streamRecipes() {
         return new SimpleObjectStream<>(CombinationRecipeManager.getInstance().getRecipes()).setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         CombinationRecipeManager.getInstance().getRecipes().forEach(this::addBackup);
         CombinationRecipeManager.getInstance().getRecipes().clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/extendedcrafting/CompressionCrafting.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/extendedcrafting/CompressionCrafting.java
@@ -47,7 +47,7 @@ public class CompressionCrafting extends VirtualizedRegistry<CompressorRecipe> {
         return add(new CompressorRecipe(output, input.toMcIngredient(), inputCount, catalyst.toMcIngredient(), consumeCatalyst, powerCost, powerRate));
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('extendedcrafting:singularity:6')"))
+    @MethodDescription(example = @Example("item('extendedcrafting:singularity:6')"))
     public boolean removeByOutput(ItemStack output) {
         return CompressorRecipeManager.getInstance().getRecipes().removeIf(r -> {
             if (r.getOutput().equals(output)) {
@@ -58,7 +58,7 @@ public class CompressionCrafting extends VirtualizedRegistry<CompressorRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByCatalyst", example = @Example("item('extendedcrafting:material:11')"))
+    @MethodDescription(example = @Example("item('extendedcrafting:material:11')"))
     public boolean removeByCatalyst(IIngredient catalyst) {
         return CompressorRecipeManager.getInstance().getRecipes().removeIf(r -> {
             if (r.getCatalyst().equals(catalyst.toMcIngredient())) {
@@ -69,7 +69,7 @@ public class CompressionCrafting extends VirtualizedRegistry<CompressorRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:gold_ingot')"))
+    @MethodDescription(example = @Example("item('minecraft:gold_ingot')"))
     public boolean removeByInput(IIngredient input) {
         return CompressorRecipeManager.getInstance().getRecipes().removeIf(r -> {
             if (r.getInput().equals(input.toMcIngredient())) {
@@ -88,12 +88,12 @@ public class CompressionCrafting extends VirtualizedRegistry<CompressorRecipe> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<CompressorRecipe> streamRecipes() {
         return new SimpleObjectStream<>(CompressorRecipeManager.getInstance().getRecipes()).setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         CompressorRecipeManager.getInstance().getRecipes().forEach(this::addBackup);
         CompressorRecipeManager.getInstance().getRecipes().clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/extendedcrafting/EnderCrafting.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/extendedcrafting/EnderCrafting.java
@@ -75,7 +75,7 @@ public class EnderCrafting extends VirtualizedRegistry<IRecipe> {
         return recipe;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('extendedcrafting:material:40')"))
+    @MethodDescription(example = @Example("item('extendedcrafting:material:40')"))
     public boolean removeByOutput(ItemStack stack) {
         return EnderCrafterRecipeManager.getInstance().getRecipes().removeIf(recipe -> {
             if (recipe != null && recipe.getRecipeOutput().isItemEqual(stack)) {
@@ -94,12 +94,12 @@ public class EnderCrafting extends VirtualizedRegistry<IRecipe> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<IRecipe> streamRecipes() {
         return new SimpleObjectStream<>(EnderCrafterRecipeManager.getInstance().getRecipes()).setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         EnderCrafterRecipeManager.getInstance().getRecipes().forEach(this::addBackup);
         EnderCrafterRecipeManager.getInstance().getRecipes().clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/extendedcrafting/TableCrafting.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/extendedcrafting/TableCrafting.java
@@ -74,7 +74,7 @@ public class TableCrafting extends VirtualizedRegistry<ITieredRecipe> {
         return recipe;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('extendedcrafting:singularity_ultimate')"))
+    @MethodDescription(example = @Example("item('extendedcrafting:singularity_ultimate')"))
     public boolean removeByOutput(ItemStack stack) {
         return TableRecipeManager.getInstance().getRecipes().removeIf(recipe -> {
             if (recipe != null && recipe.getRecipeOutput().isItemEqual(stack)) {
@@ -93,12 +93,12 @@ public class TableCrafting extends VirtualizedRegistry<ITieredRecipe> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<ITieredRecipe> streamRecipes() {
         return new SimpleObjectStream<>(TableRecipeManager.getInstance().getRecipes()).setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         TableRecipeManager.getInstance().getRecipes().forEach(this::addBackup);
         TableRecipeManager.getInstance().getRecipes().clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/extrautils2/Crusher.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/extrautils2/Crusher.java
@@ -40,7 +40,7 @@ public class Crusher extends VirtualizedRegistry<IMachineRecipe> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:blaze_rod')"))
+    @MethodDescription(example = @Example("item('minecraft:blaze_rod')"))
     public boolean removeByInput(IIngredient input) {
         List<IMachineRecipe> agony = new ArrayList<>();
         for (IMachineRecipe recipe : XUMachineCrusher.INSTANCE.recipes_registry) {
@@ -55,7 +55,7 @@ public class Crusher extends VirtualizedRegistry<IMachineRecipe> {
         return !agony.isEmpty();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<IMachineRecipe> streamRecipes() {
         List<IMachineRecipe> list = new ArrayList<>();
         for (IMachineRecipe recipe : XUMachineCrusher.INSTANCE.recipes_registry) {
@@ -64,7 +64,7 @@ public class Crusher extends VirtualizedRegistry<IMachineRecipe> {
         return new SimpleObjectStream<>(list).setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         List<IMachineRecipe> agony = new ArrayList<>();
         for (IMachineRecipe recipe : XUMachineCrusher.INSTANCE.recipes_registry) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/extrautils2/Enchanter.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/extrautils2/Enchanter.java
@@ -39,7 +39,7 @@ public class Enchanter extends VirtualizedRegistry<IMachineRecipe> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:bookshelf')"))
+    @MethodDescription(example = @Example("item('minecraft:bookshelf')"))
     public boolean removeByInput(IIngredient input) {
         List<IMachineRecipe> agony = new ArrayList<>();
         for (IMachineRecipe recipe : XUMachineEnchanter.INSTANCE.recipes_registry) {
@@ -54,7 +54,7 @@ public class Enchanter extends VirtualizedRegistry<IMachineRecipe> {
         return !agony.isEmpty();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<IMachineRecipe> streamRecipes() {
         List<IMachineRecipe> list = new ArrayList<>();
         for (IMachineRecipe recipe : XUMachineEnchanter.INSTANCE.recipes_registry) {
@@ -63,7 +63,7 @@ public class Enchanter extends VirtualizedRegistry<IMachineRecipe> {
         return new SimpleObjectStream<>(list).setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         List<IMachineRecipe> agony = new ArrayList<>();
         for (IMachineRecipe recipe : XUMachineEnchanter.INSTANCE.recipes_registry) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/extrautils2/Furnace.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/extrautils2/Furnace.java
@@ -44,7 +44,7 @@ public class Furnace extends VirtualizedRegistry<IMachineRecipe> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:emerald_ore:*')"))
+    @MethodDescription(example = @Example("item('minecraft:emerald_ore:*')"))
     public boolean removeByInput(IIngredient input) {
         List<IMachineRecipe> agony = new ArrayList<>();
         for (IMachineRecipe recipe : XUMachineFurnace.INSTANCE.recipes_registry) {
@@ -59,7 +59,7 @@ public class Furnace extends VirtualizedRegistry<IMachineRecipe> {
         return !agony.isEmpty();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<IMachineRecipe> streamRecipes() {
         List<IMachineRecipe> list = new ArrayList<>();
         for (IMachineRecipe recipe : XUMachineFurnace.INSTANCE.recipes_registry) {
@@ -68,7 +68,7 @@ public class Furnace extends VirtualizedRegistry<IMachineRecipe> {
         return new SimpleObjectStream<>(list).setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         List<IMachineRecipe> agony = new ArrayList<>();
         for (IMachineRecipe recipe : XUMachineFurnace.INSTANCE.recipes_registry) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/extrautils2/Generator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/extrautils2/Generator.java
@@ -143,7 +143,7 @@ public class Generator extends VirtualizedRegistry<Pair<Machine, IMachineRecipe>
     }
 
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<Pair<Machine, IMachineRecipe>> streamRecipes() {
         List<Pair<Machine, IMachineRecipe>> list = new ArrayList<>();
         for (Generators name : Generators.values()) {
@@ -184,7 +184,7 @@ public class Generator extends VirtualizedRegistry<Pair<Machine, IMachineRecipe>
         return removeByGenerator(name.toString());
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         for (Generators name : Generators.values()) {
             Machine machine = MachineRegistry.getMachine(name.toString());

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/extrautils2/Resonator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/extrautils2/Resonator.java
@@ -41,7 +41,7 @@ public class Resonator extends VirtualizedRegistry<IResonatorRecipe> {
         return recipe;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('extrautils2:ingredients:4')"))
+    @MethodDescription(example = @Example("item('extrautils2:ingredients:4')"))
     public boolean removeByOutput(ItemStack output) {
         return TileResonator.resonatorRecipes.removeIf(r -> {
             if (ItemHandlerHelper.canItemStacksStack(r.getOutput(), output)) {
@@ -52,7 +52,7 @@ public class Resonator extends VirtualizedRegistry<IResonatorRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:quartz_block')"))
+    @MethodDescription(example = @Example("item('minecraft:quartz_block')"))
     public boolean removeByInput(IIngredient input) {
         return TileResonator.resonatorRecipes.removeIf(r -> {
             if (input.test(r.getInputs().get(0))) {
@@ -71,12 +71,12 @@ public class Resonator extends VirtualizedRegistry<IResonatorRecipe> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<IResonatorRecipe> streamRecipes() {
         return new SimpleObjectStream<>(TileResonator.resonatorRecipes).setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         TileResonator.resonatorRecipes.forEach(this::addBackup);
         TileResonator.resonatorRecipes.clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/AlloyKiln.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/AlloyKiln.java
@@ -54,7 +54,7 @@ public class AlloyKiln extends VirtualizedRegistry<AlloyRecipe> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('immersiveengineering:metal:6')"))
+    @MethodDescription(example = @Example("item('immersiveengineering:metal:6')"))
     public void removeByOutput(ItemStack output) {
         if (IngredientHelper.isEmpty(output)) {
             GroovyLog.msg("Error removing Immersive Engineering Alloy Kiln recipe")
@@ -73,7 +73,7 @@ public class AlloyKiln extends VirtualizedRegistry<AlloyRecipe> {
         recipes.forEach(this::addBackup);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:gold_ingot'), item('immersiveengineering:metal:3')"))
+    @MethodDescription(example = @Example("item('minecraft:gold_ingot'), item('immersiveengineering:metal:3')"))
     public void removeByInput(ItemStack input, ItemStack input1) {
         if (GroovyLog.msg("Error removing Immersive Engineering Alloy Kiln recipe")
                 .add(IngredientHelper.isEmpty(input), () -> "input 1 must not be empty")
@@ -93,12 +93,12 @@ public class AlloyKiln extends VirtualizedRegistry<AlloyRecipe> {
         }
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<AlloyRecipe> streamRecipes() {
         return new SimpleObjectStream<>(AlloyRecipe.recipeList).setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         AlloyRecipe.recipeList.forEach(this::addBackup);
         AlloyRecipe.recipeList.clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/ArcFurnace.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/ArcFurnace.java
@@ -60,7 +60,7 @@ public class ArcFurnace extends VirtualizedRegistry<ArcFurnaceRecipe> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('immersiveengineering:metal:7')"))
+    @MethodDescription(example = @Example("item('immersiveengineering:metal:7')"))
     public void removeByOutput(ItemStack output) {
         if (IngredientHelper.isEmpty(output)) {
             GroovyLog.msg("Error removing Immersive Engineering Arc Furnace recipe")
@@ -81,7 +81,7 @@ public class ArcFurnace extends VirtualizedRegistry<ArcFurnaceRecipe> {
         }
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('immersiveengineering:metal:18'), item('immersiveengineering:material:17')"))
+    @MethodDescription(example = @Example("item('immersiveengineering:metal:18'), item('immersiveengineering:material:17')"))
     public void removeByInput(IIngredient main, List<IIngredient> inputAndAdditives) {
         if (main == null || main.isEmpty() || inputAndAdditives == null || inputAndAdditives.isEmpty()) {
             GroovyLog.msg("Error removing Immersive Engineering Arc Furnace recipe")
@@ -106,7 +106,7 @@ public class ArcFurnace extends VirtualizedRegistry<ArcFurnaceRecipe> {
     }
 
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput")
+    @MethodDescription
     public void removeByInput(List<IIngredient> inputAndAdditives) {
         if (inputAndAdditives == null || inputAndAdditives.isEmpty()) {
             GroovyLog.msg("Error removing Immersive Engineering Arc Furnace recipe")
@@ -118,17 +118,17 @@ public class ArcFurnace extends VirtualizedRegistry<ArcFurnaceRecipe> {
         removeByInput(inputAndAdditives.remove(0), inputAndAdditives);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput")
+    @MethodDescription
     public void removeByInput(IIngredient... inputAndAdditives) {
         removeByInput(new ArrayList<>(Arrays.asList(inputAndAdditives)));
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<ArcFurnaceRecipe> streamRecipes() {
         return new SimpleObjectStream<>(ArcFurnaceRecipe.recipeList).setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         ArcFurnaceRecipe.recipeList.forEach(this::addBackup);
         ArcFurnaceRecipe.recipeList.clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/BlastFurnace.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/BlastFurnace.java
@@ -51,7 +51,7 @@ public class BlastFurnace extends VirtualizedRegistry<BlastFurnaceRecipe> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('immersiveengineering:metal:8')"))
+    @MethodDescription(example = @Example("item('immersiveengineering:metal:8')"))
     public void removeByOutput(ItemStack output) {
         if (IngredientHelper.isEmpty(output)) {
             GroovyLog.msg("Error removing Immersive Engineering Blast Furnace recipe")
@@ -71,7 +71,7 @@ public class BlastFurnace extends VirtualizedRegistry<BlastFurnaceRecipe> {
         list.forEach(this::addBackup);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:iron_block')"))
+    @MethodDescription(example = @Example("item('minecraft:iron_block')"))
     public void removeByInput(ItemStack input) {
         if (IngredientHelper.isEmpty(input)) {
             GroovyLog.msg("Error removing Immersive Engineering Blast Furnace recipe")
@@ -91,12 +91,12 @@ public class BlastFurnace extends VirtualizedRegistry<BlastFurnaceRecipe> {
         }
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<BlastFurnaceRecipe> streamRecipes() {
         return new SimpleObjectStream<>(BlastFurnaceRecipe.recipeList).setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         BlastFurnaceRecipe.recipeList.forEach(this::addBackup);
         BlastFurnaceRecipe.recipeList.clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/BlastFurnaceFuel.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/BlastFurnaceFuel.java
@@ -51,7 +51,7 @@ public class BlastFurnaceFuel extends VirtualizedRegistry<BlastFurnaceRecipe.Bla
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('immersiveengineering:material:6')"))
+    @MethodDescription(example = @Example("item('immersiveengineering:material:6')"))
     public void removeByInput(ItemStack input) {
         if (IngredientHelper.isEmpty(input)) {
             GroovyLog.msg("Error removing Immersive Engineering Blast Furnace recipe")
@@ -72,12 +72,12 @@ public class BlastFurnaceFuel extends VirtualizedRegistry<BlastFurnaceRecipe.Bla
         }
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<BlastFurnaceRecipe.BlastFurnaceFuel> streamRecipes() {
         return new SimpleObjectStream<>(BlastFurnaceRecipe.blastFuels).setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         BlastFurnaceRecipe.blastFuels.forEach(this::addBackup);
         BlastFurnaceRecipe.blastFuels.clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/BlueprintCrafting.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/BlueprintCrafting.java
@@ -84,7 +84,7 @@ public class BlueprintCrafting extends VirtualizedRegistry<BlueprintCraftingReci
         }
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("'components', item('immersiveengineering:material:8')"))
+    @MethodDescription(example = @Example("'components', item('immersiveengineering:material:8')"))
     public void removeByOutput(String blueprintCategory, ItemStack output) {
         if (GroovyLog.msg("Error removing Immersive Engineering Blueprint Crafting recipe")
                 .add(!BlueprintCraftingRecipe.recipeList.containsKey(blueprintCategory), () -> "category " + blueprintCategory + " does not exist")
@@ -107,7 +107,7 @@ public class BlueprintCrafting extends VirtualizedRegistry<BlueprintCraftingReci
         }
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("'components', item('immersiveengineering:metal:38'), item('immersiveengineering:metal:38'), item('immersiveengineering:metal')"))
+    @MethodDescription(example = @Example("'components', item('immersiveengineering:metal:38'), item('immersiveengineering:metal:38'), item('immersiveengineering:metal')"))
     public void removeByInput(String blueprintCategory, ItemStack... inputs) {
         if (GroovyLog.msg("Error removing Immersive Engineering Blueprint Crafting recipe")
                 .add(!BlueprintCraftingRecipe.recipeList.containsKey(blueprintCategory), () -> "category " + blueprintCategory + " does not exist")
@@ -152,12 +152,12 @@ public class BlueprintCrafting extends VirtualizedRegistry<BlueprintCraftingReci
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<BlueprintCraftingRecipe> streamRecipes() {
         return new SimpleObjectStream<>(BlueprintCraftingRecipe.recipeList.values()).setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         BlueprintCraftingRecipe.recipeList.values().forEach(this::addBackup);
         BlueprintCraftingRecipe.recipeList.clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/BottlingMachine.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/BottlingMachine.java
@@ -58,7 +58,7 @@ public class BottlingMachine extends VirtualizedRegistry<BottlingMachineRecipe> 
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('minecraft:potion').withNbt([Potion:'minecraft:mundane'])"))
+    @MethodDescription(example = @Example("item('minecraft:potion').withNbt([Potion:'minecraft:mundane'])"))
     public void removeByOutput(ItemStack output) {
         if (IngredientHelper.isEmpty(output)) {
             GroovyLog.msg("Error removing Immersive Engineering Bottling Machine recipe")
@@ -81,7 +81,7 @@ public class BottlingMachine extends VirtualizedRegistry<BottlingMachineRecipe> 
         }
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:sponge'), fluid('water') * 1000"))
+    @MethodDescription(example = @Example("item('minecraft:sponge'), fluid('water') * 1000"))
     public void removeByInput(ItemStack input, FluidStack inputFluid) {
         if (GroovyLog.msg("Error removing Immersive Engineering Bottling Machine recipe")
                 .add(IngredientHelper.isEmpty(input), () -> "item input must not be empty")
@@ -102,12 +102,12 @@ public class BottlingMachine extends VirtualizedRegistry<BottlingMachineRecipe> 
         }
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<BottlingMachineRecipe> streamRecipes() {
         return new SimpleObjectStream<>(BottlingMachineRecipe.recipeList).setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         BottlingMachineRecipe.recipeList.forEach(this::addBackup);
         BottlingMachineRecipe.recipeList.clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/CokeOven.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/CokeOven.java
@@ -51,7 +51,7 @@ public class CokeOven extends VirtualizedRegistry<CokeOvenRecipe> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('immersiveengineering:material:6')"))
+    @MethodDescription(example = @Example("item('immersiveengineering:material:6')"))
     public void removeByOutput(ItemStack output) {
         if (IngredientHelper.isEmpty(output)) {
             GroovyLog.msg("Error removing Immersive Engineering Coke Oven recipe")
@@ -71,7 +71,7 @@ public class CokeOven extends VirtualizedRegistry<CokeOvenRecipe> {
         list.forEach(this::addBackup);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:log')"))
+    @MethodDescription(example = @Example("item('minecraft:log')"))
     public void removeByInput(ItemStack input) {
         if (IngredientHelper.isEmpty(input)) {
             GroovyLog.msg("Error removing Immersive Engineering Coke Oven recipe")
@@ -94,12 +94,12 @@ public class CokeOven extends VirtualizedRegistry<CokeOvenRecipe> {
         }
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<CokeOvenRecipe> streamRecipes() {
         return new SimpleObjectStream<>(CokeOvenRecipe.recipeList).setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         CokeOvenRecipe.recipeList.forEach(this::addBackup);
         CokeOvenRecipe.recipeList.clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/Crusher.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/Crusher.java
@@ -50,7 +50,7 @@ public class Crusher extends VirtualizedRegistry<CrusherRecipe> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('minecraft:sand')"))
+    @MethodDescription(example = @Example("item('minecraft:sand')"))
     public void removeByOutput(ItemStack output) {
         if (IngredientHelper.isEmpty(output)) {
             GroovyLog.msg("Error removing Immersive Engineering Crusher recipe")
@@ -69,7 +69,7 @@ public class Crusher extends VirtualizedRegistry<CrusherRecipe> {
         list.forEach(this::addBackup);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('immersiveengineering:material:7')"))
+    @MethodDescription(example = @Example("item('immersiveengineering:material:7')"))
     public void removeByInput(ItemStack input) {
         if (IngredientHelper.isEmpty(input)) {
             GroovyLog.msg("Error removing Immersive Engineering Crusher recipe")
@@ -88,12 +88,12 @@ public class Crusher extends VirtualizedRegistry<CrusherRecipe> {
         list.forEach(this::addBackup);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<CrusherRecipe> streamRecipes() {
         return new SimpleObjectStream<>(CrusherRecipe.recipeList).setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         CrusherRecipe.recipeList.forEach(this::addBackup);
         CrusherRecipe.recipeList.clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/Excavator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/Excavator.java
@@ -125,12 +125,12 @@ public class Excavator extends VirtualizedRegistry<Pair<ExcavatorHandler.Mineral
         }
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<Map.Entry<ExcavatorHandler.MineralMix, Integer>> streamRecipes() {
         return new SimpleObjectStream<>(ExcavatorHandler.mineralList.entrySet()).setRemover(r -> this.remove(r.getKey()));
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         ExcavatorHandler.mineralList.forEach((r, l) -> addBackup(Pair.of(r, l)));
         ExcavatorHandler.mineralList.clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/Fermenter.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/Fermenter.java
@@ -51,7 +51,7 @@ public class Fermenter extends VirtualizedRegistry<FermenterRecipe> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("fluid('ethanol')"))
+    @MethodDescription(example = @Example("fluid('ethanol')"))
     public void removeByOutput(FluidStack fluidOutput) {
         if (IngredientHelper.isEmpty(fluidOutput)) {
             GroovyLog.msg("Error removing Immersive Engineering Fermenter recipe")
@@ -73,7 +73,7 @@ public class Fermenter extends VirtualizedRegistry<FermenterRecipe> {
         }
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:reeds')"))
+    @MethodDescription(example = @Example("item('minecraft:reeds')"))
     public void removeByInput(ItemStack input) {
         if (IngredientHelper.isEmpty(input)) {
             GroovyLog.msg("Error removing Immersive Engineering Fermenter recipe")
@@ -93,12 +93,12 @@ public class Fermenter extends VirtualizedRegistry<FermenterRecipe> {
         }
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<FermenterRecipe> streamRecipes() {
         return new SimpleObjectStream<>(FermenterRecipe.recipeList).setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         FermenterRecipe.recipeList.forEach(this::addBackup);
         FermenterRecipe.recipeList.clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/MetalPress.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/MetalPress.java
@@ -53,7 +53,7 @@ public class MetalPress extends VirtualizedRegistry<MetalPressRecipe> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('immersiveengineering:material:2')"))
+    @MethodDescription(example = @Example("item('immersiveengineering:material:2')"))
     public void removeByOutput(ItemStack output) {
         if (IngredientHelper.isEmpty(output)) {
             GroovyLog.msg("Error removing Immersive Engineering Metal Press recipe")
@@ -129,7 +129,7 @@ public class MetalPress extends VirtualizedRegistry<MetalPressRecipe> {
         }
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:iron_ingot')"))
+    @MethodDescription(example = @Example("item('minecraft:iron_ingot')"))
     public void removeByInput(ItemStack input) {
         if (IngredientHelper.isEmpty(input)) {
             GroovyLog.msg("Error removing Immersive Engineering Crusher recipe")
@@ -168,13 +168,13 @@ public class MetalPress extends VirtualizedRegistry<MetalPressRecipe> {
         if (!list.isEmpty()) list.forEach(this::addBackup);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         MetalPressRecipe.recipeList.values().forEach(this::addBackup);
         MetalPressRecipe.recipeList.clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<MetalPressRecipe> streamRecipes() {
         List<MetalPressRecipe> recipes = new ArrayList<>(MetalPressRecipe.recipeList.values());
         return new SimpleObjectStream<>(recipes).setRemover(this::remove);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/MetalPress.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/MetalPress.java
@@ -53,7 +53,7 @@ public class MetalPress extends VirtualizedRegistry<MetalPressRecipe> {
         return false;
     }
 
-    @MethodDescription(example = @Example("item('immersiveengineering:material:2')"))
+    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('immersiveengineering:material:2')"))
     public void removeByOutput(ItemStack output) {
         if (IngredientHelper.isEmpty(output)) {
             GroovyLog.msg("Error removing Immersive Engineering Metal Press recipe")
@@ -129,7 +129,7 @@ public class MetalPress extends VirtualizedRegistry<MetalPressRecipe> {
         }
     }
 
-    @MethodDescription(example = @Example("item('minecraft:iron_ingot')"))
+    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:iron_ingot')"))
     public void removeByInput(ItemStack input) {
         if (IngredientHelper.isEmpty(input)) {
             GroovyLog.msg("Error removing Immersive Engineering Crusher recipe")

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/Mixer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/Mixer.java
@@ -54,7 +54,7 @@ public class Mixer extends VirtualizedRegistry<MixerRecipe> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("fluid('potion').withNbt([Potion:'minecraft:night_vision'])"))
+    @MethodDescription(example = @Example("fluid('potion').withNbt([Potion:'minecraft:night_vision'])"))
     public void removeByOutput(FluidStack fluidOutput) {
         if (GroovyLog.msg("Error removing Immersive Engineering Mixer recipe")
                 .add(IngredientHelper.isEmpty(fluidOutput), () -> "fluid output must not be empty")
@@ -76,7 +76,7 @@ public class Mixer extends VirtualizedRegistry<MixerRecipe> {
         }
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:sand'), item('minecraft:sand'), item('minecraft:clay_ball'), item('minecraft:gravel')"))
+    @MethodDescription(example = @Example("item('minecraft:sand'), item('minecraft:sand'), item('minecraft:clay_ball'), item('minecraft:gravel')"))
     public void removeByInput(IIngredient... itemInputs) {
         if (GroovyLog.msg("Error removing Immersive Engineering Mixer recipe")
                 .add(itemInputs == null || itemInputs.length == 0, () -> "item input must not be empty")
@@ -98,7 +98,7 @@ public class Mixer extends VirtualizedRegistry<MixerRecipe> {
         }
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("fluid('water'), item('minecraft:speckled_melon')"))
+    @MethodDescription(example = @Example("fluid('water'), item('minecraft:speckled_melon')"))
     public void removeByInput(FluidStack fluidInput, IIngredient... itemInput) {
         if (GroovyLog.msg("Error removing Immersive Engineering Mixer recipe")
                 .add(IngredientHelper.isEmpty(fluidInput), () -> "fluid input must not be empty")
@@ -122,12 +122,12 @@ public class Mixer extends VirtualizedRegistry<MixerRecipe> {
         }
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<MixerRecipe> streamRecipes() {
         return new SimpleObjectStream<>(MixerRecipe.recipeList).setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         MixerRecipe.recipeList.forEach(this::addBackup);
         MixerRecipe.recipeList.clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/Refinery.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/Refinery.java
@@ -50,7 +50,7 @@ public class Refinery extends VirtualizedRegistry<RefineryRecipe> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example(value = "fluid('biodiesel')", commented = true))
+    @MethodDescription(example = @Example(value = "fluid('biodiesel')", commented = true))
     public void removeByOutput(FluidStack fluidOutput) {
         if (IngredientHelper.isEmpty(fluidOutput)) {
             GroovyLog.msg("Error removing Immersive Engineering Refinery recipe")
@@ -73,7 +73,7 @@ public class Refinery extends VirtualizedRegistry<RefineryRecipe> {
         }
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("fluid('plantoil'), fluid('ethanol')"))
+    @MethodDescription(example = @Example("fluid('plantoil'), fluid('ethanol')"))
     public void removeByInput(FluidStack input0, FluidStack input1) {
         if (GroovyLog.msg("Error removing Immersive Engineering Refinery recipe")
                 .add(IngredientHelper.isEmpty(input0), () -> "fluid input 1 must not be empty")
@@ -94,12 +94,12 @@ public class Refinery extends VirtualizedRegistry<RefineryRecipe> {
         }
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<RefineryRecipe> streamRecipes() {
         return new SimpleObjectStream<>(RefineryRecipe.recipeList).setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         RefineryRecipe.recipeList.forEach(this::addBackup);
         RefineryRecipe.recipeList.clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/Squeezer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/Squeezer.java
@@ -57,7 +57,7 @@ public class Squeezer extends VirtualizedRegistry<SqueezerRecipe> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("fluid('plantoil')"))
+    @MethodDescription(example = @Example("fluid('plantoil')"))
     public void removeByOutput(FluidStack fluidOutput) {
         if (IngredientHelper.isEmpty(fluidOutput)) {
             GroovyLog.msg("Error removing Immersive Engineering Squeezer recipe")
@@ -80,7 +80,7 @@ public class Squeezer extends VirtualizedRegistry<SqueezerRecipe> {
         }
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput")
+    @MethodDescription
     public void removeByOutput(FluidStack fluidOutput, ItemStack itemOutput) {
         if (GroovyLog.msg("Error removing Immersive Engineering Squeezer recipe")
                 .add(IngredientHelper.isEmpty(fluidOutput), () -> "fluid output must not be empty")
@@ -101,7 +101,7 @@ public class Squeezer extends VirtualizedRegistry<SqueezerRecipe> {
         }
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('immersiveengineering:material:18')"))
+    @MethodDescription(example = @Example("item('immersiveengineering:material:18')"))
     public void removeByOutput(ItemStack itemOutput) {
         if (GroovyLog.msg("Error removing Immersive Engineering Squeezer recipe")
                 .add(IngredientHelper.isEmpty(itemOutput), () -> "item input must not be empty")
@@ -123,7 +123,7 @@ public class Squeezer extends VirtualizedRegistry<SqueezerRecipe> {
         }
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:wheat_seeds')"))
+    @MethodDescription(example = @Example("item('minecraft:wheat_seeds')"))
     public void removeByInput(ItemStack input) {
         if (IngredientHelper.isEmpty(input)) {
             GroovyLog.msg("Error removing Immersive Engineering Squeezer recipe")
@@ -141,12 +141,12 @@ public class Squeezer extends VirtualizedRegistry<SqueezerRecipe> {
         }
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<SqueezerRecipe> streamRecipes() {
         return new SimpleObjectStream<>(SqueezerRecipe.recipeList).setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         SqueezerRecipe.recipeList.forEach(this::addBackup);
         SqueezerRecipe.recipeList.clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/inspirations/AnvilSmashing.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/inspirations/AnvilSmashing.java
@@ -135,7 +135,7 @@ public class AnvilSmashing extends VirtualizedRegistry<Pair<IBlockState, IBlockS
         }
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         InspirationsRegistryAccessor.getAnvilSmashing().forEach((a, b) -> addBackup(Pair.of(a, b)));
         InspirationsRegistryAccessor.getAnvilSmashing().clear();
@@ -145,7 +145,7 @@ public class AnvilSmashing extends VirtualizedRegistry<Pair<IBlockState, IBlockS
         InspirationsRegistryAccessor.getAnvilBreaking().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<Map.Entry<IBlockState, IBlockState>> streamRecipes() {
         return new SimpleObjectStream<>(InspirationsRegistryAccessor.getAnvilSmashing().entrySet())
                 .setRemover(r -> remove(r.getKey(), r.getValue()));

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/inspirations/Cauldron.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/inspirations/Cauldron.java
@@ -202,13 +202,13 @@ public class Cauldron extends VirtualizedRegistry<ICauldronRecipe> {
         removeByFluidOutput(output.getFluid());
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         InspirationsRegistryAccessor.getCauldronRecipes().forEach(this::addBackup);
         InspirationsRegistryAccessor.getCauldronRecipes().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<ICauldronRecipe> streamRecipes() {
         return new SimpleObjectStream<>(InspirationsRegistryAccessor.getCauldronRecipes())
                 .setRemover(this::remove);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/integrateddynamics/DryingBasin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/integrateddynamics/DryingBasin.java
@@ -56,7 +56,7 @@ public class DryingBasin extends VirtualizedRegistry<IRecipe<IngredientAndFluidS
         return true;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput")
+    @MethodDescription
     public boolean removeByInput(ItemStack input) {
         return BlockDryingBasin.getInstance().getRecipeRegistry().allRecipes().removeIf(r -> {
             if (r.getInput().getIngredient().test(input)) {
@@ -67,7 +67,7 @@ public class DryingBasin extends VirtualizedRegistry<IRecipe<IngredientAndFluidS
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput")
+    @MethodDescription
     public boolean removeByOutput(ItemStack input) {
         return BlockDryingBasin.getInstance().getRecipeRegistry().allRecipes().removeIf(r -> {
             if (r.getOutput().getIngredient().test(input)) {
@@ -78,13 +78,13 @@ public class DryingBasin extends VirtualizedRegistry<IRecipe<IngredientAndFluidS
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         BlockDryingBasin.getInstance().getRecipeRegistry().allRecipes().forEach(this::addBackup);
         BlockDryingBasin.getInstance().getRecipeRegistry().allRecipes().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<IRecipe<IngredientAndFluidStackRecipeComponent, IngredientAndFluidStackRecipeComponent, DurationRecipeProperties>> streamRecipes() {
         return new SimpleObjectStream<>(BlockDryingBasin.getInstance().getRecipeRegistry().allRecipes())
                 .setRemover(this::remove);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/integrateddynamics/MechanicalDryingBasin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/integrateddynamics/MechanicalDryingBasin.java
@@ -47,7 +47,7 @@ public class MechanicalDryingBasin extends VirtualizedRegistry<IRecipe<Ingredien
         return true;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput")
+    @MethodDescription
     public boolean removeByInput(ItemStack input) {
         return BlockMechanicalDryingBasin.getInstance().getRecipeRegistry().allRecipes().removeIf(r -> {
             if (r.getInput().getIngredient().test(input)) {
@@ -58,7 +58,7 @@ public class MechanicalDryingBasin extends VirtualizedRegistry<IRecipe<Ingredien
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput")
+    @MethodDescription
     public boolean removeByOutput(ItemStack input) {
         return BlockMechanicalDryingBasin.getInstance().getRecipeRegistry().allRecipes().removeIf(r -> {
             if (r.getOutput().getIngredient().test(input)) {
@@ -69,13 +69,13 @@ public class MechanicalDryingBasin extends VirtualizedRegistry<IRecipe<Ingredien
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         BlockMechanicalDryingBasin.getInstance().getRecipeRegistry().allRecipes().forEach(this::addBackup);
         BlockMechanicalDryingBasin.getInstance().getRecipeRegistry().allRecipes().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<IRecipe<IngredientAndFluidStackRecipeComponent, IngredientAndFluidStackRecipeComponent, DurationRecipeProperties>> streamRecipes() {
         return new SimpleObjectStream<>(BlockMechanicalDryingBasin.getInstance().getRecipeRegistry().allRecipes())
                 .setRemover(this::remove);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/integrateddynamics/MechanicalSqueezer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/integrateddynamics/MechanicalSqueezer.java
@@ -48,7 +48,7 @@ public class MechanicalSqueezer extends VirtualizedRegistry<IRecipe<IngredientRe
         return true;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput")
+    @MethodDescription
     public boolean removeByInput(ItemStack input) {
         return BlockMechanicalSqueezer.getInstance().getRecipeRegistry().allRecipes().removeIf(r -> {
             if (r.getInput().getIngredient().test(input)) {
@@ -59,13 +59,13 @@ public class MechanicalSqueezer extends VirtualizedRegistry<IRecipe<IngredientRe
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         BlockMechanicalSqueezer.getInstance().getRecipeRegistry().allRecipes().forEach(this::addBackup);
         BlockMechanicalSqueezer.getInstance().getRecipeRegistry().allRecipes().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<IRecipe<IngredientRecipeComponent, IngredientsAndFluidStackRecipeComponent, DurationRecipeProperties>> streamRecipes() {
         return new SimpleObjectStream<>(BlockMechanicalSqueezer.getInstance().getRecipeRegistry().allRecipes())
                 .setRemover(this::remove);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/integrateddynamics/Squeezer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/integrateddynamics/Squeezer.java
@@ -61,7 +61,7 @@ public class Squeezer extends VirtualizedRegistry<IRecipe<IngredientRecipeCompon
         return true;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput")
+    @MethodDescription
     public boolean removeByInput(ItemStack input) {
         return BlockSqueezer.getInstance().getRecipeRegistry().allRecipes().removeIf(r -> {
             if (r.getInput().getIngredient().test(input)) {
@@ -72,13 +72,13 @@ public class Squeezer extends VirtualizedRegistry<IRecipe<IngredientRecipeCompon
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         BlockSqueezer.getInstance().getRecipeRegistry().allRecipes().forEach(this::addBackup);
         BlockSqueezer.getInstance().getRecipeRegistry().allRecipes().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<IRecipe<IngredientRecipeComponent, IngredientsAndFluidStackRecipeComponent, DummyPropertiesComponent>> streamRecipes() {
         return new SimpleObjectStream<>(BlockSqueezer.getInstance().getRecipeRegistry().allRecipes())
                 .setRemover(this::remove);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/ChemicalInfuser.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/ChemicalInfuser.java
@@ -37,7 +37,7 @@ public class ChemicalInfuser extends VirtualizedMekanismRegistry<ChemicalInfuser
         return recipe;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("gas('hydrogen'), gas('chlorine')"))
+    @MethodDescription(example = @Example("gas('hydrogen'), gas('chlorine')"))
     public boolean removeByInput(GasStack leftInput, GasStack rightInput) {
         GroovyLog.Msg msg = GroovyLog.msg("Error removing Mekanism Chemical Infuser recipe").error();
         msg.add(Mekanism.isEmpty(leftInput), () -> "left gas input must not be empty");

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/ChemicalOxidizer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/ChemicalOxidizer.java
@@ -45,7 +45,7 @@ public class ChemicalOxidizer extends VirtualizedMekanismRegistry<OxidationRecip
         return recipe1;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("ore('dustSulfur')"))
+    @MethodDescription(example = @Example("ore('dustSulfur')"))
     public boolean removeByInput(IIngredient ingredient) {
         if (IngredientHelper.isEmpty(ingredient)) {
             removeError("input must not be empty");

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Combiner.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Combiner.java
@@ -45,7 +45,7 @@ public class Combiner extends VirtualizedMekanismRegistry<CombinerRecipe> {
         return recipe1;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:flint'), item('minecraft:cobblestone')"))
+    @MethodDescription(example = @Example("item('minecraft:flint'), item('minecraft:cobblestone')"))
     public boolean removeByInput(IIngredient ingredient, ItemStack extra) {
         GroovyLog.Msg msg = GroovyLog.msg("Error removing Mekanism Combiner recipe").error();
         msg.add(IngredientHelper.isEmpty(ingredient), () -> "input must not be empty");

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Crusher.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Crusher.java
@@ -43,7 +43,7 @@ public class Crusher extends VirtualizedMekanismRegistry<CrusherRecipe> {
         return recipe1;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("ore('ingotTin')"))
+    @MethodDescription(example = @Example("ore('ingotTin')"))
     public boolean removeByInput(IIngredient ingredient) {
         if (IngredientHelper.isEmpty(ingredient)) {
             removeError("input must not be empty");

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Crystallizer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Crystallizer.java
@@ -38,7 +38,7 @@ public class Crystallizer extends VirtualizedMekanismRegistry<CrystallizerRecipe
         return recipe;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("gas('cleanGold')"))
+    @MethodDescription(example = @Example("gas('cleanGold')"))
     public boolean removeByInput(GasStack input) {
         GroovyLog.Msg msg = GroovyLog.msg("Error removing Mekanism Crystallizer recipe").error();
         msg.add(Mekanism.isEmpty(input), () -> "input must not be empty");

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/DissolutionChamber.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/DissolutionChamber.java
@@ -45,7 +45,7 @@ public class DissolutionChamber extends VirtualizedMekanismRegistry<DissolutionR
         return recipe1;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('mekanism:oreblock:0')"))
+    @MethodDescription(example = @Example("item('mekanism:oreblock:0')"))
     public boolean removeByInput(IIngredient ingredient) {
         if (IngredientHelper.isEmpty(ingredient)) {
             removeError("input must not be empty");

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/ElectrolyticSeparator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/ElectrolyticSeparator.java
@@ -40,7 +40,7 @@ public class ElectrolyticSeparator extends VirtualizedMekanismRegistry<Separator
         return recipe;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("fluid('water')"))
+    @MethodDescription(example = @Example("fluid('water')"))
     public boolean removeByInput(FluidStack input) {
         GroovyLog.Msg msg = GroovyLog.msg("Error removing Mekanism Electrolytic Separator recipe").error();
         msg.add(IngredientHelper.isEmpty(input), () -> "input must not be empty");

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/EnrichmentChamber.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/EnrichmentChamber.java
@@ -44,7 +44,7 @@ public class EnrichmentChamber extends VirtualizedMekanismRegistry<EnrichmentRec
         return recipe1;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:diamond')"))
+    @MethodDescription(example = @Example("item('minecraft:diamond')"))
     public boolean removeByInput(IIngredient ingredient) {
         if (IngredientHelper.isEmpty(ingredient)) {
             removeError("input must not be empty");

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/InjectionChamber.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/InjectionChamber.java
@@ -46,7 +46,7 @@ public class InjectionChamber extends VirtualizedMekanismRegistry<InjectionRecip
         return recipe1;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:hardened_clay'), gas('water')"))
+    @MethodDescription(example = @Example("item('minecraft:hardened_clay'), gas('water')"))
     public boolean removeByInput(IIngredient ingredient, GasStack gasInput) {
         GroovyLog.Msg msg = GroovyLog.msg("Error removing Mekanism Injection Chamber recipe").error();
         msg.add(IngredientHelper.isEmpty(ingredient), () -> "input must not be empty");

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/MetallurgicInfuser.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/MetallurgicInfuser.java
@@ -52,7 +52,7 @@ public class MetallurgicInfuser extends VirtualizedMekanismRegistry<MetallurgicI
         return add(ingredient, InfuseRegistry.get(infuseType), infuseAmount, output);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("ore('dustObsidian'), 'DIAMOND'"))
+    @MethodDescription(example = @Example("ore('dustObsidian'), 'DIAMOND'"))
     public boolean removeByInput(IIngredient ingredient, InfuseType infuseType) {
         GroovyLog.Msg msg = GroovyLog.msg("Error removing Mekanism Metallurgic Infuser recipe").error();
         msg.add(IngredientHelper.isEmpty(ingredient), () -> "input must not be empty");

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/OsmiumCompressor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/OsmiumCompressor.java
@@ -47,7 +47,7 @@ public class OsmiumCompressor extends VirtualizedMekanismRegistry<OsmiumCompress
         return recipe1;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("ore('dustRefinedObsidian'), gas('liquidosmium')"))
+    @MethodDescription(example = @Example("ore('dustRefinedObsidian'), gas('liquidosmium')"))
     public boolean removeByInput(IIngredient ingredient, GasStack gasInput) {
         GroovyLog.Msg msg = GroovyLog.msg("Error removing Mekanism Osmium Compressor recipe").error();
         msg.add(IngredientHelper.isEmpty(ingredient), () -> "input must not be empty");

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/PressurizedReactionChamber.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/PressurizedReactionChamber.java
@@ -41,7 +41,7 @@ public class PressurizedReactionChamber extends VirtualizedMekanismRegistry<Pres
         return r;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("ore('logWood'), fluid('water'), gas('oxygen')"))
+    @MethodDescription(example = @Example("ore('logWood'), fluid('water'), gas('oxygen')"))
     public boolean removeByInput(IIngredient inputSolid, FluidStack inputFluid, GasStack inputGas) {
         if (GroovyLog.msg("Error removing Mekanism Pressurized Reaction Chamber recipe").error()
                 .add(IngredientHelper.isEmpty(inputSolid), () -> "item input must not be empty")

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/PurificationChamber.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/PurificationChamber.java
@@ -46,7 +46,7 @@ public class PurificationChamber extends VirtualizedMekanismRegistry<Purificatio
         return recipe1;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('mekanism:oreblock:0'), gas('oxygen')"))
+    @MethodDescription(example = @Example("item('mekanism:oreblock:0'), gas('oxygen')"))
     public boolean removeByInput(IIngredient ingredient, GasStack gasInput) {
         GroovyLog.Msg msg = GroovyLog.msg("Error removing Mekanism Purification Chamber recipe").error();
         msg.add(IngredientHelper.isEmpty(ingredient), () -> "input must not be empty");

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Sawmill.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Sawmill.java
@@ -62,7 +62,7 @@ public class Sawmill extends VirtualizedMekanismRegistry<SawmillRecipe> {
         return recipe1;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:ladder')"))
+    @MethodDescription(example = @Example("item('minecraft:ladder')"))
     public boolean removeByInput(IIngredient ingredient) {
         if (IngredientHelper.isEmpty(ingredient)) {
             removeError("input must not be empty");

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Smelting.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Smelting.java
@@ -49,7 +49,7 @@ public class Smelting extends VirtualizedMekanismRegistry<SmeltingRecipe> {
         return recipe1;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example(value = "item('minecraft:clay')", commented = true))
+    @MethodDescription(example = @Example(value = "item('minecraft:clay')", commented = true))
     public boolean removeByInput(IIngredient ingredient) {
         if (IngredientHelper.isEmpty(ingredient)) {
             removeError("input must not be empty");

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/SolarNeutronActivator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/SolarNeutronActivator.java
@@ -37,7 +37,7 @@ public class SolarNeutronActivator extends VirtualizedMekanismRegistry<SolarNeut
         return recipe;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("gas('lithium')"))
+    @MethodDescription(example = @Example("gas('lithium')"))
     public boolean removeByInput(GasStack input) {
         GroovyLog.Msg msg = GroovyLog.msg("Error removing Mekanism Solar Neutron Activator recipe").error();
         msg.add(Mekanism.isEmpty(input), () -> "input must not be empty");

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/ThermalEvaporationPlant.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/ThermalEvaporationPlant.java
@@ -38,7 +38,7 @@ public class ThermalEvaporationPlant extends VirtualizedMekanismRegistry<Thermal
         return recipe;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("fluid('water')"))
+    @MethodDescription(example = @Example("fluid('water')"))
     public boolean removeByInput(FluidStack input) {
         GroovyLog.Msg msg = GroovyLog.msg("Error removing Mekanism Solar Neutron Activator recipe").error();
         msg.add(IngredientHelper.isEmpty(input), () -> "input must not be empty");

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Washer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Washer.java
@@ -37,7 +37,7 @@ public class Washer extends VirtualizedMekanismRegistry<WasherRecipe> {
         return recipe;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("gas('iron')"))
+    @MethodDescription(example = @Example("gas('iron')"))
     public boolean removeByInput(GasStack input) {
         GroovyLog.Msg msg = GroovyLog.msg("Error removing Mekanism Washer recipe").error();
         msg.add(Mekanism.isEmpty(input), () -> "input must not be empty");

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/recipe/VirtualizedMekanismRegistry.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/recipe/VirtualizedMekanismRegistry.java
@@ -47,13 +47,13 @@ public abstract class VirtualizedMekanismRegistry<R extends MachineRecipe<?, ?, 
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<R> streamRecipes() {
         return new SimpleObjectStream<>(recipeRegistry.get().values())
                 .setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         recipeRegistry.get().values().forEach(this::addBackup);
         recipeRegistry.get().clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/pyrotech/Anvil.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/pyrotech/Anvil.java
@@ -52,7 +52,7 @@ public class Anvil extends ForgeRegistryWrapper<AnvilRecipe> {
                 .register();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('minecraft:stone_slab', 3)"))
+    @MethodDescription(example = @Example("item('minecraft:stone_slab', 3)"))
     public void removeByOutput(ItemStack output) {
         if (GroovyLog.msg("Error removing pyrotech anvil recipe")
                 .add(IngredientHelper.isEmpty(output), () -> "Output 1 must not be empty")

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/pyrotech/Barrel.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/pyrotech/Barrel.java
@@ -37,7 +37,7 @@ public class Barrel extends ForgeRegistryWrapper<BarrelRecipe> {
                 .register();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("fluid('freckleberry_wine') * 1000"))
+    @MethodDescription(example = @Example("fluid('freckleberry_wine') * 1000"))
     public void removeByOutput(FluidStack output) {
         if (GroovyLog.msg("Error removing barrel recipe")
                 .add(IngredientHelper.isEmpty(output), () -> "Output 1 must not be empty")

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/pyrotech/Campfire.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/pyrotech/Campfire.java
@@ -33,7 +33,7 @@ public class Campfire extends ForgeRegistryWrapper<CampfireRecipe> {
                 .register();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:porkchop')"))
+    @MethodDescription(example = @Example("item('minecraft:porkchop')"))
     public void removeByInput(ItemStack input) {
         if (GroovyLog.msg("Error removing campfire recipe")
                 .add(IngredientHelper.isEmpty(input), () -> "Input 1 must not be empty")
@@ -48,7 +48,7 @@ public class Campfire extends ForgeRegistryWrapper<CampfireRecipe> {
         }
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('minecraft:cooked_porkchop')"))
+    @MethodDescription(example = @Example("item('minecraft:cooked_porkchop')"))
     public void removeByOutput(IIngredient output) {
         if (GroovyLog.msg("Error removing campfire recipe")
                 .add(IngredientHelper.isEmpty(output), () -> "Output 1 must not be empty")

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/pyrotech/ChoppingBlock.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/pyrotech/ChoppingBlock.java
@@ -26,7 +26,7 @@ public class ChoppingBlock extends ForgeRegistryWrapper<ChoppingBlockRecipe> {
         return new RecipeBuilder();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:log2')"))
+    @MethodDescription(example = @Example("item('minecraft:log2')"))
     public void removeByInput(ItemStack input) {
         if (GroovyLog.msg("Error removing chopping block recipe")
                 .add(IngredientHelper.isEmpty(input), () -> "Input 1 must not be empty")
@@ -41,7 +41,7 @@ public class ChoppingBlock extends ForgeRegistryWrapper<ChoppingBlockRecipe> {
         }
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('minecraft:planks', 4)"))
+    @MethodDescription(example = @Example("item('minecraft:planks', 4)"))
     public void removeByOutput(IIngredient output) {
         if (GroovyLog.msg("Error removing chopping block recipe")
                 .add(IngredientHelper.isEmpty(output), () -> "Output 1 must not be empty")

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/pyrotech/CompactingBin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/pyrotech/CompactingBin.java
@@ -34,7 +34,7 @@ public class CompactingBin extends ForgeRegistryWrapper<CompactingBinRecipe> {
                 .register();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:snowball')"))
+    @MethodDescription(example = @Example("item('minecraft:snowball')"))
     public void removeByInput(ItemStack input) {
         if (GroovyLog.msg("Error removing compacting bin recipe")
                 .add(IngredientHelper.isEmpty(input), () -> "Input 1 must not be empty")
@@ -49,7 +49,7 @@ public class CompactingBin extends ForgeRegistryWrapper<CompactingBinRecipe> {
         }
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('minecraft:bone_block')"))
+    @MethodDescription(example = @Example("item('minecraft:bone_block')"))
     public void removeByOutput(IIngredient output) {
         if (GroovyLog.msg("Error removing compacting bin recipe")
                 .add(IngredientHelper.isEmpty(output), () -> "Output 1 must not be empty")

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/pyrotech/CompostBin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/pyrotech/CompostBin.java
@@ -35,7 +35,7 @@ public class CompostBin extends ForgeRegistryWrapper<CompostBinRecipe> {
                 .register();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:golden_carrot')"))
+    @MethodDescription(example = @Example("item('minecraft:golden_carrot')"))
     public void removeByInput(ItemStack input) {
         if (GroovyLog.msg("Error removing compost bin recipe")
                 .add(IngredientHelper.isEmpty(input), () -> "Input 1 must not be empty")
@@ -50,7 +50,7 @@ public class CompostBin extends ForgeRegistryWrapper<CompostBinRecipe> {
         }
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput")
+    @MethodDescription
     public void removeByOutput(IIngredient output) {
         if (GroovyLog.msg("Error removing compost bin recipe")
                 .add(IngredientHelper.isEmpty(output), () -> "Output 1 must not be empty")

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/pyrotech/CrudeDryingRack.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/pyrotech/CrudeDryingRack.java
@@ -34,7 +34,7 @@ public class CrudeDryingRack extends ForgeRegistryWrapper<CrudeDryingRackRecipe>
                 .register();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:wheat')"))
+    @MethodDescription(example = @Example("item('minecraft:wheat')"))
     public void removeByInput(ItemStack input) {
         if (GroovyLog.msg("Error removing crude drying rack recipe")
                 .add(IngredientHelper.isEmpty(input), () -> "Input 1 must not be empty")
@@ -49,7 +49,7 @@ public class CrudeDryingRack extends ForgeRegistryWrapper<CrudeDryingRackRecipe>
         }
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput")
+    @MethodDescription
     public void removeByOutput(IIngredient output) {
         if (GroovyLog.msg("Error removing crude drying rack recipe")
                 .add(IngredientHelper.isEmpty(output), () -> "Output 1 must not be empty")

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/pyrotech/DryingRack.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/pyrotech/DryingRack.java
@@ -34,7 +34,7 @@ public class DryingRack extends ForgeRegistryWrapper<DryingRackRecipe> {
                 .register();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:wheat')"))
+    @MethodDescription(example = @Example("item('minecraft:wheat')"))
     public void removeByInput(ItemStack input) {
         if (GroovyLog.msg("Error removing drying rack recipe")
                 .add(IngredientHelper.isEmpty(input), () -> "Input 1 must not be empty")
@@ -49,7 +49,7 @@ public class DryingRack extends ForgeRegistryWrapper<DryingRackRecipe> {
         }
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput")
+    @MethodDescription
     public void removeByOutput(IIngredient output) {
         if (GroovyLog.msg("Error removing drying rack recipe")
                 .add(IngredientHelper.isEmpty(output), () -> "Output 1 must not be empty")

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/pyrotech/Kiln.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/pyrotech/Kiln.java
@@ -36,7 +36,7 @@ public class Kiln extends ForgeRegistryWrapper<KilnPitRecipe> {
                 .register();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput")
+    @MethodDescription
     public void removeByInput(ItemStack input) {
         if (GroovyLog.msg("Error removing pit kiln recipe")
                 .add(IngredientHelper.isEmpty(input), () -> "Input 1 must not be empty")
@@ -51,7 +51,7 @@ public class Kiln extends ForgeRegistryWrapper<KilnPitRecipe> {
         }
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('pyrotech:bucket_clay')"))
+    @MethodDescription(example = @Example("item('pyrotech:bucket_clay')"))
     public void removeByOutput(IIngredient output) {
         if (GroovyLog.msg("Error removing pit kiln recipe")
                 .add(IngredientHelper.isEmpty(output), () -> "Output 1 must not be empty")

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/pyrotech/SoakingPot.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/pyrotech/SoakingPot.java
@@ -35,7 +35,7 @@ public class SoakingPot extends ForgeRegistryWrapper<SoakingPotRecipe> {
                 .register();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput")
+    @MethodDescription
     public void removeByInput(ItemStack input) {
         if (GroovyLog.msg("Error removing soaking pot recipe")
                 .add(IngredientHelper.isEmpty(input), () -> "Input 1 must not be empty")
@@ -50,7 +50,7 @@ public class SoakingPot extends ForgeRegistryWrapper<SoakingPotRecipe> {
         }
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('pyrotech:material', 54)"))
+    @MethodDescription(example = @Example("item('pyrotech:material', 54)"))
     public void removeByOutput(IIngredient output) {
         if (GroovyLog.msg("Error removing soaking pot recipe")
                 .add(IngredientHelper.isEmpty(output), () -> "Output 1 must not be empty")

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/pyrotech/TanningRack.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/pyrotech/TanningRack.java
@@ -35,7 +35,7 @@ public class TanningRack extends ForgeRegistryWrapper<TanningRackRecipe> {
                 .register();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:wheat')"))
+    @MethodDescription(example = @Example("item('minecraft:wheat')"))
     public void removeByInput(ItemStack input) {
         if (GroovyLog.msg("Error removing tanning rack recipe")
                 .add(IngredientHelper.isEmpty(input), () -> "Input 1 must not be empty")
@@ -50,7 +50,7 @@ public class TanningRack extends ForgeRegistryWrapper<TanningRackRecipe> {
         }
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput")
+    @MethodDescription
     public void removeByOutput(IIngredient output) {
         if (GroovyLog.msg("Error removing tanning rack recipe")
                 .add(IngredientHelper.isEmpty(output), () -> "Output 1 must not be empty")

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/AnimalHarvest.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/AnimalHarvest.java
@@ -72,13 +72,13 @@ public class AnimalHarvest extends VirtualizedRegistry<Pair<ResourceLocation, An
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         getAnimalHarvestRecipes().forEach((key, value) -> addBackup(Pair.of(key, value)));
         getAnimalHarvestRecipes().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<Map.Entry<ResourceLocation, AnimalHarvestRecipe>> streamRecipes() {
         return new SimpleObjectStream<>(getAnimalHarvestRecipes().entrySet())
                 .setRemover(r -> this.removeByName(r.getKey()));

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/AnimalHarvestFish.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/AnimalHarvestFish.java
@@ -76,13 +76,13 @@ public class AnimalHarvestFish extends VirtualizedRegistry<Pair<ResourceLocation
         return removeByOutput(fish);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         getAnimalHarvestFishRecipes().forEach((key, value) -> addBackup(Pair.of(key, value)));
         getAnimalHarvestFishRecipes().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<Map.Entry<ResourceLocation, AnimalHarvestFishRecipe>> streamRecipes() {
         return new SimpleObjectStream<>(getAnimalHarvestFishRecipes().entrySet())
                 .setRemover(r -> this.removeByName(r.getKey()));

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/BarkCarving.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/BarkCarving.java
@@ -114,13 +114,13 @@ public class BarkCarving extends VirtualizedRegistry<Pair<ResourceLocation, Bark
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         getBarkRecipeMap().forEach((key, value) -> addBackup(Pair.of(key, value)));
         getBarkRecipeMap().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<BarkRecipe> streamRecipes() {
         return new SimpleObjectStream<>(getBarkRecipes())
                 .setRemover(r -> this.removeByName(r.getName()));

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Chrysopoeia.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Chrysopoeia.java
@@ -90,13 +90,13 @@ public class Chrysopoeia extends VirtualizedRegistry<Pair<ResourceLocation, Chry
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         ModRecipesAccessor.getChrysopoeiaRecipes().forEach((key, value) -> addBackup(Pair.of(key, value)));
         ModRecipesAccessor.getChrysopoeiaRecipes().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<Map.Entry<ResourceLocation, ChrysopoeiaRecipe>> streamRecipes() {
         return new SimpleObjectStream<>(ModRecipesAccessor.getChrysopoeiaRecipes().entrySet())
                 .setRemover(r -> this.removeByName(r.getKey()));

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/FeyCrafter.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/FeyCrafter.java
@@ -76,13 +76,13 @@ public class FeyCrafter extends VirtualizedRegistry<Pair<ResourceLocation, FeyCr
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         getFeyCraftingRecipes().forEach((key, value) -> addBackup(Pair.of(key, value)));
         getFeyCraftingRecipes().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<Map.Entry<ResourceLocation, FeyCraftingRecipe>> streamRecipes() {
         return new SimpleObjectStream<>(getFeyCraftingRecipes().entrySet())
                 .setRemover(r -> this.removeByName(r.getKey()));

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/FlowerGeneration.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/FlowerGeneration.java
@@ -94,13 +94,13 @@ public class FlowerGeneration extends VirtualizedRegistry<Pair<ResourceLocation,
         return removeByFlower(((ItemBlock) output.getItem()).getBlock().getStateFromMeta(output.getMetadata()));
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         getFlowerRecipes().forEach((key, value) -> addBackup(Pair.of(key, value)));
         getFlowerRecipes().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<Map.Entry<ResourceLocation, FlowerRecipe>> streamRecipes() {
         return new SimpleObjectStream<>(getFlowerRecipes().entrySet())
                 .setRemover(r -> this.removeByName(r.getKey()));

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/LifeEssence.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/LifeEssence.java
@@ -54,13 +54,13 @@ public class LifeEssence extends VirtualizedRegistry<Class<? extends EntityLivin
         return remove((Class<? extends EntityLivingBase>) entity.getEntityClass());
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         getLifeEssenceList().forEach(this::addBackup);
         getLifeEssenceList().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<Class<? extends EntityLivingBase>> streamRecipes() {
         return new SimpleObjectStream<>(getLifeEssenceList()).setRemover(this::remove);
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Modifiers.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Modifiers.java
@@ -115,7 +115,7 @@ public class Modifiers extends VirtualizedRegistry<ResourceLocation> {
         }
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<ResourceLocation> streamRecipes() {
         return new SimpleObjectStream<>(ModifierRegistryAccessor.getDisabledModifiers()).setRemover(this::disable);
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Mortar.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Mortar.java
@@ -90,14 +90,14 @@ public class Mortar extends VirtualizedRegistry<Pair<ResourceLocation, MortarRec
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         ModRecipesAccessor.getMortarRecipes().forEach((key, value) -> addBackup(Pair.of(key, value)));
         ModRecipesAccessor.getMortarRecipes().clear();
     }
 
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<MortarRecipe> streamRecipes() {
         return new SimpleObjectStream<>(getMortarRecipes())
                 .setRemover(r -> this.removeByName(r.getRegistryName()));

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Moss.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Moss.java
@@ -86,14 +86,14 @@ public class Moss extends VirtualizedRegistry<Pair<ItemStack, ItemStack>> {
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         MossConfigAccessor.getMossyCobblestones().forEach((in, out) -> addBackup(Pair.of(in, out)));
         MossConfigAccessor.getMossyCobblestones().clear();
         Moss.reload();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<Map.Entry<ItemStack, ItemStack>> streamRecipes() {
         return new SimpleObjectStream<>(MossConfigAccessor.getMossyCobblestones().entrySet()).setRemover(r -> this.remove(r.getKey()));
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Pacifist.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Pacifist.java
@@ -75,13 +75,13 @@ public class Pacifist extends VirtualizedRegistry<Pair<ResourceLocation, Pacifis
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         getPacifistEntities().forEach((key, value) -> addBackup(Pair.of(key, value)));
         getPacifistEntities().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<Map.Entry<ResourceLocation, PacifistEntry>> streamRecipes() {
         return new SimpleObjectStream<>(getPacifistEntities().entrySet())
                 .setRemover(r -> this.removeByName(r.getKey()));

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Pyre.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Pyre.java
@@ -77,13 +77,13 @@ public class Pyre extends VirtualizedRegistry<Pair<ResourceLocation, PyreCraftin
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         getPyreCraftingRecipes().forEach((key, value) -> addBackup(Pair.of(key, value)));
         getPyreCraftingRecipes().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<Map.Entry<ResourceLocation, PyreCraftingRecipe>> streamRecipes() {
         return new SimpleObjectStream<>(getPyreCraftingRecipes().entrySet())
                 .setRemover(r -> this.removeByName(r.getKey()));

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/RunicShearBlock.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/RunicShearBlock.java
@@ -85,13 +85,13 @@ public class RunicShearBlock extends VirtualizedRegistry<Pair<ResourceLocation, 
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         getRunicShearRecipes().forEach((key, value) -> addBackup(Pair.of(key, value)));
         getRunicShearRecipes().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<Map.Entry<ResourceLocation, RunicShearRecipe>> streamRecipes() {
         return new SimpleObjectStream<>(getRunicShearRecipes().entrySet())
                 .setRemover(r -> this.removeByName(r.getKey()));

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/RunicShearEntity.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/RunicShearEntity.java
@@ -93,13 +93,13 @@ public class RunicShearEntity extends VirtualizedRegistry<Pair<ResourceLocation,
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         getRunicShearEntityRecipes().forEach((key, value) -> addBackup(Pair.of(key, value)));
         getRunicShearEntityRecipes().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<Map.Entry<ResourceLocation, RunicShearEntityRecipe>> streamRecipes() {
         return new SimpleObjectStream<>(getRunicShearEntityRecipes().entrySet())
                 .setRemover(r -> this.removeByName(r.getKey()));

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/SummonCreature.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/SummonCreature.java
@@ -78,14 +78,14 @@ public class SummonCreature extends VirtualizedRegistry<Pair<ResourceLocation, S
         return false;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         ModRecipesAccessor.getSummonCreatureEntries().forEach((key, value) -> addBackup(Pair.of(key, value)));
         ModRecipesAccessor.getSummonCreatureEntries().clear();
         ModRecipesAccessor.getSummonCreatureClasses().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<Map.Entry<ResourceLocation, SummonCreatureRecipe>> streamRecipes() {
         return new SimpleObjectStream<>(ModRecipesAccessor.getSummonCreatureEntries().entrySet())
                 .setRemover(r -> this.removeByName(r.getKey()));

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Transmutation.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Transmutation.java
@@ -110,13 +110,13 @@ public class Transmutation extends VirtualizedRegistry<Pair<ResourceLocation, Tr
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         ModRecipesAccessor.getTransmutationRecipes().forEach((key, value) -> addBackup(Pair.of(key, value)));
         ModRecipesAccessor.getTransmutationRecipes().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<Map.Entry<ResourceLocation, TransmutationRecipe>> streamRecipes() {
         return new SimpleObjectStream<>(ModRecipesAccessor.getTransmutationRecipes().entrySet())
                 .setRemover(r -> this.removeByName(r.getKey()));

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/Crucible.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/Crucible.java
@@ -81,7 +81,7 @@ public class Crucible extends VirtualizedRegistry<CrucibleRecipe> {
         return true;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('minecraft:gunpowder')"))
+    @MethodDescription(example = @Example("item('minecraft:gunpowder')"))
     public void removeByOutput(IIngredient output) {
         if (IngredientHelper.isEmpty(output)) {
             GroovyLog.msg("Error removing Thaumcraft Crucible recipe")
@@ -110,14 +110,14 @@ public class Crucible extends VirtualizedRegistry<CrucibleRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<Map.Entry<ResourceLocation, IThaumcraftRecipe>> streamRecipes() {
         List<Map.Entry<ResourceLocation, IThaumcraftRecipe>> recipes = ThaumcraftApi.getCraftingRecipes().entrySet().stream().filter(x -> x.getValue() instanceof CrucibleRecipe).collect(Collectors.toList());
         return new SimpleObjectStream<>(recipes)
                 .setRemover(x -> remove((CrucibleRecipe) x));
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         List<Map.Entry<ResourceLocation, IThaumcraftRecipe>> recipes = ThaumcraftApi.getCraftingRecipes().entrySet().stream().filter(x -> x.getValue() instanceof CrucibleRecipe).collect(Collectors.toList());
         for (Map.Entry<ResourceLocation, IThaumcraftRecipe> recipe : recipes) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/DustTrigger.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/DustTrigger.java
@@ -74,7 +74,7 @@ public class DustTrigger extends VirtualizedRegistry<IDustTrigger> {
         return found;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('thaumcraft:arcane_workbench')"))
+    @MethodDescription(example = @Example("item('thaumcraft:arcane_workbench')"))
     public void removeByOutput(ItemStack output) {
         doDirtyReflection();
         Iterator<IDustTrigger> it = IDustTrigger.triggers.iterator();
@@ -96,7 +96,7 @@ public class DustTrigger extends VirtualizedRegistry<IDustTrigger> {
         }
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<IDustTrigger> streamRecipes() {
         return new SimpleObjectStream<>(IDustTrigger.triggers)
                 .setRemover(this::remove);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/InfusionCrafting.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/InfusionCrafting.java
@@ -82,7 +82,7 @@ public class InfusionCrafting extends VirtualizedRegistry<Pair<ResourceLocation,
         return !recipes.isEmpty();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('thaumcraft:crystal_terra')"))
+    @MethodDescription(example = @Example("item('thaumcraft:crystal_terra')"))
     public void removeByOutput(IIngredient output) {
         if (IngredientHelper.isEmpty(output)) {
             GroovyLog.msg("Error removing Thaumcraft Infusion Crafting recipe")
@@ -117,14 +117,14 @@ public class InfusionCrafting extends VirtualizedRegistry<Pair<ResourceLocation,
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<Map.Entry<ResourceLocation, IThaumcraftRecipe>> streamRecipes() {
         List<Map.Entry<ResourceLocation, IThaumcraftRecipe>> recipes = ThaumcraftApi.getCraftingRecipes().entrySet().stream().filter(x -> x.getValue() instanceof InfusionRecipe).collect(Collectors.toList());
         return new SimpleObjectStream<>(recipes)
                 .setRemover(x -> remove((InfusionRecipe) x.getValue()));
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         List<Map.Entry<ResourceLocation, IThaumcraftRecipe>> recipes = ThaumcraftApi.getCraftingRecipes().entrySet().stream().filter(x -> x.getValue() instanceof InfusionRecipe).collect(Collectors.toList());
         for (Map.Entry<ResourceLocation, IThaumcraftRecipe> recipe : recipes) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/SmeltingBonus.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/SmeltingBonus.java
@@ -62,7 +62,7 @@ public class SmeltingBonus extends VirtualizedRegistry<ThaumcraftApi.SmeltBonus>
         return removed;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('minecraft:gold_nugget')"))
+    @MethodDescription(example = @Example("item('minecraft:gold_nugget')"))
     public void removeByOutput(ItemStack output) {
         List<ThaumcraftApi.SmeltBonus> remove = new ArrayList<>();
         for (ThaumcraftApi.SmeltBonus bonus : CommonInternals.smeltingBonus) {
@@ -74,12 +74,12 @@ public class SmeltingBonus extends VirtualizedRegistry<ThaumcraftApi.SmeltBonus>
         CommonInternals.smeltingBonus.removeAll(remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<ThaumcraftApi.SmeltBonus> streamRecipes() {
         return new SimpleObjectStream<>(CommonInternals.smeltingBonus).setRemover(this::remove);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         CommonInternals.smeltingBonus.forEach(this::addBackup);
         CommonInternals.smeltingBonus.clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/arcane/ArcaneWorkbench.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/arcane/ArcaneWorkbench.java
@@ -32,7 +32,7 @@ public class ArcaneWorkbench extends NamedRegistry {
         ReloadableRegistryManager.removeRegistryEntry(ForgeRegistries.RECIPES, name);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('thaumcraft:mechanism_simple')"))
+    @MethodDescription(example = @Example("item('thaumcraft:mechanism_simple')"))
     public void removeByOutput(IIngredient output) {
         VanillaModule.crafting.removeByOutput(output, true);
     }
@@ -50,7 +50,7 @@ public class ArcaneWorkbench extends NamedRegistry {
         return new ArcaneRecipeBuilder.Shapeless();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         List<IArcaneRecipe> recipes = ForgeRegistries.RECIPES.getValuesCollection().stream()
                 .filter(recipe -> recipe instanceof IArcaneRecipe)

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/aspect/Aspect.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/aspect/Aspect.java
@@ -35,13 +35,13 @@ public class Aspect extends VirtualizedRegistry<thaumcraft.api.aspects.Aspect> {
         return thaumcraft.api.aspects.Aspect.aspects.remove(aspect.getTag(), aspect);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<Map.Entry<String, thaumcraft.api.aspects.Aspect>> streamRecipes() {
         return new SimpleObjectStream<>(thaumcraft.api.aspects.Aspect.aspects.entrySet())
                 .setRemover(x -> remove(x.getValue()));
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         thaumcraft.api.aspects.Aspect.aspects.forEach((k, v) -> addBackup(v));
         thaumcraft.api.aspects.Aspect.aspects.clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/warp/Warp.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/warp/Warp.java
@@ -37,7 +37,7 @@ public class Warp extends VirtualizedRegistry<Warp.InternalWarp> {
         }
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         CommonInternals.warpMap.forEach((key, value) -> addBackup(new InternalWarp(key, value)));
         CommonInternals.warpMap.clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/woot/Drops.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/woot/Drops.java
@@ -97,13 +97,13 @@ public class Drops extends VirtualizedRegistry<Object> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         ((CustomDropsRepositoryAccessor) Woot.customDropsRepository).getDrops().forEach(this::addBackup);
         ((CustomDropsRepositoryAccessor) Woot.customDropsRepository).getDrops().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<Object> streamRecipes() {
         return new SimpleObjectStream<>(((CustomDropsRepositoryAccessor) Woot.customDropsRepository).getDrops())
                 .setRemover(this::remove);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/woot/MobConfig.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/woot/MobConfig.java
@@ -98,7 +98,7 @@ public class MobConfig extends VirtualizedRegistry<Pair<String, Integer>> {
         remove(new WootMobName(name));
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         ((WootConfigurationManagerAccessor) Woot.wootConfiguration).getIntegerMobMap().forEach((key, value) -> addBackup(Pair.of(key, value)));
         ((WootConfigurationManagerAccessor) Woot.wootConfiguration).getIntegerMobMap().clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/woot/Policy.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/woot/Policy.java
@@ -202,7 +202,7 @@ public class Policy extends VirtualizedRegistry<Pair<Policy.PolicyType, Object>>
         ((PolicyRepositoryAccessor) Woot.policyRepository).getExternalGenerateOnlyList().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         removeAllFromEntityModBlacklist();
         removeAllFromEntityBlacklist();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/woot/Spawning.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/woot/Spawning.java
@@ -87,13 +87,13 @@ public class Spawning extends VirtualizedRegistry<Pair<WootMobName, SpawnRecipe>
         return remove(new WootMobName(name, tag));
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         ((SpawnRecipeRepositoryAccessor) Woot.spawnRecipeRepository).getRecipes().forEach((l, r) -> addBackup(Pair.of(l, r)));
         ((SpawnRecipeRepositoryAccessor) Woot.spawnRecipeRepository).getRecipes().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<Map.Entry<WootMobName, SpawnRecipe>> streamRecipes() {
         return new SimpleObjectStream<>(((SpawnRecipeRepositoryAccessor) Woot.spawnRecipeRepository).getRecipes().entrySet())
                 .setRemover(x -> remove(x.getKey()));

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/woot/StygianIronAnvil.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/woot/StygianIronAnvil.java
@@ -75,7 +75,7 @@ public class StygianIronAnvil extends VirtualizedRegistry<IAnvilRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('woot:stygianironplate')"))
+    @MethodDescription(example = @Example("item('woot:stygianironplate')"))
     public boolean removeByOutput(ItemStack output) {
         return Woot.anvilManager.getRecipes().removeIf(x -> {
             if (ItemStack.areItemsEqual(x.getCopyOutput(), output)) {
@@ -86,14 +86,14 @@ public class StygianIronAnvil extends VirtualizedRegistry<IAnvilRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         Woot.anvilManager.getRecipes().forEach(this::addBackup);
         Woot.anvilManager.getRecipes().clear();
     }
 
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<IAnvilRecipe> streamRecipes() {
         return new SimpleObjectStream<>(Woot.anvilManager.getRecipes())
                 .setRemover(this::remove);

--- a/src/main/java/com/cleanroommc/groovyscript/documentation/Registry.java
+++ b/src/main/java/com/cleanroommc/groovyscript/documentation/Registry.java
@@ -287,7 +287,13 @@ public class Registry {
 
     private String methodDescription(Method method) {
         String desc = method.getAnnotation(MethodDescription.class).description();
-        String lang = desc.isEmpty() ? String.format("%s.%s", baseTranslationKey, method.getName()) : desc;
+        String registryDefault = String.format("%s.%s", baseTranslationKey, method.getName());
+        String globalDefault = String.format("groovyscript.wiki.%s", method.getName());
+        // If `desc` isn't defined, check the `registryDefault` key. If it exists, use it.
+        // Then, check the `globalDefault` key. If it exists use it. Otherwise, we want to still use the `registryDefault` for logging a missing key.
+        String lang = desc.isEmpty()
+                      ? I18n.hasKey(registryDefault) || !I18n.hasKey(globalDefault) ? registryDefault : globalDefault
+                      : desc;
 
         return String.format("- %s:\n\n%s",
                              Documentation.translate(lang),

--- a/src/main/java/com/cleanroommc/groovyscript/registry/ForgeRegistryWrapper.java
+++ b/src/main/java/com/cleanroommc/groovyscript/registry/ForgeRegistryWrapper.java
@@ -63,14 +63,14 @@ public class ForgeRegistryWrapper<T extends IForgeRegistryEntry<T>> extends Name
         return true;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         for (T recipe : this.registry) {
             ReloadableRegistryManager.removeRegistryEntry(this.registry, recipe.getRegistryName());
         }
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<T> streamRecipes() {
         return new SimpleObjectStream<>(this.registry.getValuesCollection()).setRemover(recipe -> {
             ResourceLocation key = this.registry.getKey(recipe);


### PR DESCRIPTION
changes in this PR:
- made `@MethodDescription#description` check for global fallback key if exact key isnt defined
	- old flow: `key -> use desc if not empty -> use the exact key`
	- new flow: `key -> use desc if not empty -> check exact key, use if exists -> check global key, use if exists -> use exact key` (missing keys should log exact key)
- apparently the mixer was using the `removeByOutput` key for a `removeByInput` method, so that got fixed