### PR TITLE
More validation of documenting annotations 

### DIFF
--- a/examples/postInit/pyrotech.groovy
+++ b/examples/postInit/pyrotech.groovy
@@ -188,6 +188,7 @@ mods.pyrotech.soaking_pot.recipeBuilder()
     .time(400)
     .campfireRequired(true)
     .name('diamond_to_emerald_with_amongium_soaking_pot')
+    .register()
 
 
 mods.pyrotech.soaking_pot.add('dirt_to_apple', item('minecraft:dirt'), fluid('water'), item('minecraft:apple'), 1200)

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/starlightaltar/AltarRecipeBuilder.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/starlightaltar/AltarRecipeBuilder.java
@@ -249,7 +249,6 @@ public class AltarRecipeBuilder {
             return this;
         }
 
-        @RecipeBuilderMethodDescription(field = "inputs")
         public Shaped input(ItemHandle[] inputs) {
             this.inputs = inputs;
             return this;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/MillStone.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/MillStone.java
@@ -110,7 +110,7 @@ public class MillStone extends VirtualizedRegistry<MillRecipe> {
             return this;
         }
 
-        @RecipeBuilderMethodDescription
+        @RecipeBuilderMethodDescription(field = "ticks")
         public RecipeBuilder time(int ticks) {
             this.ticks = ticks;
             return this;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Combiner.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Combiner.java
@@ -73,6 +73,7 @@ public class Combiner extends VirtualizedMekanismRegistry<CombinerRecipe> {
         @Property(defaultValue = "new ItemStack(Blocks.COBBLESTONE)")
         private ItemStack extra;
 
+        @RecipeBuilderMethodDescription
         public RecipeBuilder extra(ItemStack extra) {
             this.extra = extra;
             return this;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/ElectrolyticSeparator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/ElectrolyticSeparator.java
@@ -62,6 +62,7 @@ public class ElectrolyticSeparator extends VirtualizedMekanismRegistry<Separator
         @Property(valid = @Comp(type = Comp.Type.GT, value = "0"))
         private double energy;
 
+        @RecipeBuilderMethodDescription
         public RecipeBuilder energy(double energy) {
             this.energy = energy;
             return this;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/MetallurgicInfuser.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/MetallurgicInfuser.java
@@ -88,15 +88,18 @@ public class MetallurgicInfuser extends VirtualizedMekanismRegistry<MetallurgicI
         @Property(valid = @Comp(type = Comp.Type.GT, value = "0"))
         private int amount;
 
+        @RecipeBuilderMethodDescription
         public RecipeBuilder infuse(InfuseType infuse) {
             this.infuse = infuse;
             return this;
         }
 
+        @RecipeBuilderMethodDescription
         public RecipeBuilder infuse(String infuse) {
             return infuse(InfuseRegistry.get(infuse));
         }
 
+        @RecipeBuilderMethodDescription
         public RecipeBuilder amount(int amount) {
             this.amount = amount;
             return this;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/PressurizedReactionChamber.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/PressurizedReactionChamber.java
@@ -77,11 +77,13 @@ public class PressurizedReactionChamber extends VirtualizedMekanismRegistry<Pres
         @Property(valid = @Comp(type = Comp.Type.GT, value = "0"))
         private double energy;
 
+        @RecipeBuilderMethodDescription
         public RecipeBuilder duration(int duration) {
             this.duration = duration;
             return this;
         }
 
+        @RecipeBuilderMethodDescription
         public RecipeBuilder energy(double energy) {
             this.energy = energy;
             return this;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Sawmill.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Sawmill.java
@@ -91,11 +91,13 @@ public class Sawmill extends VirtualizedMekanismRegistry<SawmillRecipe> {
         @Property(defaultValue = "1.0", valid = {@Comp(type = Comp.Type.GTE, value = "0"), @Comp(type = Comp.Type.LTE, value = "1")})
         private double chance = 1.0;
 
+        @RecipeBuilderMethodDescription
         public RecipeBuilder extra(ItemStack extra) {
             this.extra = extra;
             return this;
         }
 
+        @RecipeBuilderMethodDescription
         public RecipeBuilder chance(double chance) {
             this.chance = chance;
             return this;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/pyrotech/ChoppingBlock.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/pyrotech/ChoppingBlock.java
@@ -63,9 +63,10 @@ public class ChoppingBlock extends ForgeRegistryWrapper<ChoppingBlockRecipe> {
 
         @Property
         private final IntList chops = new IntArrayList();
+        @Property
         private final IntList quantities = new IntArrayList();
 
-        @RecipeBuilderMethodDescription(field = "chops, quantities")
+        @RecipeBuilderMethodDescription(field = {"chops", "quantities"})
         public RecipeBuilder chops(int chops, int quantities) {
             this.chops.add(chops);
             this.quantities.add(quantities);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/pyrotech/SoakingPot.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/pyrotech/SoakingPot.java
@@ -103,6 +103,7 @@ public class SoakingPot extends ForgeRegistryWrapper<SoakingPotRecipe> {
         }
 
         @Override
+        @RecipeBuilderRegistrationMethod
         public @Nullable SoakingPotRecipe register() {
             if (!validate()) return null;
             SoakingPotRecipe recipe = new SoakingPotRecipe(output.get(0), input.get(0).toMcIngredient(), fluidInput.get(0), campfireRequired, time).setRegistryName(name);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/rustic/Alchemy.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/rustic/Alchemy.java
@@ -100,7 +100,7 @@ public class Alchemy extends VirtualizedRegistry<ICondenserRecipe> {
         @Property
         private boolean advanced;
 
-        @RecipeBuilderMethodDescription
+        @RecipeBuilderMethodDescription(field = "output")
         public RecipeBuilder effect(PotionEffect effect) {
             var output = new ItemStack(ModItems.ELIXIR);
             ElixirUtils.addEffect(effect, output);

--- a/src/main/java/com/cleanroommc/groovyscript/documentation/Builder.java
+++ b/src/main/java/com/cleanroommc/groovyscript/documentation/Builder.java
@@ -2,8 +2,6 @@ package com.cleanroommc.groovyscript.documentation;
 
 import com.cleanroommc.groovyscript.api.GroovyLog;
 import com.cleanroommc.groovyscript.api.documentation.annotations.*;
-import com.cleanroommc.groovyscript.compat.mods.GroovyContainer;
-import com.cleanroommc.groovyscript.compat.mods.GroovyPropertyContainer;
 import com.google.common.collect.ComparisonChain;
 import it.unimi.dsi.fastutil.chars.Char2CharArrayMap;
 import it.unimi.dsi.fastutil.chars.Char2CharMap;
@@ -29,7 +27,6 @@ public class Builder {
         defaultReturnValue(Character.MIN_VALUE);
     }};
 
-    private final GroovyContainer<? extends GroovyPropertyContainer> mod;
     private final String reference;
     private final Method builderMethod;
     private final RecipeBuilderDescription annotation;
@@ -37,8 +34,7 @@ public class Builder {
     private final Map<String, List<RecipeBuilderMethod>> methods;
     private final List<Method> registrationMethods;
 
-    public Builder(GroovyContainer<? extends GroovyPropertyContainer> mod, Method builderMethod, String reference, String baseTranslationKey) {
-        this.mod = mod;
+    public Builder(Method builderMethod, String reference, String baseTranslationKey) {
         this.builderMethod = builderMethod;
         this.reference = reference;
         this.annotation = builderMethod.getAnnotation(RecipeBuilderDescription.class);

--- a/src/main/java/com/cleanroommc/groovyscript/documentation/Builder.java
+++ b/src/main/java/com/cleanroommc/groovyscript/documentation/Builder.java
@@ -250,7 +250,7 @@ public class Builder {
         }
 
         if (registrationMethods.isEmpty()) {
-            GroovyLog.get().warn("Couldn't find any registration methods for '{}'", reference);
+            GroovyLog.get().warn("Couldn't find any registration methods for recipe builder '{}'", reference);
         } else {
             for (Method registerMethod : registrationMethods) {
                 out.append("- ");
@@ -291,7 +291,7 @@ public class Builder {
                     List<RecipeBuilderMethod> recipeBuilderMethods = methods.get(fieldDocumentation.getField().getName());
 
                     if (recipeBuilderMethods == null || recipeBuilderMethods.isEmpty()) {
-                        GroovyLog.get().warn("Couldn't find any methods targeting field '{}' in build '{}'", fieldDocumentation.getField().getName(), reference);
+                        GroovyLog.get().warn("Couldn't find any methods targeting field '{}' in recipe builder '{}'", fieldDocumentation.getField().getName(), reference);
                     } else {
                         out.append(new CodeBlockBuilder()
                                            .line(recipeBuilderMethods.stream()

--- a/src/main/java/com/cleanroommc/groovyscript/documentation/Registry.java
+++ b/src/main/java/com/cleanroommc/groovyscript/documentation/Registry.java
@@ -2,7 +2,6 @@ package com.cleanroommc.groovyscript.documentation;
 
 import com.cleanroommc.groovyscript.api.GroovyBlacklist;
 import com.cleanroommc.groovyscript.api.INamed;
-import com.cleanroommc.groovyscript.api.IScriptReloadable;
 import com.cleanroommc.groovyscript.api.documentation.annotations.*;
 import com.cleanroommc.groovyscript.compat.mods.GroovyContainer;
 import com.cleanroommc.groovyscript.compat.mods.GroovyPropertyContainer;
@@ -122,7 +121,7 @@ public class Registry {
         out.append("// ").append(getTitle()).append(":").append("\n");
         out.append("// ").append(WordUtils.wrap(getDescription(), Documentation.MAX_LINE_LENGTH, "\n// ", false)).append("\n\n");
         out.append(documentMethodDescriptionType(MethodDescription.Type.REMOVAL));
-        for (Method method : recipeBuilderMethods) out.append(new Builder(mod, method, reference, baseTranslationKey).builderExampleFile()).append("\n");
+        for (Method method : recipeBuilderMethods) out.append(new Builder(method, reference, baseTranslationKey).builderExampleFile()).append("\n");
         if (!recipeBuilderMethods.isEmpty()) out.append("\n");
         out.append(documentMethodDescriptionType(MethodDescription.Type.ADDITION));
         out.append(documentMethodDescriptionType(MethodDescription.Type.VALUE));
@@ -207,7 +206,7 @@ public class Registry {
                 .append(I18n.format("groovyscript.wiki.recipe_builder_note", Documentation.DEFAULT_FORMAT.linkToBuilder())).append("\n\n");
 
         for (int i = 0; i < recipeBuilderMethods.size(); i++) {
-            Builder builder = new Builder(mod, recipeBuilderMethods.get(i), reference, baseTranslationKey);
+            Builder builder = new Builder(recipeBuilderMethods.get(i), reference, baseTranslationKey);
             out.append(new AdmonitionBuilder()
                                .type(Admonition.Type.ABSTRACT)
                                .hasTitle(true)

--- a/src/main/java/com/cleanroommc/groovyscript/registry/AbstractCraftingRecipeBuilder.java
+++ b/src/main/java/com/cleanroommc/groovyscript/registry/AbstractCraftingRecipeBuilder.java
@@ -95,7 +95,7 @@ public abstract class AbstractCraftingRecipeBuilder<R> {
         return this;
     }
 
-    @RecipeBuilderMethodDescription
+    @RecipeBuilderMethodDescription(field = "replace")
     public AbstractCraftingRecipeBuilder<R> replaceByName() {
         this.replace = 2;
         return this;

--- a/src/main/resources/assets/groovyscript/lang/en_us.lang
+++ b/src/main/resources/assets/groovyscript/lang/en_us.lang
@@ -1801,6 +1801,7 @@ groovyscript.wiki.pyrotech.campfire.add=Adds recipes in the format `name`, `inpu
 groovyscript.wiki.pyrotech.chopping_block.title=Chopping Block
 groovyscript.wiki.pyrotech.chopping_block.description=When using a axe it can convert items
 groovyscript.wiki.pyrotech.chopping_block.chops.value=Sets how often the item needs to be hit with output amount. Call it 4 times for 4 different tiers (Crude, Stone, Iron, Diamond)
+groovyscript.wiki.pyrotech.chopping_block.quantities.value=Sets the amount of items output for a given tier. Call it 4 times for 4 different tiers (Crude, Stone, Iron, Diamond)
 
 groovyscript.wiki.pyrotech.compacting_bin.title=Compacting Bin
 groovyscript.wiki.pyrotech.compacting_bin.description=When using a shovel it can convert items


### PR DESCRIPTION
changes in this PR:
- adds some more checks for missing document stuff, logging as warns.
	- No methods targeting an annotated field (`Couldn't find any methods targeting field '{}' in recipe builder '{}'`)
	- No such annotated field targeted by a method (`Couldn't find field '{}' referenced in a method used for recipe builder '{}'`)
	- No fields used at all (`Couldn't find any fields being used for recipe builder '{}'`)
- removed an used constructor param for the `Builder`.
- updated annotations, a lang key, and an example file to ensure existing annotations pass these checks. (impacts `Pyrotech`, `Astral Sorcery`, `Mekanism`, and `Rustic`)