### PR TITLE
add Industrial Foregoing compat

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -32,7 +32,7 @@ final def mod_dependencies = [
         'aether-255308:3280119'                               : [project.debug_aether],
         'alchemistry-293425:3186612'                          : [project.debug_alchemistry],
         'alchemylib-293426:2761706'                           : [project.debug_alchemistry],
-        'shadowfacts-forgelin-248453:2785465'                 : [project.debug_alchemistry],
+        'shadowfacts-forgelin-248453:2785465'                 : [project.debug_alchemistry, project.debug_industrial_foregoing],
         'ae2-extended-life-570458:4553942'                    : [project.debug_applied_energistics_2],
         'arcane-archives-311357:3057332'                      : [project.debug_arcane_archives],
         'guidebook-253874:2989594'                            : [project.debug_arcane_archives],
@@ -63,6 +63,8 @@ final def mod_dependencies = [
         // WARNING: experimental must be placed before classic, otherwise you will crash when debugging either. Check FluidGenerator compat to confirm
         'industrialcraft_experimental-242638:3838713'         : [project.debug_industrial_craft_2_experimental],
         'industrialcraft_classic-242942:3093607'              : [project.debug_industrial_craft_2_classic],
+        'tesla-core-lib-254602:3438487'                       : [project.debug_industrial_foregoing],
+        'industrialforegoing-266515:2745321'                  : [project.debug_industrial_foregoing],
         'inspirations-284007:2843007'                         : [project.debug_inspirations],
         'mantle-74924:2713386'                                : [project.debug_inspirations, project.debug_tinkers],
         'common-capabilities-247007:3053017'                  : [project.debug_integrated_dynamics],

--- a/examples/postInit/industrialforegoing.groovy
+++ b/examples/postInit/industrialforegoing.groovy
@@ -1,0 +1,118 @@
+
+// Auto generated groovyscript example file
+// MODS_LOADED: industrialforegoing
+
+import net.minecraft.potion.PotionEffect
+
+println 'mod \'industrialforegoing\' detected, running script'
+
+// Bioreactor:
+// Converts an input item into Biofuel, with the amount of Biofuel generated being based on the number of concurrent
+// conversion processes inside the Bioreactor.
+
+mods.industrialforegoing.bio_reactor.removeByInput(item('minecraft:wheat_seeds'))
+// mods.industrialforegoing.bio_reactor.removeAll()
+
+mods.industrialforegoing.bio_reactor.add(item('minecraft:clay'))
+
+// Latex Extractor:
+// Converts an input block in-world into a fluidstack over time, eventually breaking the block.
+
+mods.industrialforegoing.extractor.removeByInput(item('minecraft:log2:1'))
+// mods.industrialforegoing.extractor.removeByOutput(fluid('latex'))
+// mods.industrialforegoing.extractor.removeAll()
+
+mods.industrialforegoing.extractor.add(item('minecraft:clay'), fluid('lava') * 50)
+mods.industrialforegoing.extractor.add(item('minecraft:stone'), fluid('water') * 100, 1)
+
+// Fluid Dictionary Converter:
+// Converts one fluid into another fluid at a given ratio.
+
+// mods.industrialforegoing.fluid_dictionary.removeByInput(fluid('essence'))
+// mods.industrialforegoing.fluid_dictionary.removeByOutput(fluid(essence'))
+// mods.industrialforegoing.fluid_dictionary.removeAll()
+
+mods.industrialforegoing.fluid_dictionary.add(fluid('biofuel'), fluid('latex'),)
+mods.industrialforegoing.fluid_dictionary.add(fluid('latex'), fluid('biofuel'),)
+mods.industrialforegoing.fluid_dictionary.add(fluid('essence'), fluid('latex'), 2)
+mods.industrialforegoing.fluid_dictionary.add(fluid('latex'), fluid('essence'), 0.5)
+
+// Laser Drill:
+// Converts power into ores, with a given weight, between a minimum and maximum Y value, in any whitelisted biome or not in
+// any blacklisted biome, and with a specific color of laser lens impacting the probability.
+
+mods.industrialforegoing.laser_drill.removeByBlacklist(biome('minecraft:sky'))
+mods.industrialforegoing.laser_drill.removeByLens(5)
+// mods.industrialforegoing.laser_drill.removeByLens(item('industrialforegoing:laser_lens:5'))
+mods.industrialforegoing.laser_drill.removeByOutput(item('minecraft:coal_ore'))
+mods.industrialforegoing.laser_drill.removeByWhitelist(biome('minecraft:hell'))
+// mods.industrialforegoing.laser_drill.removeAll()
+
+mods.industrialforegoing.laser_drill.recipeBuilder()
+    .output(item('minecraft:clay'))
+    .lensMeta(5)
+    .weight(100)
+    .register()
+
+
+// Fermentation Station:
+// Converts an input fluidstack into an output fluidstack.
+
+mods.industrialforegoing.ore_fermenter.removeByInput(fluid('if.ore_fluid_raw').withNbt([Ore: 'oreRedstone']))
+// mods.industrialforegoing.ore_fermenter.removeByOutput(fluid('if.ore_fluid_fermented').withNbt([Ore: 'oreRedstone']))
+// mods.industrialforegoing.ore_fermenter.removeAll()
+
+mods.industrialforegoing.ore_fermenter.add(fluid('if.ore_fluid_raw').withNbt(['Ore': 'oreGold']), fluid('if.ore_fluid_fermented').withNbt(['Ore': 'oreGold']) * 2)
+
+// Washing Factory:
+// Converts an input itemstack and input fluidstack into an output fluidstack.
+
+// mods.industrialforegoing.ore_raw.removeByInput(fluid('meat'))
+mods.industrialforegoing.ore_raw.removeByOre(ore('oreRedstone'))
+// mods.industrialforegoing.ore_raw.removeByOre('oreRedstone')
+// mods.industrialforegoing.ore_raw.removeByOutput(fluid('if.ore_fluid_raw').withNbt(['Ore': 'oreRedstone']),)
+// mods.industrialforegoing.ore_raw.removeAll()
+
+mods.industrialforegoing.ore_raw.add(ore('stone'), fluid('water') * 1000, fluid('lava') * 50)
+mods.industrialforegoing.ore_raw.add(ore('oreGold'), fluid('meat') * 200, fluid('if.ore_fluid_raw').withNbt(['Ore': 'oreGold']) * 300)
+
+// Fluid Sieving Machine:
+// Converts an input itemstack and input fluidstack into an output itemstack.
+
+mods.industrialforegoing.ore_sieve.removeByInput(fluid('if.pink_slime'))
+mods.industrialforegoing.ore_sieve.removeByInput(item('minecraft:sand'))
+// mods.industrialforegoing.ore_sieve.removeByOutput(item('industrialforegoing:pink_slime_ingot)
+// mods.industrialforegoing.ore_sieve.removeAll()
+
+mods.industrialforegoing.ore_sieve.add(fluid('lava') * 5, item('minecraft:gold_ingot'), item('minecraft:clay'))
+mods.industrialforegoing.ore_sieve.add(fluid('if.ore_fluid_fermented').withNbt(['Ore': 'oreGold']) * 100, item('minecraft:nether_star') * 2, item('minecraft:clay'))
+
+// Protein Reactor:
+// Converts an input item into Protein, with the amount of Protein generated being based on the number of concurrent
+// conversion processes inside the Protein Reactor.
+
+mods.industrialforegoing.protein_reactor.removeByInput(item('minecraft:porkchop'))
+// mods.industrialforegoing.protein_reactor.removeAll()
+
+mods.industrialforegoing.protein_reactor.add(item('minecraft:clay'))
+
+// Sludge Refiner:
+// Converts 1000mb of Sludge into a random itemstack based on the weight of the given itemstack.
+
+mods.industrialforegoing.sludge_refiner.removeByOutput(item('minecraft:clay_ball'))
+// mods.industrialforegoing.sludge_refiner.removeAll()
+
+mods.industrialforegoing.sludge_refiner.add(item('minecraft:gold_ingot'), 5)
+
+// Straw:
+// Converts an fluid block in-world into various effects for the player when consumed via a straw.
+
+// mods.industrialforegoing.straw.removeAll()
+
+mods.industrialforegoing.straw.recipeBuilder()
+    .fluidInput(fluid('if.pink_slime'))
+    .effect(new PotionEffect(potion('minecraft:strength'), 1800, 3))
+    .register()
+
+
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,6 +22,7 @@ debug_forestry = false
 debug_immersive_engineering = false
 debug_industrial_craft_2_classic = false
 debug_industrial_craft_2_experimental = false
+debug_industrial_foregoing = false
 debug_inspirations = false
 debug_integrated_dynamics = false
 debug_mekanism = false

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ModSupport.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ModSupport.java
@@ -26,6 +26,7 @@ import com.cleanroommc.groovyscript.compat.mods.extrautils2.ExtraUtils2;
 import com.cleanroommc.groovyscript.compat.mods.forestry.Forestry;
 import com.cleanroommc.groovyscript.compat.mods.ic2.IC2;
 import com.cleanroommc.groovyscript.compat.mods.immersiveengineering.ImmersiveEngineering;
+import com.cleanroommc.groovyscript.compat.mods.industrialforegoing.IndustrialForegoing;
 import com.cleanroommc.groovyscript.compat.mods.inspirations.Inspirations;
 import com.cleanroommc.groovyscript.compat.mods.integrateddynamics.IntegratedDynamics;
 import com.cleanroommc.groovyscript.compat.mods.jei.JustEnoughItems;
@@ -81,6 +82,7 @@ public class ModSupport implements IDynamicGroovyProperty {
     public static final GroovyContainer<Forestry> FORESTRY = new InternalModContainer<>("forestry", "Forestry", Forestry::new);
     public static final GroovyContainer<ImmersiveEngineering> IMMERSIVE_ENGINEERING = new InternalModContainer<>("immersiveengineering", "Immersive Engineering", ImmersiveEngineering::new, "ie");
     public static final GroovyContainer<IC2> INDUSTRIALCRAFT = new InternalModContainer<>("ic2", "Industrial Craft 2", IC2::new, "industrialcraft");
+    public static final GroovyContainer<IndustrialForegoing> INDUSTRIAL_FOREGOING = new InternalModContainer<>("industrialforegoing", "Industrial Foregoing", IndustrialForegoing::new);
     public static final GroovyContainer<Inspirations> INSPIRATIONS = new InternalModContainer<>("inspirations", "Inspirations", Inspirations::new);
     public static final GroovyContainer<IntegratedDynamics> INTEGRATED_DYNAMICS = new InternalModContainer<>("integrateddynamics", "Integrated Dynamics", IntegratedDynamics::new, "id");
     public static final GroovyContainer<JustEnoughItems> JEI = new InternalModContainer<>("jei", "Just Enough Items", JustEnoughItems::new, "hei");

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/industrialforegoing/BioReactor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/industrialforegoing/BioReactor.java
@@ -1,0 +1,75 @@
+package com.cleanroommc.groovyscript.compat.mods.industrialforegoing;
+
+import com.buuz135.industrial.api.recipe.BioReactorEntry;
+import com.buuz135.industrial.api.recipe.IReactorEntry;
+import com.cleanroommc.groovyscript.api.GroovyBlacklist;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.Example;
+import com.cleanroommc.groovyscript.api.documentation.annotations.MethodDescription;
+import com.cleanroommc.groovyscript.api.documentation.annotations.RegistryDescription;
+import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
+import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import com.google.common.base.Predicate;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import org.jetbrains.annotations.Nullable;
+
+@RegistryDescription
+public class BioReactor extends VirtualizedRegistry<IReactorEntry> {
+
+    @Override
+    @GroovyBlacklist
+    public void onReload() {
+        BioReactorEntry.BIO_REACTOR_ENTRIES.removeAll(removeScripted());
+        BioReactorEntry.BIO_REACTOR_ENTRIES.addAll(restoreFromBackup());
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.industrialforegoing.bio_reactor.add0", type = MethodDescription.Type.ADDITION, example = @Example("item('minecraft:clay')"))
+    public IReactorEntry add(ItemStack input) {
+        return add(input, null);
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.industrialforegoing.bio_reactor.add1", type = MethodDescription.Type.ADDITION)
+    public IReactorEntry add(ItemStack input, @Nullable Predicate<NBTTagCompound> nbtCheck) {
+        IReactorEntry recipe = new BioReactorEntry(input, nbtCheck);
+        add(recipe);
+        return recipe;
+    }
+
+    public void add(IReactorEntry recipe) {
+        if (recipe == null) return;
+        addScripted(recipe);
+        BioReactorEntry.BIO_REACTOR_ENTRIES.add(recipe);
+    }
+
+    public boolean remove(IReactorEntry recipe) {
+        if (recipe == null) return false;
+        addBackup(recipe);
+        BioReactorEntry.BIO_REACTOR_ENTRIES.remove(recipe);
+        return true;
+    }
+
+    @MethodDescription(example = @Example("item('minecraft:wheat_seeds')"))
+    public boolean removeByInput(IIngredient input) {
+        return BioReactorEntry.BIO_REACTOR_ENTRIES.removeIf(recipe -> {
+            if (input.test(recipe.getStack())) {
+                addBackup(recipe);
+                return true;
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
+    public void removeAll() {
+        BioReactorEntry.BIO_REACTOR_ENTRIES.forEach(this::addBackup);
+        BioReactorEntry.BIO_REACTOR_ENTRIES.clear();
+    }
+
+    @MethodDescription(type = MethodDescription.Type.QUERY)
+    public SimpleObjectStream<IReactorEntry> streamRecipes() {
+        return new SimpleObjectStream<>(BioReactorEntry.BIO_REACTOR_ENTRIES)
+                .setRemover(this::remove);
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/industrialforegoing/Extractor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/industrialforegoing/Extractor.java
@@ -1,0 +1,88 @@
+package com.cleanroommc.groovyscript.compat.mods.industrialforegoing;
+
+import com.buuz135.industrial.api.extractor.ExtractorEntry;
+import com.cleanroommc.groovyscript.api.GroovyBlacklist;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.Example;
+import com.cleanroommc.groovyscript.api.documentation.annotations.MethodDescription;
+import com.cleanroommc.groovyscript.api.documentation.annotations.RegistryDescription;
+import com.cleanroommc.groovyscript.helper.Alias;
+import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
+import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
+
+@RegistryDescription
+public class Extractor extends VirtualizedRegistry<ExtractorEntry> {
+
+    public Extractor() {
+        super(Alias.generateOfClass(Extractor.class).andGenerate("TreeFluidExtractor"));
+    }
+
+    @Override
+    @GroovyBlacklist
+    public void onReload() {
+        ExtractorEntry.EXTRACTOR_ENTRIES.removeAll(removeScripted());
+        ExtractorEntry.EXTRACTOR_ENTRIES.addAll(restoreFromBackup());
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.industrialforegoing.extractor.add0", type = MethodDescription.Type.ADDITION, example = @Example("item('minecraft:clay'), fluid('lava') * 50"))
+    public ExtractorEntry add(ItemStack input, FluidStack output) {
+        return add(input, output, 0.005F);
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.industrialforegoing.extractor.add1", type = MethodDescription.Type.ADDITION, example = @Example("item('minecraft:stone'), fluid('water') * 100, 1"))
+    public ExtractorEntry add(ItemStack input, FluidStack output, float breakChance) {
+        ExtractorEntry recipe = new ExtractorEntry(input, output, breakChance);
+        add(recipe);
+        return recipe;
+    }
+
+    public void add(ExtractorEntry recipe) {
+        if (recipe == null) return;
+        addScripted(recipe);
+        ExtractorEntry.EXTRACTOR_ENTRIES.add(recipe);
+    }
+
+    public boolean remove(ExtractorEntry recipe) {
+        if (recipe == null) return false;
+        addBackup(recipe);
+        ExtractorEntry.EXTRACTOR_ENTRIES.remove(recipe);
+        return true;
+    }
+
+    @MethodDescription(example = @Example("item('minecraft:log2:1')"))
+    public boolean removeByInput(IIngredient input) {
+        return ExtractorEntry.EXTRACTOR_ENTRIES.removeIf(recipe -> {
+            if (input.test(recipe.getItemStack())) {
+                addBackup(recipe);
+                return true;
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(example = @Example(value = "fluid('latex')", commented = true))
+    public boolean removeByOutput(IIngredient output) {
+        return ExtractorEntry.EXTRACTOR_ENTRIES.removeIf(recipe -> {
+            if (output.test(recipe.getFluidStack())) {
+                addBackup(recipe);
+                return true;
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
+    public void removeAll() {
+        ExtractorEntry.EXTRACTOR_ENTRIES.forEach(this::addBackup);
+        ExtractorEntry.EXTRACTOR_ENTRIES.clear();
+    }
+
+    @MethodDescription(type = MethodDescription.Type.QUERY)
+    public SimpleObjectStream<ExtractorEntry> streamRecipes() {
+        return new SimpleObjectStream<>(ExtractorEntry.EXTRACTOR_ENTRIES)
+                .setRemover(this::remove);
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/industrialforegoing/FluidDictionary.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/industrialforegoing/FluidDictionary.java
@@ -1,0 +1,102 @@
+package com.cleanroommc.groovyscript.compat.mods.industrialforegoing;
+
+import com.buuz135.industrial.api.recipe.FluidDictionaryEntry;
+import com.cleanroommc.groovyscript.api.GroovyBlacklist;
+import com.cleanroommc.groovyscript.api.documentation.annotations.Example;
+import com.cleanroommc.groovyscript.api.documentation.annotations.MethodDescription;
+import com.cleanroommc.groovyscript.api.documentation.annotations.RegistryDescription;
+import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
+import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import net.minecraftforge.fluids.FluidStack;
+
+@RegistryDescription
+public class FluidDictionary extends VirtualizedRegistry<FluidDictionaryEntry> {
+
+    @Override
+    @GroovyBlacklist
+    public void onReload() {
+        FluidDictionaryEntry.FLUID_DICTIONARY_RECIPES.removeAll(removeScripted());
+        FluidDictionaryEntry.FLUID_DICTIONARY_RECIPES.addAll(restoreFromBackup());
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.industrialforegoing.fluid_dictionary.add0", type = MethodDescription.Type.ADDITION, example = {
+            @Example("fluid('biofuel'), fluid('latex'),"),
+            @Example("fluid('latex'), fluid('biofuel'),")
+    })
+    public FluidDictionaryEntry add(FluidStack input, FluidStack output) {
+        return add(input, output, 1);
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.industrialforegoing.fluid_dictionary.add1", type = MethodDescription.Type.ADDITION, example = {
+            @Example("fluid('essence'), fluid('latex'), 2"),
+            @Example("fluid('latex'), fluid('essence'), 0.5")
+    })
+    public FluidDictionaryEntry add(FluidStack input, FluidStack output, double ratio) {
+        return add(input.getFluid().getName(), output.getFluid().getName(), ratio);
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.industrialforegoing.fluid_dictionary.add1", type = MethodDescription.Type.ADDITION)
+    public FluidDictionaryEntry add(String input, String output, double ratio) {
+        FluidDictionaryEntry recipe = new FluidDictionaryEntry(input, output, ratio);
+        add(recipe);
+        return recipe;
+    }
+
+    public void add(FluidDictionaryEntry recipe) {
+        if (recipe == null) return;
+        addScripted(recipe);
+        FluidDictionaryEntry.FLUID_DICTIONARY_RECIPES.add(recipe);
+    }
+
+    public boolean remove(FluidDictionaryEntry recipe) {
+        if (recipe == null) return false;
+        addBackup(recipe);
+        FluidDictionaryEntry.FLUID_DICTIONARY_RECIPES.remove(recipe);
+        return true;
+    }
+
+    @MethodDescription
+    public boolean removeByInput(String fluid) {
+        return FluidDictionaryEntry.FLUID_DICTIONARY_RECIPES.removeIf(recipe -> {
+            if (fluid.equals(recipe.getFluidOrigin())) {
+                addBackup(recipe);
+                return true;
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(example = @Example(value = "fluid('essence')", commented = true))
+    public boolean removeByInput(FluidStack fluid) {
+        return removeByInput(fluid.getFluid().getName());
+    }
+
+    @MethodDescription
+    public boolean removeByOutput(String fluid) {
+        return FluidDictionaryEntry.FLUID_DICTIONARY_RECIPES.removeIf(recipe -> {
+            if (fluid.equals(recipe.getFluidResult())) {
+                addBackup(recipe);
+                return true;
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(example = @Example(value = "fluid(essence')", commented = true))
+    public boolean removeByOutput(FluidStack fluid) {
+        return removeByOutput(fluid.getFluid().getName());
+    }
+
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
+    public void removeAll() {
+        FluidDictionaryEntry.FLUID_DICTIONARY_RECIPES.forEach(this::addBackup);
+        FluidDictionaryEntry.FLUID_DICTIONARY_RECIPES.clear();
+    }
+
+    @MethodDescription(type = MethodDescription.Type.QUERY)
+    public SimpleObjectStream<FluidDictionaryEntry> streamRecipes() {
+        return new SimpleObjectStream<>(FluidDictionaryEntry.FLUID_DICTIONARY_RECIPES)
+                .setRemover(this::remove);
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/industrialforegoing/IndustrialForegoing.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/industrialforegoing/IndustrialForegoing.java
@@ -1,0 +1,31 @@
+package com.cleanroommc.groovyscript.compat.mods.industrialforegoing;
+
+import com.cleanroommc.groovyscript.compat.mods.ModPropertyContainer;
+
+public class IndustrialForegoing extends ModPropertyContainer {
+
+    public final BioReactor bioReactor = new BioReactor();
+    public final Extractor extractor = new Extractor();
+    public final FluidDictionary fluidDictionary = new FluidDictionary();
+    public final LaserDrill laserDrill = new LaserDrill();
+    public final OreFermenter oreFermenter = new OreFermenter();
+    public final OreRaw oreRaw = new OreRaw();
+    public final OreSieve oreSieve = new OreSieve();
+    public final ProteinReactor proteinReactor = new ProteinReactor();
+    public final SludgeRefiner sludgeRefiner = new SludgeRefiner();
+    public final Straw straw = new Straw();
+
+    public IndustrialForegoing() {
+        addRegistry(bioReactor);
+        addRegistry(extractor);
+        addRegistry(fluidDictionary);
+        addRegistry(laserDrill);
+        addRegistry(oreFermenter);
+        addRegistry(oreRaw);
+        addRegistry(oreSieve);
+        addRegistry(proteinReactor);
+        addRegistry(sludgeRefiner);
+        addRegistry(straw);
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/industrialforegoing/LaserDrill.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/industrialforegoing/LaserDrill.java
@@ -1,0 +1,260 @@
+package com.cleanroommc.groovyscript.compat.mods.industrialforegoing;
+
+import com.buuz135.industrial.api.recipe.LaserDrillEntry;
+import com.cleanroommc.groovyscript.api.GroovyBlacklist;
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.biome.Biome;
+import org.apache.commons.lang3.tuple.Pair;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+@RegistryDescription
+public class LaserDrill extends VirtualizedRegistry<Pair<LaserDrillEntry.LaserDrillEntryExtended, LaserDrillEntry.OreRarity>> {
+
+    @RecipeBuilderDescription(example = @Example(".output(item('minecraft:clay')).lensMeta(5).weight(100)"))
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @Override
+    @GroovyBlacklist
+    public void onReload() {
+        removeScripted().forEach(pair -> LaserDrillEntry.findForOre(pair.getKey().getStack(), pair.getKey()).getRarities().remove(pair.getValue()));
+        restoreFromBackup().forEach(pair -> LaserDrillEntry.findForOre(pair.getKey().getStack(), pair.getKey()).getRarities().add(pair.getValue()));
+    }
+
+    @Override
+    @GroovyBlacklist
+    public void afterScriptLoad() {
+        // Clear any empty values to prevent JEI integration from causing an IndexOutOfBoundsException
+        LaserDrillEntry.LASER_DRILL_UNIQUE_VALUES.removeIf(x -> x.getRarities().isEmpty());
+
+        // Clear and update the LASER_DRILL_ENTRIES based on current LASER_DRILL_UNIQUE_VALUES
+        for (int y = 0; y < LaserDrillEntry.LASER_DRILL_ENTRIES.length; y++) {
+            LaserDrillEntry.LASER_DRILL_ENTRIES[y].clear();
+        }
+
+        for (LaserDrillEntry.LaserDrillEntryExtended entryExtended : LaserDrillEntry.LASER_DRILL_UNIQUE_VALUES) {
+            for (LaserDrillEntry.OreRarity oreRarity : entryExtended.getRarities()) {
+                for (int y = oreRarity.getMinY(); y <= oreRarity.getMaxY(); y++) {
+                    LaserDrillEntry.LASER_DRILL_ENTRIES[y].add(new LaserDrillEntry(entryExtended.getLaserMeta(), entryExtended.getStack(), oreRarity.getWeight(), oreRarity.getWhitelist(), oreRarity.getBlacklist()));
+                }
+            }
+        }
+    }
+
+    public void add(LaserDrillEntry.LaserDrillEntryExtended recipe, LaserDrillEntry.OreRarity entry) {
+        if (recipe == null) return;
+        addScripted(Pair.of(recipe, entry));
+        LaserDrillEntry.findForOre(recipe.getStack(), recipe).getRarities().add(entry);
+    }
+
+    public boolean remove(LaserDrillEntry.LaserDrillEntryExtended recipe) {
+        if (recipe == null) return false;
+        for (LaserDrillEntry.OreRarity rarity : recipe.getRarities()) {
+            addBackup(Pair.of(recipe, rarity));
+        }
+        recipe.getRarities().clear();
+        return true;
+    }
+
+    @MethodDescription(example = @Example("5"))
+    public boolean removeByLens(int lensMeta) {
+        boolean removed = false;
+        for (LaserDrillEntry.LaserDrillEntryExtended laserDrillUniqueValue : LaserDrillEntry.LASER_DRILL_UNIQUE_VALUES) {
+            removed = laserDrillUniqueValue.getRarities().removeIf(recipe -> {
+                if (lensMeta == laserDrillUniqueValue.getLaserMeta()) {
+                    addBackup(Pair.of(laserDrillUniqueValue, recipe));
+                    return true;
+                }
+                return false;
+            }) || removed;
+        }
+        return removed;
+    }
+
+    @MethodDescription(example = @Example(value = "item('industrialforegoing:laser_lens:5')", commented = true))
+    public boolean removeByLens(ItemStack lens) {
+        return removeByLens(lens.getItemDamage());
+    }
+
+    @MethodDescription(example = @Example("item('minecraft:coal_ore')"))
+    public boolean removeByOutput(IIngredient output) {
+        boolean removed = false;
+        for (LaserDrillEntry.LaserDrillEntryExtended laserDrillUniqueValue : LaserDrillEntry.LASER_DRILL_UNIQUE_VALUES) {
+            removed = laserDrillUniqueValue.getRarities().removeIf(recipe -> {
+                if (output.test(laserDrillUniqueValue.getStack())) {
+                    addBackup(Pair.of(laserDrillUniqueValue, recipe));
+                    return true;
+                }
+                return false;
+            }) || removed;
+        }
+        return removed;
+    }
+
+    @MethodDescription(example = @Example("biome('minecraft:hell')"))
+    public boolean removeByWhitelist(Biome biome) {
+        boolean removed = false;
+        for (LaserDrillEntry.LaserDrillEntryExtended laserDrillUniqueValue : LaserDrillEntry.LASER_DRILL_UNIQUE_VALUES) {
+            removed = laserDrillUniqueValue.getRarities().removeIf(recipe -> {
+                if (recipe.getWhitelist().contains(biome)) {
+                    addBackup(Pair.of(laserDrillUniqueValue, recipe));
+                    return true;
+                }
+                return false;
+            }) || removed;
+        }
+        return removed;
+    }
+
+    @MethodDescription(example = @Example("biome('minecraft:sky')"))
+    public boolean removeByBlacklist(Biome biome) {
+        boolean removed = false;
+        for (LaserDrillEntry.LaserDrillEntryExtended laserDrillUniqueValue : LaserDrillEntry.LASER_DRILL_UNIQUE_VALUES) {
+            removed = laserDrillUniqueValue.getRarities().removeIf(recipe -> {
+                if (recipe.getBlacklist().contains(biome)) {
+                    addBackup(Pair.of(laserDrillUniqueValue, recipe));
+                    return true;
+                }
+                return false;
+            }) || removed;
+        }
+        return removed;
+    }
+
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
+    public void removeAll() {
+        LaserDrillEntry.LASER_DRILL_UNIQUE_VALUES.forEach(recipe -> {
+            recipe.getRarities().forEach(entry -> addBackup(Pair.of(recipe, entry)));
+            recipe.getRarities().clear();
+        });
+    }
+
+    @MethodDescription(type = MethodDescription.Type.QUERY)
+    public SimpleObjectStream<LaserDrillEntry.LaserDrillEntryExtended> streamRecipes() {
+        return new SimpleObjectStream<>(LaserDrillEntry.LASER_DRILL_UNIQUE_VALUES)
+                .setRemover(this::remove);
+    }
+
+    @Property(property = "output", valid = @Comp("1"))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<LaserDrillEntry.LaserDrillEntryExtended> {
+
+        @Property
+        private final List<Biome> whitelist = new ArrayList<>();
+        @Property
+        private final List<Biome> blacklist = new ArrayList<>();
+        @Property
+        private int lensMeta;
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GT))
+        private int weight;
+        @Property(valid = @Comp(value = "255", type = Comp.Type.LTE))
+        private int minY;
+        @Property(defaultValue = "255", valid = @Comp(value = "255", type = Comp.Type.LTE))
+        private int maxY = 255;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder whitelist(Biome whitelist) {
+            this.whitelist.add(whitelist);
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder whitelist(Biome... biomes) {
+            for (Biome biome : biomes) {
+                whitelist(biome);
+            }
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder whitelist(Collection<Biome> biomes) {
+            for (Biome biome : biomes) {
+                whitelist(biome);
+            }
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder blacklist(Biome blacklist) {
+            this.blacklist.add(blacklist);
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder blacklist(Biome... biomes) {
+            for (Biome biome : biomes) {
+                blacklist(biome);
+            }
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder blacklist(Collection<Biome> biomes) {
+            for (Biome biome : biomes) {
+                blacklist(biome);
+            }
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder lensMeta(int lensMeta) {
+            this.lensMeta = lensMeta;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder weight(int weight) {
+            this.weight = weight;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder minY(int minY) {
+            this.minY = minY;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder maxY(int maxY) {
+            this.maxY = maxY;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Industrial Foregoing Laser Drill Entry";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 0, 0, 1, 1);
+            validateFluids(msg);
+            msg.add(weight <= 0, "weight must be greater than or equal to 1, yet it was {}", weight);
+            msg.add(minY < 0, "minY must be greater than or equal to 0, yet it was {}", minY);
+            msg.add(maxY > 255, "maxY must be less than or equal to 255, yet it was {}", maxY);
+            msg.add(minY > maxY, "minY must be less than or equal to maxY, yet minY was {} and maxY was {}", minY, maxY);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable LaserDrillEntry.LaserDrillEntryExtended register() {
+            if (!validate()) return null;
+            LaserDrillEntry.LaserDrillEntryExtended recipe = LaserDrillEntry.findForOre(output.get(0), new LaserDrillEntry.LaserDrillEntryExtended(lensMeta, output.get(0)));
+            LaserDrillEntry.OreRarity entry = new LaserDrillEntry.OreRarity(weight, whitelist, blacklist, maxY, minY);
+            ModSupport.INDUSTRIAL_FOREGOING.get().laserDrill.add(recipe, entry);
+            return recipe;
+        }
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/industrialforegoing/OreFermenter.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/industrialforegoing/OreFermenter.java
@@ -1,0 +1,82 @@
+package com.cleanroommc.groovyscript.compat.mods.industrialforegoing;
+
+import com.buuz135.industrial.api.recipe.ore.OreFluidEntryFermenter;
+import com.cleanroommc.groovyscript.api.GroovyBlacklist;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.Example;
+import com.cleanroommc.groovyscript.api.documentation.annotations.MethodDescription;
+import com.cleanroommc.groovyscript.api.documentation.annotations.RegistryDescription;
+import com.cleanroommc.groovyscript.helper.Alias;
+import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
+import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import net.minecraftforge.fluids.FluidStack;
+
+@RegistryDescription
+public class OreFermenter extends VirtualizedRegistry<OreFluidEntryFermenter> {
+
+    public OreFermenter() {
+        super(Alias.generateOfClass(OreFermenter.class).andGenerate("Fermentation"));
+    }
+
+    @Override
+    @GroovyBlacklist
+    public void onReload() {
+        OreFluidEntryFermenter.ORE_FLUID_FERMENTER.removeAll(removeScripted());
+        OreFluidEntryFermenter.ORE_FLUID_FERMENTER.addAll(restoreFromBackup());
+    }
+
+    @MethodDescription(type = MethodDescription.Type.ADDITION, example = @Example("fluid('if.ore_fluid_raw').withNbt(['Ore': 'oreGold']), fluid('if.ore_fluid_fermented').withNbt(['Ore': 'oreGold']) * 2"))
+    public OreFluidEntryFermenter add(FluidStack input, FluidStack output) {
+        OreFluidEntryFermenter recipe = new OreFluidEntryFermenter(input, output);
+        add(recipe);
+        return recipe;
+    }
+
+    public void add(OreFluidEntryFermenter recipe) {
+        if (recipe == null) return;
+        addScripted(recipe);
+        OreFluidEntryFermenter.ORE_FLUID_FERMENTER.add(recipe);
+    }
+
+    public boolean remove(OreFluidEntryFermenter recipe) {
+        if (recipe == null) return false;
+        addBackup(recipe);
+        OreFluidEntryFermenter.ORE_FLUID_FERMENTER.remove(recipe);
+        return true;
+    }
+
+    @MethodDescription(example = @Example("fluid('if.ore_fluid_raw').withNbt([Ore: 'oreRedstone'])"))
+    public boolean removeByInput(IIngredient input) {
+        return OreFluidEntryFermenter.ORE_FLUID_FERMENTER.removeIf(recipe -> {
+            if (input.test(recipe.getInput())) {
+                addBackup(recipe);
+                return true;
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(example = @Example(value = "fluid('if.ore_fluid_fermented').withNbt([Ore: 'oreRedstone'])", commented = true))
+    public boolean removeByOutput(IIngredient output) {
+        return OreFluidEntryFermenter.ORE_FLUID_FERMENTER.removeIf(recipe -> {
+            if (output.test(recipe.getOutput())) {
+                addBackup(recipe);
+                return true;
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
+    public void removeAll() {
+        OreFluidEntryFermenter.ORE_FLUID_FERMENTER.forEach(this::addBackup);
+        OreFluidEntryFermenter.ORE_FLUID_FERMENTER.clear();
+    }
+
+    @MethodDescription(type = MethodDescription.Type.QUERY)
+    public SimpleObjectStream<OreFluidEntryFermenter> streamRecipes() {
+        return new SimpleObjectStream<>(OreFluidEntryFermenter.ORE_FLUID_FERMENTER)
+                .setRemover(this::remove);
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/industrialforegoing/OreRaw.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/industrialforegoing/OreRaw.java
@@ -1,0 +1,107 @@
+package com.cleanroommc.groovyscript.compat.mods.industrialforegoing;
+
+import com.buuz135.industrial.api.recipe.ore.OreFluidEntryRaw;
+import com.cleanroommc.groovyscript.api.GroovyBlacklist;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.Example;
+import com.cleanroommc.groovyscript.api.documentation.annotations.MethodDescription;
+import com.cleanroommc.groovyscript.api.documentation.annotations.RegistryDescription;
+import com.cleanroommc.groovyscript.helper.Alias;
+import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
+import com.cleanroommc.groovyscript.helper.ingredient.OreDictIngredient;
+import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import net.minecraftforge.fluids.FluidStack;
+
+@RegistryDescription
+public class OreRaw extends VirtualizedRegistry<OreFluidEntryRaw> {
+
+    public OreRaw() {
+        super(Alias.generateOfClass(OreRaw.class).andGenerate("Washing"));
+    }
+
+    @Override
+    @GroovyBlacklist
+    public void onReload() {
+        OreFluidEntryRaw.ORE_RAW_ENTRIES.removeAll(removeScripted());
+        OreFluidEntryRaw.ORE_RAW_ENTRIES.addAll(restoreFromBackup());
+    }
+
+    @MethodDescription(type = MethodDescription.Type.ADDITION, example = {
+            @Example("ore('oreGold'), fluid('meat') * 200, fluid('if.ore_fluid_raw').withNbt(['Ore': 'oreGold']) * 300"),
+            @Example("ore('stone'), fluid('water') * 1000, fluid('lava') * 50")
+    })
+    public OreFluidEntryRaw add(OreDictIngredient ore, FluidStack input, FluidStack output) {
+        return add(ore.getOreDict(), input, output);
+    }
+
+    @MethodDescription(type = MethodDescription.Type.ADDITION)
+    public OreFluidEntryRaw add(String ore, FluidStack input, FluidStack output) {
+        OreFluidEntryRaw recipe = new OreFluidEntryRaw(ore, input, output);
+        add(recipe);
+        return recipe;
+    }
+
+    public void add(OreFluidEntryRaw recipe) {
+        if (recipe == null) return;
+        addScripted(recipe);
+        OreFluidEntryRaw.ORE_RAW_ENTRIES.add(recipe);
+    }
+
+    public boolean remove(OreFluidEntryRaw recipe) {
+        if (recipe == null) return false;
+        addBackup(recipe);
+        OreFluidEntryRaw.ORE_RAW_ENTRIES.remove(recipe);
+        return true;
+    }
+
+    @MethodDescription(example = @Example(value = "'oreRedstone'", commented = true))
+    public boolean removeByOre(String ore) {
+        return OreFluidEntryRaw.ORE_RAW_ENTRIES.removeIf(recipe -> {
+            if (ore.equals(recipe.getOre())) {
+                addBackup(recipe);
+                return true;
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(example = @Example("ore('oreRedstone')"))
+    public boolean removeByOre(OreDictIngredient ore) {
+        return removeByOre(ore.getOreDict());
+    }
+
+    @MethodDescription(example = @Example(value = "fluid('meat')", commented = true))
+    public boolean removeByInput(IIngredient input) {
+        return OreFluidEntryRaw.ORE_RAW_ENTRIES.removeIf(recipe -> {
+            if (input.test(recipe.getInput())) {
+                addBackup(recipe);
+                return true;
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(example = @Example(value = "fluid('if.ore_fluid_raw').withNbt(['Ore': 'oreRedstone']),", commented = true))
+    public boolean removeByOutput(IIngredient output) {
+        return OreFluidEntryRaw.ORE_RAW_ENTRIES.removeIf(recipe -> {
+            if (output.test(recipe.getOutput())) {
+                addBackup(recipe);
+                return true;
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
+    public void removeAll() {
+        OreFluidEntryRaw.ORE_RAW_ENTRIES.forEach(this::addBackup);
+        OreFluidEntryRaw.ORE_RAW_ENTRIES.clear();
+    }
+
+    @MethodDescription(type = MethodDescription.Type.QUERY)
+    public SimpleObjectStream<OreFluidEntryRaw> streamRecipes() {
+        return new SimpleObjectStream<>(OreFluidEntryRaw.ORE_RAW_ENTRIES)
+                .setRemover(this::remove);
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/industrialforegoing/OreSieve.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/industrialforegoing/OreSieve.java
@@ -1,0 +1,89 @@
+package com.cleanroommc.groovyscript.compat.mods.industrialforegoing;
+
+import com.buuz135.industrial.api.recipe.ore.OreFluidEntrySieve;
+import com.cleanroommc.groovyscript.api.GroovyBlacklist;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.Example;
+import com.cleanroommc.groovyscript.api.documentation.annotations.MethodDescription;
+import com.cleanroommc.groovyscript.api.documentation.annotations.RegistryDescription;
+import com.cleanroommc.groovyscript.helper.Alias;
+import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
+import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
+
+@RegistryDescription
+public class OreSieve extends VirtualizedRegistry<OreFluidEntrySieve> {
+
+    public OreSieve() {
+        super(Alias.generateOfClass(OreSieve.class).andGenerate("FluidSieving"));
+    }
+
+    @Override
+    @GroovyBlacklist
+    public void onReload() {
+        OreFluidEntrySieve.ORE_FLUID_SIEVE.removeAll(removeScripted());
+        OreFluidEntrySieve.ORE_FLUID_SIEVE.addAll(restoreFromBackup());
+    }
+
+    @MethodDescription(type = MethodDescription.Type.ADDITION, example = {
+            @Example("fluid('if.ore_fluid_fermented').withNbt(['Ore': 'oreGold']) * 100, item('minecraft:nether_star') * 2, item('minecraft:clay')"),
+            @Example("fluid('lava') * 5, item('minecraft:gold_ingot'), item('minecraft:clay')")
+    })
+    public OreFluidEntrySieve add(FluidStack input, ItemStack output, ItemStack sieveItem) {
+        OreFluidEntrySieve recipe = new OreFluidEntrySieve(input, output, sieveItem);
+        add(recipe);
+        return recipe;
+    }
+
+    public void add(OreFluidEntrySieve recipe) {
+        if (recipe == null) return;
+        addScripted(recipe);
+        OreFluidEntrySieve.ORE_FLUID_SIEVE.add(recipe);
+    }
+
+    public boolean remove(OreFluidEntrySieve recipe) {
+        if (recipe == null) return false;
+        addBackup(recipe);
+        OreFluidEntrySieve.ORE_FLUID_SIEVE.remove(recipe);
+        return true;
+    }
+
+    @MethodDescription(example = {
+            @Example("item('minecraft:sand')"),
+            @Example("fluid('if.pink_slime')")
+    })
+    public boolean removeByInput(IIngredient input) {
+        return OreFluidEntrySieve.ORE_FLUID_SIEVE.removeIf(recipe -> {
+            if (input.test(recipe.getInput()) || input.test(recipe.getSieveItem())) {
+                addBackup(recipe);
+                return true;
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(example = @Example(value = "item('industrialforegoing:pink_slime_ingot", commented = true))
+    public boolean removeByOutput(IIngredient output) {
+        return OreFluidEntrySieve.ORE_FLUID_SIEVE.removeIf(recipe -> {
+            if (output.test(recipe.getOutput())) {
+                addBackup(recipe);
+                return true;
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
+    public void removeAll() {
+        OreFluidEntrySieve.ORE_FLUID_SIEVE.forEach(this::addBackup);
+        OreFluidEntrySieve.ORE_FLUID_SIEVE.clear();
+    }
+
+    @MethodDescription(type = MethodDescription.Type.QUERY)
+    public SimpleObjectStream<OreFluidEntrySieve> streamRecipes() {
+        return new SimpleObjectStream<>(OreFluidEntrySieve.ORE_FLUID_SIEVE)
+                .setRemover(this::remove);
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/industrialforegoing/ProteinReactor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/industrialforegoing/ProteinReactor.java
@@ -1,0 +1,75 @@
+package com.cleanroommc.groovyscript.compat.mods.industrialforegoing;
+
+import com.buuz135.industrial.api.recipe.IReactorEntry;
+import com.buuz135.industrial.api.recipe.ProteinReactorEntry;
+import com.cleanroommc.groovyscript.api.GroovyBlacklist;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.Example;
+import com.cleanroommc.groovyscript.api.documentation.annotations.MethodDescription;
+import com.cleanroommc.groovyscript.api.documentation.annotations.RegistryDescription;
+import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
+import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import com.google.common.base.Predicate;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import org.jetbrains.annotations.Nullable;
+
+@RegistryDescription
+public class ProteinReactor extends VirtualizedRegistry<IReactorEntry> {
+
+    @Override
+    @GroovyBlacklist
+    public void onReload() {
+        ProteinReactorEntry.PROTEIN_REACTOR_ENTRIES.removeAll(removeScripted());
+        ProteinReactorEntry.PROTEIN_REACTOR_ENTRIES.addAll(restoreFromBackup());
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.industrialforegoing.protein_reactor.add0", type = MethodDescription.Type.ADDITION, example = @Example("item('minecraft:clay')"))
+    public IReactorEntry add(ItemStack input) {
+        return add(input, null);
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.industrialforegoing.protein_reactor.add1", type = MethodDescription.Type.ADDITION)
+    public IReactorEntry add(ItemStack input, @Nullable Predicate<NBTTagCompound> nbtCheck) {
+        IReactorEntry recipe = new ProteinReactorEntry(input, nbtCheck);
+        add(recipe);
+        return recipe;
+    }
+
+    public void add(IReactorEntry recipe) {
+        if (recipe == null) return;
+        addScripted(recipe);
+        ProteinReactorEntry.PROTEIN_REACTOR_ENTRIES.add(recipe);
+    }
+
+    public boolean remove(IReactorEntry recipe) {
+        if (recipe == null) return false;
+        addBackup(recipe);
+        ProteinReactorEntry.PROTEIN_REACTOR_ENTRIES.remove(recipe);
+        return true;
+    }
+
+    @MethodDescription(example = @Example("item('minecraft:porkchop')"))
+    public boolean removeByInput(IIngredient input) {
+        return ProteinReactorEntry.PROTEIN_REACTOR_ENTRIES.removeIf(recipe -> {
+            if (input.test(recipe.getStack())) {
+                addBackup(recipe);
+                return true;
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
+    public void removeAll() {
+        ProteinReactorEntry.PROTEIN_REACTOR_ENTRIES.forEach(this::addBackup);
+        ProteinReactorEntry.PROTEIN_REACTOR_ENTRIES.clear();
+    }
+
+    @MethodDescription(type = MethodDescription.Type.QUERY)
+    public SimpleObjectStream<IReactorEntry> streamRecipes() {
+        return new SimpleObjectStream<>(ProteinReactorEntry.PROTEIN_REACTOR_ENTRIES)
+                .setRemover(this::remove);
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/industrialforegoing/SludgeRefiner.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/industrialforegoing/SludgeRefiner.java
@@ -1,0 +1,74 @@
+package com.cleanroommc.groovyscript.compat.mods.industrialforegoing;
+
+import com.buuz135.industrial.api.recipe.SludgeEntry;
+import com.cleanroommc.groovyscript.api.GroovyBlacklist;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.Example;
+import com.cleanroommc.groovyscript.api.documentation.annotations.MethodDescription;
+import com.cleanroommc.groovyscript.api.documentation.annotations.RegistryDescription;
+import com.cleanroommc.groovyscript.core.mixin.industrialforegoing.SludgeRefinerBlockAccessor;
+import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
+import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import net.minecraft.item.ItemStack;
+
+@RegistryDescription
+public class SludgeRefiner extends VirtualizedRegistry<SludgeEntry> {
+
+    @Override
+    @GroovyBlacklist
+    public void onReload() {
+        SludgeEntry.SLUDGE_RECIPES.removeAll(removeScripted());
+        SludgeEntry.SLUDGE_RECIPES.addAll(restoreFromBackup());
+    }
+
+    @Override
+    @GroovyBlacklist
+    public void afterScriptLoad() {
+        // Clear the list and cause the sludge refiner to recompute outputs
+        SludgeRefinerBlockAccessor.setOutputs(null);
+    }
+
+    @MethodDescription(type = MethodDescription.Type.ADDITION, example = @Example("item('minecraft:gold_ingot'), 5"))
+    public SludgeEntry add(ItemStack output, int weight) {
+        SludgeEntry recipe = new SludgeEntry(output, weight);
+        add(recipe);
+        return recipe;
+    }
+
+    public void add(SludgeEntry recipe) {
+        if (recipe == null) return;
+        addScripted(recipe);
+        SludgeEntry.SLUDGE_RECIPES.add(recipe);
+    }
+
+    public boolean remove(SludgeEntry recipe) {
+        if (recipe == null) return false;
+        addBackup(recipe);
+        SludgeEntry.SLUDGE_RECIPES.remove(recipe);
+        return true;
+    }
+
+    @MethodDescription(example = @Example("item('minecraft:clay_ball')"))
+    public boolean removeByOutput(IIngredient output) {
+        return SludgeEntry.SLUDGE_RECIPES.removeIf(recipe -> {
+            if (output.test(recipe.getStack())) {
+                addBackup(recipe);
+                return true;
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
+    public void removeAll() {
+        SludgeEntry.SLUDGE_RECIPES.forEach(this::addBackup);
+        SludgeEntry.SLUDGE_RECIPES.clear();
+    }
+
+    @MethodDescription(type = MethodDescription.Type.QUERY)
+    public SimpleObjectStream<SludgeEntry> streamRecipes() {
+        return new SimpleObjectStream<>(SludgeEntry.SLUDGE_RECIPES)
+                .setRemover(this::remove);
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/industrialforegoing/Straw.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/industrialforegoing/Straw.java
@@ -1,0 +1,105 @@
+package com.cleanroommc.groovyscript.compat.mods.industrialforegoing;
+
+import com.buuz135.industrial.api.straw.StrawHandler;
+import com.buuz135.industrial.registry.IFRegistries;
+import com.buuz135.industrial.utils.apihandlers.straw.PotionStrawHandler;
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import com.cleanroommc.groovyscript.registry.ForgeRegistryWrapper;
+import net.minecraft.potion.PotionEffect;
+import net.minecraftforge.fluids.FluidStack;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+@RegistryDescription
+public class Straw extends ForgeRegistryWrapper<StrawHandler> {
+
+    public Straw() {
+        super(IFRegistries.STRAW_HANDLER_REGISTRY);
+    }
+
+    @RecipeBuilderDescription(example = @Example(value = ".fluidInput(fluid('if.pink_slime')).effect(new PotionEffect(potion('minecraft:strength'), 1800, 3))", imports = "net.minecraft.potion.PotionEffect"))
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.industrialforegoing.straw.add0", type = MethodDescription.Type.ADDITION)
+    public StrawHandler add(FluidStack fluidInput, Collection<PotionEffect> effect) {
+        return recipeBuilder()
+                .effect(effect)
+                .fluidInput(fluidInput)
+                .register();
+    }
+
+    @MethodDescription(description = "groovyscript.wiki.industrialforegoing.straw.add1", type = MethodDescription.Type.ADDITION)
+    public StrawHandler add(String name, FluidStack fluidInput, Collection<PotionEffect> effect) {
+        return recipeBuilder()
+                .effect(effect)
+                .name(name)
+                .fluidInput(fluidInput)
+                .register();
+    }
+
+    @Property(property = "fluidInput", valid = @Comp("1"))
+    @Property(property = "name")
+    public static class RecipeBuilder extends AbstractRecipeBuilder<StrawHandler> {
+
+        @Property(valid = @Comp(type = Comp.Type.GTE, value = "1"))
+        private final Collection<PotionEffect> effect = new ArrayList<>();
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder effect(PotionEffect effect) {
+            this.effect.add(effect);
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder effect(PotionEffect... effects) {
+            for (PotionEffect ingredient : effects) {
+                effect(ingredient);
+            }
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder effect(Collection<PotionEffect> effects) {
+            for (PotionEffect ingredient : effects) {
+                effect(ingredient);
+            }
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Industrial Foregoing Straw Entry";
+        }
+
+        @Override
+        public String getRecipeNamePrefix() {
+            return "groovyscript_straw_entry_";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateName();
+            validateItems(msg);
+            validateFluids(msg, 1, 1, 0, 0);
+            msg.add(effect.isEmpty(), "effect must have entries, yet it was empty");
+        }
+
+        @RecipeBuilderRegistrationMethod
+        @Override
+        public @Nullable StrawHandler register() {
+            if (!validate()) return null;
+            PotionStrawHandler recipe = new PotionStrawHandler(fluidInput.get(0).getFluid());
+            effect.forEach(recipe::addPotion);
+            recipe.setRegistryName(this.name);
+            ModSupport.INDUSTRIAL_FOREGOING.get().straw.add(recipe);
+            return recipe;
+        }
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/core/LateMixin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/LateMixin.java
@@ -25,6 +25,7 @@ public class LateMixin implements ILateMixinLoader {
             "forestry",
             "ic2_classic",
             "ic2_exp",
+            "industrialforegoing",
             "inspirations",
             "jei",
             "mekanism",

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/industrialforegoing/SludgeRefinerBlockAccessor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/industrialforegoing/SludgeRefinerBlockAccessor.java
@@ -1,0 +1,22 @@
+package com.cleanroommc.groovyscript.core.mixin.industrialforegoing;
+
+import com.buuz135.industrial.tile.block.SludgeRefinerBlock;
+import com.buuz135.industrial.utils.ItemStackWeightedItem;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import java.util.ArrayList;
+
+@Mixin(value = SludgeRefinerBlock.class, remap = false)
+public interface SludgeRefinerBlockAccessor {
+
+    @Accessor("OUTPUTS")
+    static ArrayList<ItemStackWeightedItem> getOutputs() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Accessor("OUTPUTS")
+    static void setOutputs(ArrayList<ItemStackWeightedItem> OUTPUTS) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/resources/assets/groovyscript/lang/en_us.lang
+++ b/src/main/resources/assets/groovyscript/lang/en_us.lang
@@ -979,6 +979,63 @@ groovyscript.wiki.immersiveengineering.squeezer.description=Converts an input it
 groovyscript.wiki.immersiveengineering.squeezer.add=Adds recipes in the format `fluidOutput`, `itemOutput`, `input`, `energy`
 groovyscript.wiki.immersiveengineering.squeezer.energy.value=Sets the amount of power consumed to complete the recipe
 
+
+# Industrial Foregoing
+groovyscript.wiki.industrialforegoing.bio_reactor.title=Bioreactor
+groovyscript.wiki.industrialforegoing.bio_reactor.description=Converts an input item into Biofuel, with the amount of Biofuel generated being based on the number of concurrent conversion processes inside the Bioreactor.
+groovyscript.wiki.industrialforegoing.bio_reactor.add0=Adds a Bioreactor recipe in the format `input`
+groovyscript.wiki.industrialforegoing.bio_reactor.add1=Adds a Bioreactor recipe in the format `input`, `nbtCheck`
+
+groovyscript.wiki.industrialforegoing.extractor.title=Latex Extractor
+groovyscript.wiki.industrialforegoing.extractor.description=Converts an input block in-world into a fluidstack over time, eventually breaking the block.
+groovyscript.wiki.industrialforegoing.extractor.add0=Adds a Latex Extractor recipe in the format `input`, `output`
+groovyscript.wiki.industrialforegoing.extractor.add1=Adds a Latex Extractor recipe in the format `input`, `output`, `breakChance`
+
+groovyscript.wiki.industrialforegoing.fluid_dictionary.title=Fluid Dictionary Converter
+groovyscript.wiki.industrialforegoing.fluid_dictionary.description=Converts one fluid into another fluid at a given ratio.
+groovyscript.wiki.industrialforegoing.fluid_dictionary.add0=Adds a Fluid Dictionary Converter recipe in the format `input`, `output`
+groovyscript.wiki.industrialforegoing.fluid_dictionary.add1=Adds a Fluid Dictionary Converter recipe in the format `input`, `output`, `ratio`
+
+groovyscript.wiki.industrialforegoing.laser_drill.title=Laser Drill
+groovyscript.wiki.industrialforegoing.laser_drill.description=Converts power into ores, with a given weight, between a minimum and maximum Y value, in any whitelisted biome or not in any blacklisted biome, and with a specific color of laser lens impacting the probability.
+groovyscript.wiki.industrialforegoing.laser_drill.maxY.value=Sets the maximum Y the output can be found at
+groovyscript.wiki.industrialforegoing.laser_drill.minY.value=Sets the minimum Y the output can be found at
+groovyscript.wiki.industrialforegoing.laser_drill.weight.value=Sets the chance the output is generated
+groovyscript.wiki.industrialforegoing.laser_drill.lensMeta.value=Sets the metadata of the lens that impacts the weight probability, which determines the color of the lens
+groovyscript.wiki.industrialforegoing.laser_drill.blacklist.value=Sets the biomes the output cannot be generated in
+groovyscript.wiki.industrialforegoing.laser_drill.whitelist.value=Sets the biomes the output can be generated in
+groovyscript.wiki.industrialforegoing.laser_drill.removeByBlacklist=Removes all ores with the given biome blacklisted
+groovyscript.wiki.industrialforegoing.laser_drill.removeByLens=Removes all ores with the given lens meta
+groovyscript.wiki.industrialforegoing.laser_drill.removeByWhitelist=Removes all ores with the given biome whitelisted
+
+groovyscript.wiki.industrialforegoing.ore_fermenter.title=Fermentation Station
+groovyscript.wiki.industrialforegoing.ore_fermenter.description=Converts an input fluidstack into an output fluidstack.
+groovyscript.wiki.industrialforegoing.ore_fermenter.add=Adds a Fermentation Station recipe in the format `input`, `output`
+
+groovyscript.wiki.industrialforegoing.ore_raw.title=Washing Factory
+groovyscript.wiki.industrialforegoing.ore_raw.description=Converts an input itemstack and input fluidstack into an output fluidstack.
+groovyscript.wiki.industrialforegoing.ore_raw.add=Adds a Washing Factory recipe in the format `ore`, `input`, `output`
+
+groovyscript.wiki.industrialforegoing.ore_sieve.title=Fluid Sieving Machine
+groovyscript.wiki.industrialforegoing.ore_sieve.description=Converts an input itemstack and input fluidstack into an output itemstack.
+groovyscript.wiki.industrialforegoing.ore_sieve.add=Adds a Fluid Sieving Machine recipe in the format `input`, `output`, `sieveItem`
+
+groovyscript.wiki.industrialforegoing.protein_reactor.title=Protein Reactor
+groovyscript.wiki.industrialforegoing.protein_reactor.description=Converts an input item into Protein, with the amount of Protein generated being based on the number of concurrent conversion processes inside the Protein Reactor.
+groovyscript.wiki.industrialforegoing.protein_reactor.add0=Adds a Protein Reactor recipe in the format `input`
+groovyscript.wiki.industrialforegoing.protein_reactor.add1=Adds a Protein Reactor recipe in the format `input`, `nbtCheck`
+
+groovyscript.wiki.industrialforegoing.sludge_refiner.title=Sludge Refiner
+groovyscript.wiki.industrialforegoing.sludge_refiner.description=Converts 1000mb of Sludge into a random itemstack based on the weight of the given itemstack.
+groovyscript.wiki.industrialforegoing.sludge_refiner.add=Adds a Protein Reactor recipe in the format `output`, `weight`
+
+groovyscript.wiki.industrialforegoing.straw.title=Straw
+groovyscript.wiki.industrialforegoing.straw.description=Converts an fluid block in-world into various effects for the player when consumed via a straw.
+groovyscript.wiki.industrialforegoing.straw.add0=Adds a Straw recipe in the format `fluidInput`, `effect`
+groovyscript.wiki.industrialforegoing.straw.add1=Adds a Straw recipe in the format `name`, `fluidInput`, `effect`
+groovyscript.wiki.industrialforegoing.straw.effect.value=Sets what potion effects are given upon consuming the fluid.
+
+
 # Inspirations
 groovyscript.wiki.inspirations.anvil_smashing.title=Anvil Smashing
 groovyscript.wiki.inspirations.anvil_smashing.description=Converts a Block or IBlockState into an IBlockState when an anvil falls on top of it (from any height).

--- a/src/main/resources/mixin.groovyscript.industrialforegoing.json
+++ b/src/main/resources/mixin.groovyscript.industrialforegoing.json
@@ -1,0 +1,10 @@
+{
+  "package": "com.cleanroommc.groovyscript.core.mixin.industrialforegoing",
+  "refmap": "mixins.groovyscript.refmap.json",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": [
+    "SludgeRefinerBlockAccessor"
+  ]
+}


### PR DESCRIPTION
changes in this PR:
- adds `BioReactor`, `Extractor`, `FluidDictionary`, `LaserDrill`, `OreFermenter`, `OreRaw`, `OreSieve`, `ProteinReactor`, `SludgeRefiner`, and `Straw` compat.
- adds examples file and i18n wiki keys for the above compat.
