### PR TITLE
add Tech Reborn compat

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -95,6 +95,8 @@ final def mod_dependencies = [
         'prodigytech-297414:2769520'                          : [project.debug_prodigytech],
         'roots-246183:3905074'                                : [project.debug_roots],
         'rustic-256141:3107974'                               : [project.debug_rustic],
+        'reborncore-237903:3330308'                           : [project.debug_tech_reborn],
+        'techreborn-233564:2966851'                           : [project.debug_tech_reborn],
         'thaumcraft-223628:2629023'                           : [project.debug_thaum],
         'cofh_core-69162:2920433'                             : [project.debug_thermal],
         'cofh_world-271384:2920434'                           : [project.debug_thermal],
@@ -155,6 +157,11 @@ dependencies {
 
     if (project.debug_pyrotech.toBoolean()) {
         runtimeOnly rfg.deobf("curse.maven:dropt-284973:3758733")
+    }
+
+    compileOnly rfg.deobf('TechReborn:TechReborn-ModCompatibility-1.12.2:1.4.0.76:universal')
+    if (project.debug_tech_reborn.toBoolean()) {
+        runtimeOnly rfg.deobf('TechReborn:TechReborn-ModCompatibility-1.12.2:1.4.0.76:universal')
     }
 
     runtimeOnly 'com.cleanroommc:strip-latest-forge-requirements:1.0'

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -111,6 +111,8 @@ dependencies {
 
     // TODO: check if there is anything to exclude
     specialEmbed "io.github.classgraph:classgraph:4.8.165"
+    // have to include compileOnly for if any mods we're adding compat for shade an older version of classgraph, such as Reborn Core.
+    compileOnly "io.github.classgraph:classgraph:4.8.165"
 
     specialEmbed("org.eclipse.lsp4j:org.eclipse.lsp4j:0.20.1") {
         exclude group: 'com.google.guava', module: 'guava'

--- a/examples/postInit/techreborn.groovy
+++ b/examples/postInit/techreborn.groovy
@@ -2,7 +2,7 @@
 // Auto generated groovyscript example file
 // MODS_LOADED: techreborn
 
-println 'mod \'techreborn\' detected, running script'
+log.info 'mod \'techreborn\' detected, running script'
 
 // Alloy Smelter:
 // Converts two itemstack inputs into an itemstack output after a given process time, consuming energy per tick.

--- a/examples/postInit/techreborn.groovy
+++ b/examples/postInit/techreborn.groovy
@@ -1,0 +1,588 @@
+
+// Auto generated groovyscript example file
+// MODS_LOADED: techreborn
+
+println 'mod \'techreborn\' detected, running script'
+
+// Alloy Smelter:
+// Converts two itemstack inputs into an itemstack output after a given process time, consuming energy per tick.
+
+mods.techreborn.alloy_smelter.removeByInput(item('techreborn:ingot:4'))
+mods.techreborn.alloy_smelter.removeByOutput(item('techreborn:ingot:5'))
+// mods.techreborn.alloy_smelter.removeAll()
+
+mods.techreborn.alloy_smelter.recipeBuilder()
+    .input(item('minecraft:clay'), item('minecraft:diamond') * 2)
+    .output(item('minecraft:gold_ingot'))
+    .time(10)
+    .perTick(100)
+    .register()
+
+mods.techreborn.alloy_smelter.recipeBuilder()
+    .input(item('minecraft:diamond') * 3, item('minecraft:diamond') * 2)
+    .output(item('minecraft:clay') * 2)
+    .time(5)
+    .perTick(32)
+    .register()
+
+
+// Assembling Machine:
+// Converts two itemstack inputs into an itemstack output after a given process time, consuming energy per tick.
+
+mods.techreborn.assembling_machine.removeByInput(item('techreborn:plates:35'))
+mods.techreborn.assembling_machine.removeByOutput(item('techreborn:part:29'))
+// mods.techreborn.assembling_machine.removeAll()
+
+mods.techreborn.assembling_machine.recipeBuilder()
+    .input(item('minecraft:clay'), item('minecraft:diamond') * 2)
+    .output(item('minecraft:gold_ingot'))
+    .time(10)
+    .perTick(100)
+    .register()
+
+mods.techreborn.assembling_machine.recipeBuilder()
+    .input(item('minecraft:diamond') * 3, item('minecraft:diamond') * 2)
+    .output(item('minecraft:clay') * 2)
+    .time(5)
+    .perTick(32)
+    .register()
+
+
+// Industrial Blast Furnace:
+// Converts one or two itemstack inputs into one or two itemstack outputs after a given process time, requiring at least a
+// given amount of heat and consuming energy per tick.
+
+mods.techreborn.blast_furnace.removeByInput(item('techreborn:dust:1'))
+mods.techreborn.blast_furnace.removeByOutput(item('techreborn:ingot:12'))
+// mods.techreborn.blast_furnace.removeAll()
+
+mods.techreborn.blast_furnace.recipeBuilder()
+    .input(item('minecraft:clay'), item('minecraft:diamond') * 2)
+    .output(item('minecraft:gold_ingot'))
+    .time(10)
+    .perTick(100)
+    .neededHeat(3800)
+    .register()
+
+mods.techreborn.blast_furnace.recipeBuilder()
+    .input(item('minecraft:diamond') * 3, item('minecraft:diamond') * 2)
+    .output(item('minecraft:clay') * 2)
+    .time(5)
+    .neededHeat(1500)
+    .register()
+
+
+// Industrial Centrifuge:
+// Converts one or two itemstack inputs into up to four an itemstack output after a given process time, consuming energy
+// per tick.
+
+mods.techreborn.centrifuge.removeByInput(item('techreborn:dust:33'))
+mods.techreborn.centrifuge.removeByOutput(item('techreborn:dynamiccell').withNbt(['Fluid': ['FluidName': 'fluidmethane', 'Amount': 1000]]))
+// mods.techreborn.centrifuge.removeAll()
+
+mods.techreborn.centrifuge.recipeBuilder()
+    .input(item('minecraft:clay'), item('minecraft:diamond') * 2)
+    .output(item('minecraft:gold_ingot'), item('minecraft:clay') * 5, item('minecraft:clay') * 2, item('minecraft:clay'))
+    .time(10)
+    .perTick(100)
+    .register()
+
+mods.techreborn.centrifuge.recipeBuilder()
+    .input(item('minecraft:diamond') * 3, item('minecraft:diamond') * 2)
+    .output(item('minecraft:clay') * 2)
+    .time(5)
+    .perTick(32)
+    .register()
+
+
+// Chemical Reactor:
+// Converts two itemstack inputs into an itemstack output after a given process time, consuming energy per tick.
+
+mods.techreborn.chemical_reactor.removeByInput(item('techreborn:dynamiccell').withNbt(['Fluid': ['FluidName': 'water', 'Amount': 1000]]))
+mods.techreborn.chemical_reactor.removeByOutput(item('techreborn:dynamiccell').withNbt(['Fluid': ['FluidName': 'water', 'Amount': 1000]]))
+// mods.techreborn.chemical_reactor.removeAll()
+
+mods.techreborn.chemical_reactor.recipeBuilder()
+    .input(item('minecraft:clay'), item('minecraft:diamond') * 2)
+    .output(item('minecraft:gold_ingot'))
+    .time(10)
+    .perTick(100)
+    .register()
+
+mods.techreborn.chemical_reactor.recipeBuilder()
+    .input(item('minecraft:diamond') * 3, item('minecraft:diamond') * 2)
+    .output(item('minecraft:clay') * 2)
+    .time(5)
+    .perTick(32)
+    .register()
+
+
+// Compressor:
+// Converts an itemstack input into an itemstack output after a given process time, consuming energy per tick.
+
+mods.techreborn.compressor.removeByInput(item('minecraft:diamond'))
+mods.techreborn.compressor.removeByOutput(item('techreborn:plates:36'))
+// mods.techreborn.compressor.removeAll()
+
+mods.techreborn.compressor.recipeBuilder()
+    .input(item('minecraft:clay'))
+    .output(item('minecraft:gold_ingot'))
+    .time(10)
+    .perTick(100)
+    .register()
+
+mods.techreborn.compressor.recipeBuilder()
+    .input(item('minecraft:diamond') * 3)
+    .output(item('minecraft:clay') * 2)
+    .time(5)
+    .perTick(32)
+    .register()
+
+
+// Diesel Generator:
+// Converts a fluidstack input into power, at a given rate per tick.
+
+mods.techreborn.diesel_generator.removeByInput(fluid('fluiddiesel'))
+// mods.techreborn.diesel_generator.removeAll()
+
+mods.techreborn.diesel_generator.recipeBuilder()
+    .fluidInput(fluid('water'))
+    .energy(10000)
+    .perTick(500)
+    .register()
+
+mods.techreborn.diesel_generator.recipeBuilder()
+    .fluidInput(fluid('lava'))
+    .energy(200)
+    .perTick(10)
+    .register()
+
+
+// Distillation Tower:
+// Converts one or two itemstack inputs into up to four an itemstack output after a given process time, consuming energy
+// per tick.
+
+mods.techreborn.distillation_tower.removeByInput(item('techreborn:dynamiccell').withNbt(['Fluid': ['FluidName': 'fluidoil', 'Amount': 1000]]))
+// mods.techreborn.distillation_tower.removeByOutput(item('techreborn:dynamiccell').withNbt(['Fluid': ['FluidName': 'fluidmethane', 'Amount': 1000]]))
+// mods.techreborn.distillation_tower.removeAll()
+
+mods.techreborn.distillation_tower.recipeBuilder()
+    .input(item('minecraft:clay'), item('minecraft:diamond') * 2)
+    .output(item('minecraft:gold_ingot'), item('minecraft:clay') * 5, item('minecraft:clay') * 2, item('minecraft:clay'))
+    .time(10)
+    .perTick(100)
+    .register()
+
+mods.techreborn.distillation_tower.recipeBuilder()
+    .input(item('minecraft:diamond') * 3, item('minecraft:diamond') * 2)
+    .output(item('minecraft:clay') * 2)
+    .time(5)
+    .perTick(32)
+    .register()
+
+
+// Extractor:
+// Converts an itemstack input into an itemstack output after a given process time, consuming energy per tick.
+
+mods.techreborn.extractor.removeByInput(item('minecraft:slime_ball'))
+mods.techreborn.extractor.removeByOutput(item('minecraft:wool'))
+// mods.techreborn.extractor.removeAll()
+
+mods.techreborn.extractor.recipeBuilder()
+    .input(item('minecraft:clay'))
+    .output(item('minecraft:gold_ingot'))
+    .time(10)
+    .perTick(100)
+    .register()
+
+mods.techreborn.extractor.recipeBuilder()
+    .input(item('minecraft:diamond') * 3)
+    .output(item('minecraft:clay') * 2)
+    .time(5)
+    .perTick(32)
+    .register()
+
+
+// Fluid Replicator:
+// Converts a configurable amount of UU-Matter into a output fluidstack of 1000mb after a given process time, replicating a
+// fluid source block placed in-world and consuming energy per tick.
+
+mods.techreborn.fluid_replicator.removeByOutput(fluid('water'))
+// mods.techreborn.fluid_replicator.removeAll()
+
+mods.techreborn.fluid_replicator.recipeBuilder()
+    .matter(10)
+    .fluidOutput(fluid('water'))
+    .time(100)
+    .perTick(10)
+    .register()
+
+mods.techreborn.fluid_replicator.recipeBuilder()
+    .matter(1)
+    .fluidOutput(fluid('fluidmethane'))
+    .time(5)
+    .perTick(1000)
+    .register()
+
+
+// Fusion Reactor:
+// Converts two itemstack inputs into an itemstack output after a given process time, requiring a cost to start the recipe
+// and either generating or consuming power while the recipe runs.
+
+mods.techreborn.fusion_reactor.removeByInput(item('techreborn:part:17'))
+mods.techreborn.fusion_reactor.removeByOutput(item('techreborn:ore:1'))
+// mods.techreborn.fusion_reactor.removeAll()
+
+mods.techreborn.fusion_reactor.recipeBuilder()
+    .input(item('minecraft:clay'), item('minecraft:diamond') * 2)
+    .output(item('minecraft:gold_ingot'))
+    .time(10)
+    .perTick(-25000)
+    .start(200)
+    .size(30)
+    .register()
+
+mods.techreborn.fusion_reactor.recipeBuilder()
+    .input(item('minecraft:diamond') * 3, item('minecraft:diamond') * 2)
+    .output(item('minecraft:clay') * 2)
+    .time(5)
+    .perTick(30000)
+    .start(1000000)
+    .register()
+
+
+// Gas Turbine:
+// Converts a fluidstack input into power, at a given rate per tick.
+
+mods.techreborn.gas_turbine.removeByInput(fluid('fluidhydrogen'))
+// mods.techreborn.gas_turbine.removeAll()
+
+mods.techreborn.gas_turbine.recipeBuilder()
+    .fluidInput(fluid('water'))
+    .energy(10000)
+    .perTick(500)
+    .register()
+
+mods.techreborn.gas_turbine.recipeBuilder()
+    .fluidInput(fluid('lava'))
+    .energy(200)
+    .perTick(10)
+    .register()
+
+
+// Grinder:
+// Converts an itemstack input into an itemstack output after a given process time, consuming energy per tick.
+
+mods.techreborn.grinder.removeByInput(item('minecraft:coal_ore'))
+mods.techreborn.grinder.removeByOutput(item('minecraft:diamond'))
+// mods.techreborn.grinder.removeAll()
+
+mods.techreborn.grinder.recipeBuilder()
+    .input(item('minecraft:clay'))
+    .output(item('minecraft:gold_ingot'))
+    .time(10)
+    .perTick(100)
+    .register()
+
+mods.techreborn.grinder.recipeBuilder()
+    .input(item('minecraft:diamond') * 3)
+    .output(item('minecraft:clay') * 2)
+    .time(5)
+    .perTick(32)
+    .register()
+
+
+// Implosion Compressor:
+// Converts two itemstack inputs into up to two itemstack outputs after a given process time, consuming energy per tick.
+
+mods.techreborn.implosion_compressor.removeByInput(item('techreborn:ingot:22'))
+mods.techreborn.implosion_compressor.removeByOutput(item('minecraft:diamond'))
+// mods.techreborn.implosion_compressor.removeAll()
+
+mods.techreborn.implosion_compressor.recipeBuilder()
+    .input(item('minecraft:clay'), item('minecraft:diamond') * 2)
+    .output(item('minecraft:gold_ingot'))
+    .time(10)
+    .perTick(100)
+    .register()
+
+mods.techreborn.implosion_compressor.recipeBuilder()
+    .input(item('minecraft:diamond') * 3, item('minecraft:diamond') * 2)
+    .output(item('minecraft:clay') * 2)
+    .time(5)
+    .perTick(32)
+    .register()
+
+
+// Industrial Electrolyzer:
+// Converts up to two itemstack inputs into up to four itemstack outputs after a given process time, consuming energy per
+// tick.
+
+mods.techreborn.industrial_electrolyzer.removeByInput(item('minecraft:dye:15'))
+mods.techreborn.industrial_electrolyzer.removeByOutput(item('techreborn:dust:1'))
+// mods.techreborn.industrial_electrolyzer.removeAll()
+
+mods.techreborn.industrial_electrolyzer.recipeBuilder()
+    .input(item('minecraft:clay'), item('minecraft:diamond') * 2)
+    .output(item('minecraft:gold_ingot'), item('minecraft:clay') * 5, item('minecraft:clay') * 2, item('minecraft:clay'))
+    .time(10)
+    .perTick(100)
+    .register()
+
+mods.techreborn.industrial_electrolyzer.recipeBuilder()
+    .input(item('minecraft:diamond') * 3, item('minecraft:diamond') * 2)
+    .output(item('minecraft:clay') * 2)
+    .time(5)
+    .perTick(32)
+    .register()
+
+
+// Industrial Grinder:
+// Converts an itemstack input and fluidstack input into up to four itemstack outputs after a given process time, consuming
+// energy per tick.
+
+mods.techreborn.industrial_grinder.removeByInput(fluid('water'))
+mods.techreborn.industrial_grinder.removeByInput(item('techreborn:ore2'))
+mods.techreborn.industrial_grinder.removeByOutput(item('techreborn:dust:53'))
+// mods.techreborn.industrial_grinder.removeAll()
+
+mods.techreborn.industrial_grinder.recipeBuilder()
+    .input(item('minecraft:clay'))
+    .fluidInput(fluid('lava') * 50)
+    .output(item('minecraft:gold_ingot'), item('minecraft:clay') * 5, item('minecraft:clay') * 2, item('minecraft:clay'))
+    .time(10)
+    .perTick(100)
+    .register()
+
+mods.techreborn.industrial_grinder.recipeBuilder()
+    .input(item('minecraft:diamond') * 3)
+    .fluidInput(fluid('water') * 250)
+    .output(item('minecraft:clay') * 2)
+    .time(5)
+    .perTick(32)
+    .register()
+
+
+// Sawmill:
+// Converts an itemstack input and fluidstack output into three itemstack outputs after a given process time, consuming
+// energy per tick.
+
+mods.techreborn.industrial_sawmill.removeByInput(fluid('water'))
+mods.techreborn.industrial_sawmill.removeByInput(item('minecraft:log'))
+mods.techreborn.industrial_sawmill.removeByOutput(item('minecraft:planks:4'))
+// mods.techreborn.industrial_sawmill.removeAll()
+
+mods.techreborn.industrial_sawmill.recipeBuilder()
+    .input(item('minecraft:clay'))
+    .fluidInput(fluid('lava') * 100)
+    .output(item('minecraft:gold_ingot'), item('minecraft:clay') * 5, item('minecraft:clay'))
+    .time(10)
+    .perTick(100)
+    .register()
+
+mods.techreborn.industrial_sawmill.recipeBuilder()
+    .input(item('minecraft:diamond') * 3)
+    .fluidInput(fluid('water') * 500)
+    .output(item('minecraft:clay') * 2)
+    .time(5)
+    .perTick(32)
+    .register()
+
+
+// Plasma Generator:
+// Converts a fluidstack input into power, at a given rate per tick.
+
+mods.techreborn.plasma_generator.removeByInput(fluid('fluidheliumplasma'))
+// mods.techreborn.plasma_generator.removeAll()
+
+mods.techreborn.plasma_generator.recipeBuilder()
+    .fluidInput(fluid('water'))
+    .energy(10000)
+    .perTick(500)
+    .register()
+
+mods.techreborn.plasma_generator.recipeBuilder()
+    .fluidInput(fluid('lava'))
+    .energy(200)
+    .perTick(10)
+    .register()
+
+
+// Plate Bending Machine:
+// Converts an itemstack input into an itemstack output after a given process time, consuming energy per tick.
+
+mods.techreborn.plate_bending_machine.removeByInput(item('minecraft:gold_ingot'))
+mods.techreborn.plate_bending_machine.removeByOutput(item('techreborn:plates:36'))
+// mods.techreborn.plate_bending_machine.removeAll()
+
+mods.techreborn.plate_bending_machine.recipeBuilder()
+    .input(item('minecraft:clay'))
+    .output(item('minecraft:gold_ingot'))
+    .time(10)
+    .perTick(100)
+    .register()
+
+mods.techreborn.plate_bending_machine.recipeBuilder()
+    .input(item('minecraft:diamond') * 3)
+    .output(item('minecraft:clay') * 2)
+    .time(5)
+    .perTick(32)
+    .register()
+
+
+// Rolling Machine:
+// Converts a custom crafting recipe into an output itemstack.
+
+mods.techreborn.rolling_machine.removeByOutput(item('minecraft:tripwire_hook'))
+// mods.techreborn.rolling_machine.removeAll()
+
+mods.techreborn.rolling_machine.shapedBuilder()
+    .output(item('minecraft:stone'))
+    .matrix('BXX',
+            'X B')
+    .key('B', item('minecraft:stone'))
+    .key('X', item('minecraft:gold_ingot'))
+    .mirrored()
+    .register()
+
+mods.techreborn.rolling_machine.shapedBuilder()
+    .output(item('minecraft:diamond') * 32)
+    .matrix([[item('minecraft:gold_ingot'), item('minecraft:gold_ingot'), item('minecraft:gold_ingot')],
+            [item('minecraft:gold_ingot'), item('minecraft:gold_ingot'), item('minecraft:gold_ingot')],
+            [item('minecraft:gold_ingot'), item('minecraft:gold_ingot'), item('minecraft:gold_ingot')]])
+    .register()
+
+mods.techreborn.rolling_machine.shapelessBuilder()
+    .output(item('minecraft:clay') * 8)
+    .input(item('minecraft:stone'), item('minecraft:stone'), item('minecraft:stone'))
+    .register()
+
+mods.techreborn.rolling_machine.shapelessBuilder()
+    .output(item('minecraft:clay') * 32)
+    .input(item('minecraft:diamond'), item('minecraft:diamond'), item('minecraft:diamond'), item('minecraft:diamond'), item('minecraft:diamond'), item('minecraft:diamond'), item('minecraft:diamond'), item('minecraft:diamond'))
+    .register()
+
+
+
+// Scrapbox:
+// Converts a scrapbox into a random itemstack output, either via manual player interaction or via a machine with a given
+// process time, consuming energy per tick.
+
+mods.techreborn.scrapbox.removeByOutput(item('minecraft:diamond'))
+// mods.techreborn.scrapbox.removeAll()
+
+mods.techreborn.scrapbox.recipeBuilder()
+    .output(item('minecraft:clay'))
+    .register()
+
+mods.techreborn.scrapbox.recipeBuilder()
+    .output(item('minecraft:gold_block'))
+    .time(2)
+    .perTick(100)
+    .register()
+
+
+// Semi-Fluid Generator:
+// Converts a fluidstack input into power, at a given rate per tick.
+
+mods.techreborn.semi_fluid_generator.removeByInput(fluid('fluidbiofuel'))
+// mods.techreborn.semi_fluid_generator.removeAll()
+
+mods.techreborn.semi_fluid_generator.recipeBuilder()
+    .fluidInput(fluid('water'))
+    .energy(10000)
+    .perTick(500)
+    .register()
+
+mods.techreborn.semi_fluid_generator.recipeBuilder()
+    .fluidInput(fluid('lava'))
+    .energy(200)
+    .perTick(10)
+    .register()
+
+
+// Solid Canning Machine:
+// Converts two itemstack inputs into an itemstack output after a given process time, consuming energy per tick.
+
+mods.techreborn.solid_canning_machine.removeByInput(item('techreborn:ingot:23'))
+mods.techreborn.solid_canning_machine.removeByOutput(item('techreborn:part:46'))
+// mods.techreborn.solid_canning_machine.removeAll()
+
+mods.techreborn.solid_canning_machine.recipeBuilder()
+    .input(item('minecraft:clay'), item('minecraft:diamond') * 2)
+    .output(item('minecraft:gold_ingot'))
+    .time(10)
+    .perTick(100)
+    .register()
+
+mods.techreborn.solid_canning_machine.recipeBuilder()
+    .input(item('minecraft:diamond') * 3, item('minecraft:diamond') * 2)
+    .output(item('minecraft:clay') * 2)
+    .time(5)
+    .perTick(32)
+    .register()
+
+
+// Thermal Generator:
+// Converts a fluidstack input into power, at a given rate per tick.
+
+mods.techreborn.thermal_generator.removeByInput(fluid('lava'))
+// mods.techreborn.thermal_generator.removeAll()
+
+mods.techreborn.thermal_generator.recipeBuilder()
+    .fluidInput(fluid('water'))
+    .energy(10000)
+    .perTick(500)
+    .register()
+
+mods.techreborn.thermal_generator.recipeBuilder()
+    .fluidInput(fluid('lava'))
+    .energy(200)
+    .perTick(10)
+    .register()
+
+
+// Vacuum Freezer:
+// Converts an itemstack input into an itemstack output after a given process time, consuming energy per tick.
+
+mods.techreborn.vacuum_freezer.removeByInput(item('techreborn:dynamiccell').withNbt(['Fluid': ['FluidName': 'water', 'Amount': 1000]]))
+mods.techreborn.vacuum_freezer.removeByOutput(item('minecraft:packed_ice'))
+// mods.techreborn.vacuum_freezer.removeAll()
+
+mods.techreborn.vacuum_freezer.recipeBuilder()
+    .input(item('minecraft:clay'))
+    .output(item('minecraft:gold_ingot'))
+    .time(10)
+    .perTick(100)
+    .register()
+
+mods.techreborn.vacuum_freezer.recipeBuilder()
+    .input(item('minecraft:diamond') * 3)
+    .output(item('minecraft:clay') * 2)
+    .time(5)
+    .perTick(32)
+    .register()
+
+
+// Wire Mill:
+// Converts an itemstack input into an itemstack output after a given process time, consuming energy per tick.
+
+mods.techreborn.wire_mill.removeByInput(item('minecraft:gold_ingot'))
+mods.techreborn.wire_mill.removeByOutput(item('techreborn:cable'))
+// mods.techreborn.wire_mill.removeAll()
+
+mods.techreborn.wire_mill.recipeBuilder()
+    .input(item('minecraft:clay'))
+    .output(item('minecraft:gold_ingot'))
+    .time(10)
+    .perTick(100)
+    .register()
+
+mods.techreborn.wire_mill.recipeBuilder()
+    .input(item('minecraft:diamond') * 3)
+    .output(item('minecraft:clay') * 2)
+    .time(5)
+    .perTick(32)
+    .register()
+
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -58,6 +58,7 @@ debug_projecte = false
 debug_pyrotech = false
 debug_roots = false
 debug_rustic = false
+debug_tech_reborn = false
 debug_thaum = false
 debug_thermal = false
 debug_tinkers = false

--- a/repositories.gradle
+++ b/repositories.gradle
@@ -1,11 +1,11 @@
 // Add any additional repositories for your dependencies here
 
 repositories {
-    maven {
-        // used for EnderIO
-        url 'http://maven.tterrag.com/'
-        allowInsecureProtocol = true
-    }
+//    maven {
+//        // formerly used for EnderIO, currently unused
+//        url 'http://maven.tterrag.com/'
+//        allowInsecureProtocol = true
+//    }
     maven {
         // used for TechReborn
         name 'Mod Maven'

--- a/repositories.gradle
+++ b/repositories.gradle
@@ -2,6 +2,7 @@
 
 repositories {
     maven {
+        // used for EnderIO
         url 'http://maven.tterrag.com/'
         allowInsecureProtocol = true
     }

--- a/repositories.gradle
+++ b/repositories.gradle
@@ -6,6 +6,11 @@ repositories {
         allowInsecureProtocol = true
     }
     maven {
+        // used for TechReborn
+        name 'Mod Maven'
+        url 'https://modmaven.dev'
+    }
+    maven {
         url 'https://mvnrepository.com/artifact/org.apache.groovy/groovy'
     }
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ModSupport.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ModSupport.java
@@ -49,6 +49,7 @@ import com.cleanroommc.groovyscript.compat.mods.pyrotech.PyroTech;
 import com.cleanroommc.groovyscript.compat.mods.roots.Roots;
 import com.cleanroommc.groovyscript.compat.mods.rustic.Rustic;
 import com.cleanroommc.groovyscript.compat.mods.tcomplement.TinkersComplement;
+import com.cleanroommc.groovyscript.compat.mods.techreborn.TechReborn;
 import com.cleanroommc.groovyscript.compat.mods.thaumcraft.Thaumcraft;
 import com.cleanroommc.groovyscript.compat.mods.thermalexpansion.ThermalExpansion;
 import com.cleanroommc.groovyscript.compat.mods.tinkersconstruct.TinkersConstruct;
@@ -119,6 +120,7 @@ public class ModSupport {
     public static final GroovyContainer<PyroTech> PYROTECH = new InternalModContainer<>("pyrotech", "Pyrotech", PyroTech::new);
     public static final GroovyContainer<Roots> ROOTS = new InternalModContainer<>("roots", "Roots 3", Roots::new);
     public static final GroovyContainer<Rustic> RUSTIC = new InternalModContainer<>("rustic", "Rustic", Rustic::new);
+    public static final GroovyContainer<TechReborn> TECH_REBORN = new InternalModContainer<>("techreborn", "Tech Reborn", TechReborn::new);
     public static final GroovyContainer<Thaumcraft> THAUMCRAFT = new InternalModContainer<>("thaumcraft", "Thaumcraft", Thaumcraft::new, "tc", "thaum");
     public static final GroovyContainer<TheAurorian> THE_AURORIAN = new InternalModContainer<>("theaurorian", "The Aurorian", TheAurorian::new, "aurorian");
     public static final GroovyContainer<ThermalExpansion> THERMAL_EXPANSION = new InternalModContainer<>("thermalexpansion", "Thermal Expansion", ThermalExpansion::new, "thermal");

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/AbstractGeneratorRegistry.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/AbstractGeneratorRegistry.java
@@ -1,0 +1,70 @@
+package com.cleanroommc.groovyscript.compat.mods.techreborn;
+
+import com.cleanroommc.groovyscript.api.GroovyBlacklist;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.Example;
+import com.cleanroommc.groovyscript.api.documentation.annotations.MethodDescription;
+import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
+import com.cleanroommc.groovyscript.helper.ingredient.OreDictIngredient;
+import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
+import org.jetbrains.annotations.ApiStatus;
+import reborncore.api.praescriptum.fuels.Fuel;
+import reborncore.api.praescriptum.fuels.FuelHandler;
+
+public abstract class AbstractGeneratorRegistry extends VirtualizedRegistry<Fuel> {
+
+    abstract FuelHandler handler();
+
+    @Override
+    @GroovyBlacklist
+    @ApiStatus.Internal
+    public void onReload() {
+        handler().getFuels().removeAll(removeScripted());
+        handler().getFuels().addAll(restoreFromBackup());
+    }
+
+    public void add(Fuel recipe) {
+        if (recipe != null) {
+            addScripted(recipe);
+            recipe.register();
+        }
+    }
+
+    public boolean remove(Fuel recipe) {
+        if (handler().getFuels().removeIf(r -> r == recipe)) {
+            addBackup(recipe);
+            return true;
+        }
+        return false;
+    }
+
+    @MethodDescription
+    public void removeByInput(IIngredient input) {
+        handler().getFuels().removeIf(recipe -> {
+            if (recipe.getInputIngredients().stream().map(x -> x.ingredient).anyMatch(x -> {
+                if (x instanceof ItemStack itemStack) return input.test(itemStack);
+                if (x instanceof FluidStack fluidStack) return input.test(fluidStack);
+                if (x instanceof String s && input instanceof OreDictIngredient ore) return ore.getOreDict().equals(s);
+                return false;
+            })) {
+                addBackup(recipe);
+                return true;
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(type = MethodDescription.Type.QUERY)
+    public SimpleObjectStream<Fuel> streamRecipes() {
+        return new SimpleObjectStream<>(handler().getFuels()).setRemover(this::remove);
+    }
+
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
+    public void removeAll() {
+        handler().getFuels().forEach(this::addBackup);
+        handler().getFuels().clear();
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/AbstractGenericTechRebornRegistry.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/AbstractGenericTechRebornRegistry.java
@@ -1,0 +1,81 @@
+package com.cleanroommc.groovyscript.compat.mods.techreborn;
+
+import com.cleanroommc.groovyscript.api.GroovyBlacklist;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.Example;
+import com.cleanroommc.groovyscript.api.documentation.annotations.MethodDescription;
+import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
+import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import org.jetbrains.annotations.ApiStatus;
+import reborncore.api.recipe.IBaseRecipeType;
+import reborncore.api.recipe.RecipeHandler;
+import reborncore.common.recipes.RecipeTranslator;
+
+public abstract class AbstractGenericTechRebornRegistry extends VirtualizedRegistry<IBaseRecipeType> {
+
+    abstract String reference();
+
+    @Override
+    @GroovyBlacklist
+    @ApiStatus.Internal
+    public void onReload() {
+        removeScripted().forEach(recipe -> RecipeHandler.recipeList.removeIf(r -> r == recipe));
+        RecipeHandler.recipeList.addAll(restoreFromBackup());
+    }
+
+    public void add(IBaseRecipeType recipe) {
+        if (recipe != null) {
+            addScripted(recipe);
+            RecipeHandler.recipeList.add(recipe);
+        }
+    }
+
+    public boolean remove(IBaseRecipeType recipe) {
+        if (RecipeHandler.recipeList.removeIf(r -> r == recipe)) {
+            addBackup(recipe);
+            return true;
+        }
+        return false;
+    }
+
+    public void removeByInput(IIngredient input) {
+        RecipeHandler.recipeList.removeIf(recipe -> {
+            if (recipe.getRecipeName().equals(reference())) {
+                if (recipe.getInputs().stream().map(RecipeTranslator::getStackFromObject).anyMatch(input)) {
+                    addBackup(recipe);
+                    return true;
+                }
+            }
+            return false;
+        });
+    }
+
+    public void removeByOutput(IIngredient output) {
+        RecipeHandler.recipeList.removeIf(recipe -> {
+            if (recipe.getRecipeName().equals(reference())) {
+                if (recipe.getOutputs().stream().anyMatch(output)) {
+                    addBackup(recipe);
+                    return true;
+                }
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(type = MethodDescription.Type.QUERY)
+    public SimpleObjectStream<IBaseRecipeType> streamRecipes() {
+        return new SimpleObjectStream<>(RecipeHandler.getRecipeClassFromName(reference())).setRemover(this::remove);
+    }
+
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
+    public void removeAll() {
+        RecipeHandler.recipeList.removeIf(recipe -> {
+            if (recipe.getRecipeName().equals(reference())) {
+                addBackup(recipe);
+                return true;
+            }
+            return false;
+        });
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/AbstractPraescriptumRegistry.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/AbstractPraescriptumRegistry.java
@@ -1,0 +1,83 @@
+package com.cleanroommc.groovyscript.compat.mods.techreborn;
+
+import com.cleanroommc.groovyscript.api.GroovyBlacklist;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.Example;
+import com.cleanroommc.groovyscript.api.documentation.annotations.MethodDescription;
+import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
+import com.cleanroommc.groovyscript.helper.ingredient.OreDictIngredient;
+import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
+import org.jetbrains.annotations.ApiStatus;
+import reborncore.api.praescriptum.recipes.Recipe;
+import reborncore.api.praescriptum.recipes.RecipeHandler;
+
+import java.util.Arrays;
+
+public abstract class AbstractPraescriptumRegistry extends VirtualizedRegistry<Recipe> {
+
+    abstract RecipeHandler handler();
+
+    @Override
+    @GroovyBlacklist
+    @ApiStatus.Internal
+    public void onReload() {
+        handler().getRecipes().removeAll(removeScripted());
+        handler().getRecipes().addAll(restoreFromBackup());
+    }
+
+    public void add(Recipe recipe) {
+        if (recipe != null) {
+            addScripted(recipe);
+            recipe.register();
+        }
+    }
+
+    public boolean remove(Recipe recipe) {
+        if (handler().getRecipes().removeIf(r -> r == recipe)) {
+            addBackup(recipe);
+            return true;
+        }
+        return false;
+    }
+
+    @MethodDescription
+    public void removeByInput(IIngredient input) {
+        handler().getRecipes().removeIf(recipe -> {
+            if (recipe.getInputIngredients().stream().map(x -> x.ingredient).anyMatch(x -> {
+                if (x instanceof ItemStack itemStack) return input.test(itemStack);
+                if (x instanceof FluidStack fluidStack) return input.test(fluidStack);
+                if (x instanceof String s) return Arrays.stream(new OreDictIngredient(s).getMatchingStacks()).anyMatch(input);
+                return false;
+            })) {
+                addBackup(recipe);
+                return true;
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription
+    public void removeByOutput(IIngredient output) {
+        handler().getRecipes().removeIf(recipe -> {
+            if (Arrays.stream(recipe.getItemOutputs()).anyMatch(output) || Arrays.stream(recipe.getFluidOutputs()).anyMatch(output::test)) {
+                addBackup(recipe);
+                return true;
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(type = MethodDescription.Type.QUERY)
+    public SimpleObjectStream<Recipe> streamRecipes() {
+        return new SimpleObjectStream<>(handler().getRecipes()).setRemover(this::remove);
+    }
+
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
+    public void removeAll() {
+        handler().getRecipes().forEach(this::addBackup);
+        handler().getRecipes().clear();
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/AlloySmelter.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/AlloySmelter.java
@@ -80,7 +80,7 @@ public class AlloySmelter extends AbstractPraescriptumRegistry {
             if (!validate()) return null;
 
             Recipe recipe = Recipes.alloySmelter.createRecipe();
-            recipe.withInput(input.stream().map(TechReborn::toInputIngredient).collect(Collectors.toList()));
+            recipe.withInput(input.stream().map(Helper::toInputIngredient).collect(Collectors.toList()));
             output.forEach(recipe::withOutput);
             recipe.withEnergyCostPerTick(perTick);
             recipe.withOperationDuration(time);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/AlloySmelter.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/AlloySmelter.java
@@ -1,0 +1,93 @@
+package com.cleanroommc.groovyscript.compat.mods.techreborn;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import org.jetbrains.annotations.Nullable;
+import reborncore.api.praescriptum.recipes.Recipe;
+import reborncore.api.praescriptum.recipes.RecipeHandler;
+import techreborn.api.recipe.Recipes;
+
+import java.util.stream.Collectors;
+
+@RegistryDescription
+public class AlloySmelter extends AbstractPraescriptumRegistry {
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:clay'), item('minecraft:diamond') * 2).output(item('minecraft:gold_ingot')).time(10).perTick(100)"),
+            @Example(".input(item('minecraft:diamond') * 3, item('minecraft:diamond') * 2).output(item('minecraft:clay') * 2).time(5).perTick(32)")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @Override
+    public RecipeHandler handler() {
+        return Recipes.alloySmelter;
+    }
+
+    @Override
+    @MethodDescription(example = @Example("item('techreborn:ingot:4')"))
+    public void removeByInput(IIngredient input) {
+        super.removeByInput(input);
+    }
+
+    @Override
+    @MethodDescription(example = @Example("item('techreborn:ingot:5')"))
+    public void removeByOutput(IIngredient output) {
+        super.removeByOutput(output);
+    }
+
+    @Property(property = "input", valid = @Comp("2"))
+    @Property(property = "output", valid = @Comp("1"))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<Recipe> {
+
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GT))
+        private int time;
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GT))
+        private int perTick;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder time(int time) {
+            this.time = time;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder perTick(int perTick) {
+            this.perTick = perTick;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Tech Reborn Alloy Smelter recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 2, 2, 1, 1);
+            validateFluids(msg);
+            msg.add(time <= 0, "time must be greater than 0, yet it was {}", time);
+            msg.add(perTick <= 0, "perTick must be greater than 0, yet it was {}", perTick);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable Recipe register() {
+            if (!validate()) return null;
+
+            Recipe recipe = Recipes.alloySmelter.createRecipe();
+            recipe.withInput(input.stream().map(TechReborn::toInputIngredient).collect(Collectors.toList()));
+            output.forEach(recipe::withOutput);
+            recipe.withEnergyCostPerTick(perTick);
+            recipe.withOperationDuration(time);
+
+            ModSupport.TECH_REBORN.get().alloySmelter.add(recipe);
+            return recipe;
+        }
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/AssemblingMachine.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/AssemblingMachine.java
@@ -1,0 +1,93 @@
+package com.cleanroommc.groovyscript.compat.mods.techreborn;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import org.jetbrains.annotations.Nullable;
+import reborncore.api.praescriptum.recipes.Recipe;
+import reborncore.api.praescriptum.recipes.RecipeHandler;
+import techreborn.api.recipe.Recipes;
+
+import java.util.stream.Collectors;
+
+@RegistryDescription
+public class AssemblingMachine extends AbstractPraescriptumRegistry {
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:clay'), item('minecraft:diamond') * 2).output(item('minecraft:gold_ingot')).time(10).perTick(100)"),
+            @Example(".input(item('minecraft:diamond') * 3, item('minecraft:diamond') * 2).output(item('minecraft:clay') * 2).time(5).perTick(32)")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @Override
+    public RecipeHandler handler() {
+        return Recipes.assemblingMachine;
+    }
+
+    @Override
+    @MethodDescription(example = @Example("item('techreborn:plates:35')"))
+    public void removeByInput(IIngredient input) {
+        super.removeByInput(input);
+    }
+
+    @Override
+    @MethodDescription(example = @Example("item('techreborn:part:29')"))
+    public void removeByOutput(IIngredient output) {
+        super.removeByOutput(output);
+    }
+
+    @Property(property = "input", valid = @Comp("2"))
+    @Property(property = "output", valid = @Comp("1"))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<Recipe> {
+
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GT))
+        private int time;
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GT))
+        private int perTick;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder time(int time) {
+            this.time = time;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder perTick(int perTick) {
+            this.perTick = perTick;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Tech Reborn Assembling Machine recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 2, 2, 1, 1);
+            validateFluids(msg);
+            msg.add(time <= 0, "time must be greater than 0, yet it was {}", time);
+            msg.add(perTick <= 0, "perTick must be greater than 0, yet it was {}", perTick);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable Recipe register() {
+            if (!validate()) return null;
+
+            Recipe recipe = Recipes.assemblingMachine.createRecipe();
+            recipe.withInput(input.stream().map(TechReborn::toInputIngredient).collect(Collectors.toList()));
+            output.forEach(recipe::withOutput);
+            recipe.withEnergyCostPerTick(perTick);
+            recipe.withOperationDuration(time);
+
+            ModSupport.TECH_REBORN.get().assemblingMachine.add(recipe);
+            return recipe;
+        }
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/AssemblingMachine.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/AssemblingMachine.java
@@ -80,7 +80,7 @@ public class AssemblingMachine extends AbstractPraescriptumRegistry {
             if (!validate()) return null;
 
             Recipe recipe = Recipes.assemblingMachine.createRecipe();
-            recipe.withInput(input.stream().map(TechReborn::toInputIngredient).collect(Collectors.toList()));
+            recipe.withInput(input.stream().map(Helper::toInputIngredient).collect(Collectors.toList()));
             output.forEach(recipe::withOutput);
             recipe.withEnergyCostPerTick(perTick);
             recipe.withOperationDuration(time);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/BlastFurnace.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/BlastFurnace.java
@@ -83,7 +83,7 @@ public class BlastFurnace extends AbstractGenericTechRebornRegistry {
         public @Nullable BlastFurnaceRecipe register() {
             if (!validate()) return null;
             ItemStack output2 = output.size() >= 2 ? output.get(1) : null;
-            BlastFurnaceRecipe recipe = new BlastFurnaceRecipe(TechReborn.getStackFromIIngredient(input.get(0)), input.size() == 2 ? TechReborn.getStackFromIIngredient(input.get(1)) : null, output.get(0), output2, time, perTick, neededHeat);
+            BlastFurnaceRecipe recipe = new BlastFurnaceRecipe(Helper.getStackFromIIngredient(input.get(0)), input.size() == 2 ? Helper.getStackFromIIngredient(input.get(1)) : null, output.get(0), output2, time, perTick, neededHeat);
             ModSupport.TECH_REBORN.get().blastFurnace.add(recipe);
             return recipe;
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/BlastFurnace.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/BlastFurnace.java
@@ -1,0 +1,92 @@
+package com.cleanroommc.groovyscript.compat.mods.techreborn;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import net.minecraft.item.ItemStack;
+import org.jetbrains.annotations.Nullable;
+import techreborn.api.Reference;
+import techreborn.api.recipe.machines.BlastFurnaceRecipe;
+
+@RegistryDescription(admonition = @Admonition(value = "groovyscript.wiki.techreborn.blast_furnace.note0", type = Admonition.Type.INFO))
+public class BlastFurnace extends AbstractGenericTechRebornRegistry {
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:clay'), item('minecraft:diamond') * 2).output(item('minecraft:gold_ingot')).time(10).perTick(100).neededHeat(3800)"),
+            @Example(".input(item('minecraft:diamond') * 3, item('minecraft:diamond') * 2).output(item('minecraft:clay') * 2).time(5).neededHeat(1500)")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @Override
+    public String reference() {
+        return Reference.BLAST_FURNACE_RECIPE;
+    }
+
+    @Override
+    @MethodDescription(example = @Example("item('techreborn:dust:1')"))
+    public void removeByInput(IIngredient input) {
+        super.removeByInput(input);
+    }
+
+    @Override
+    @MethodDescription(example = @Example("item('techreborn:ingot:12')"))
+    public void removeByOutput(IIngredient output) {
+        super.removeByOutput(output);
+    }
+
+    @Property(property = "input", valid = {@Comp(type = Comp.Type.GTE, value = "1"), @Comp(type = Comp.Type.LTE, value = "2")})
+    @Property(property = "output", valid = {@Comp(type = Comp.Type.GTE, value = "1"), @Comp(type = Comp.Type.LTE, value = "2")})
+    public static class RecipeBuilder extends AbstractRecipeBuilder<BlastFurnaceRecipe> {
+
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GTE))
+        private int time;
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GTE), defaultValue = "128")
+        private int perTick = 128;
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GTE))
+        private int neededHeat;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder time(int time) {
+            this.time = time;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder perTick(int perTick) {
+            this.perTick = perTick;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder neededHeat(int neededHeat) {
+            this.neededHeat = neededHeat;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Tech Reborn Blast Furnace recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 1, 2, 1, 2);
+            validateFluids(msg);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable BlastFurnaceRecipe register() {
+            if (!validate()) return null;
+            ItemStack output2 = output.size() >= 2 ? output.get(1) : null;
+            BlastFurnaceRecipe recipe = new BlastFurnaceRecipe(TechReborn.getStackFromIIngredient(input.get(0)), input.size() == 2 ? TechReborn.getStackFromIIngredient(input.get(1)) : null, output.get(0), output2, time, perTick, neededHeat);
+            ModSupport.TECH_REBORN.get().blastFurnace.add(recipe);
+            return recipe;
+        }
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/Centrifuge.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/Centrifuge.java
@@ -80,7 +80,7 @@ public class Centrifuge extends AbstractPraescriptumRegistry {
             if (!validate()) return null;
 
             Recipe recipe = Recipes.centrifuge.createRecipe();
-            recipe.withInput(input.stream().map(TechReborn::toInputIngredient).collect(Collectors.toList()));
+            recipe.withInput(input.stream().map(Helper::toInputIngredient).collect(Collectors.toList()));
             output.forEach(recipe::withOutput);
             recipe.withEnergyCostPerTick(perTick);
             recipe.withOperationDuration(time);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/Centrifuge.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/Centrifuge.java
@@ -1,0 +1,93 @@
+package com.cleanroommc.groovyscript.compat.mods.techreborn;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import org.jetbrains.annotations.Nullable;
+import reborncore.api.praescriptum.recipes.Recipe;
+import reborncore.api.praescriptum.recipes.RecipeHandler;
+import techreborn.api.recipe.Recipes;
+
+import java.util.stream.Collectors;
+
+@RegistryDescription
+public class Centrifuge extends AbstractPraescriptumRegistry {
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:clay'), item('minecraft:diamond') * 2).output(item('minecraft:gold_ingot'), item('minecraft:clay') * 5, item('minecraft:clay') * 2, item('minecraft:clay')).time(10).perTick(100)"),
+            @Example(".input(item('minecraft:diamond') * 3, item('minecraft:diamond') * 2).output(item('minecraft:clay') * 2).time(5).perTick(32)")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @Override
+    public RecipeHandler handler() {
+        return Recipes.centrifuge;
+    }
+
+    @Override
+    @MethodDescription(example = @Example("item('techreborn:dust:33')"))
+    public void removeByInput(IIngredient input) {
+        super.removeByInput(input);
+    }
+
+    @Override
+    @MethodDescription(example = @Example("item('techreborn:dynamiccell').withNbt(['Fluid': ['FluidName': 'fluidmethane', 'Amount': 1000]])"))
+    public void removeByOutput(IIngredient output) {
+        super.removeByOutput(output);
+    }
+
+    @Property(property = "input", valid = {@Comp(type = Comp.Type.GTE, value = "1"), @Comp(type = Comp.Type.LTE, value = "2")})
+    @Property(property = "output", valid = {@Comp(type = Comp.Type.GTE, value = "1"), @Comp(type = Comp.Type.LTE, value = "4")})
+    public static class RecipeBuilder extends AbstractRecipeBuilder<Recipe> {
+
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GT))
+        private int time;
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GT))
+        private int perTick;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder time(int time) {
+            this.time = time;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder perTick(int perTick) {
+            this.perTick = perTick;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Tech Reborn Centrifuge recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 1, 2, 1, 4);
+            validateFluids(msg);
+            msg.add(time <= 0, "time must be greater than 0, yet it was {}", time);
+            msg.add(perTick <= 0, "perTick must be greater than 0, yet it was {}", perTick);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable Recipe register() {
+            if (!validate()) return null;
+
+            Recipe recipe = Recipes.centrifuge.createRecipe();
+            recipe.withInput(input.stream().map(TechReborn::toInputIngredient).collect(Collectors.toList()));
+            output.forEach(recipe::withOutput);
+            recipe.withEnergyCostPerTick(perTick);
+            recipe.withOperationDuration(time);
+
+            ModSupport.TECH_REBORN.get().centrifuge.add(recipe);
+            return recipe;
+        }
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/ChemicalReactor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/ChemicalReactor.java
@@ -1,0 +1,93 @@
+package com.cleanroommc.groovyscript.compat.mods.techreborn;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import org.jetbrains.annotations.Nullable;
+import reborncore.api.praescriptum.recipes.Recipe;
+import reborncore.api.praescriptum.recipes.RecipeHandler;
+import techreborn.api.recipe.Recipes;
+
+import java.util.stream.Collectors;
+
+@RegistryDescription
+public class ChemicalReactor extends AbstractPraescriptumRegistry {
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:clay'), item('minecraft:diamond') * 2).output(item('minecraft:gold_ingot')).time(10).perTick(100)"),
+            @Example(".input(item('minecraft:diamond') * 3, item('minecraft:diamond') * 2).output(item('minecraft:clay') * 2).time(5).perTick(32)")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @Override
+    public RecipeHandler handler() {
+        return Recipes.chemicalReactor;
+    }
+
+    @Override
+    @MethodDescription(example = @Example("item('techreborn:dynamiccell').withNbt(['Fluid': ['FluidName': 'water', 'Amount': 1000]])"))
+    public void removeByInput(IIngredient input) {
+        super.removeByInput(input);
+    }
+
+    @Override
+    @MethodDescription(example = @Example("item('techreborn:dynamiccell').withNbt(['Fluid': ['FluidName': 'water', 'Amount': 1000]])"))
+    public void removeByOutput(IIngredient output) {
+        super.removeByOutput(output);
+    }
+
+    @Property(property = "input", valid = @Comp("2"))
+    @Property(property = "output", valid = @Comp("1"))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<Recipe> {
+
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GT))
+        private int time;
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GT))
+        private int perTick;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder time(int time) {
+            this.time = time;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder perTick(int perTick) {
+            this.perTick = perTick;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Tech Reborn Chemical Reactor recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 2, 2, 1, 1);
+            validateFluids(msg);
+            msg.add(time <= 0, "time must be greater than 0, yet it was {}", time);
+            msg.add(perTick <= 0, "perTick must be greater than 0, yet it was {}", perTick);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable Recipe register() {
+            if (!validate()) return null;
+
+            Recipe recipe = Recipes.chemicalReactor.createRecipe();
+            recipe.withInput(input.stream().map(TechReborn::toInputIngredient).collect(Collectors.toList()));
+            output.forEach(recipe::withOutput);
+            recipe.withEnergyCostPerTick(perTick);
+            recipe.withOperationDuration(time);
+
+            ModSupport.TECH_REBORN.get().chemicalReactor.add(recipe);
+            return recipe;
+        }
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/ChemicalReactor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/ChemicalReactor.java
@@ -80,7 +80,7 @@ public class ChemicalReactor extends AbstractPraescriptumRegistry {
             if (!validate()) return null;
 
             Recipe recipe = Recipes.chemicalReactor.createRecipe();
-            recipe.withInput(input.stream().map(TechReborn::toInputIngredient).collect(Collectors.toList()));
+            recipe.withInput(input.stream().map(Helper::toInputIngredient).collect(Collectors.toList()));
             output.forEach(recipe::withOutput);
             recipe.withEnergyCostPerTick(perTick);
             recipe.withOperationDuration(time);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/Compressor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/Compressor.java
@@ -1,0 +1,93 @@
+package com.cleanroommc.groovyscript.compat.mods.techreborn;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import org.jetbrains.annotations.Nullable;
+import reborncore.api.praescriptum.recipes.Recipe;
+import reborncore.api.praescriptum.recipes.RecipeHandler;
+import techreborn.api.recipe.Recipes;
+
+import java.util.stream.Collectors;
+
+@RegistryDescription
+public class Compressor extends AbstractPraescriptumRegistry {
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:clay')).output(item('minecraft:gold_ingot')).time(10).perTick(100)"),
+            @Example(".input(item('minecraft:diamond') * 3).output(item('minecraft:clay') * 2).time(5).perTick(32)")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @Override
+    public RecipeHandler handler() {
+        return Recipes.compressor;
+    }
+
+    @Override
+    @MethodDescription(example = @Example("item('minecraft:diamond')"))
+    public void removeByInput(IIngredient input) {
+        super.removeByInput(input);
+    }
+
+    @Override
+    @MethodDescription(example = @Example("item('techreborn:plates:36')"))
+    public void removeByOutput(IIngredient output) {
+        super.removeByOutput(output);
+    }
+
+    @Property(property = "input", valid = @Comp("1"))
+    @Property(property = "output", valid = @Comp("1"))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<Recipe> {
+
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GT))
+        private int time;
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GT))
+        private int perTick;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder time(int time) {
+            this.time = time;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder perTick(int perTick) {
+            this.perTick = perTick;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Tech Reborn Compressor recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 1, 1, 1, 1);
+            validateFluids(msg);
+            msg.add(time <= 0, "time must be greater than 0, yet it was {}", time);
+            msg.add(perTick <= 0, "perTick must be greater than 0, yet it was {}", perTick);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable Recipe register() {
+            if (!validate()) return null;
+
+            Recipe recipe = Recipes.compressor.createRecipe();
+            recipe.withInput(input.stream().map(TechReborn::toInputIngredient).collect(Collectors.toList()));
+            output.forEach(recipe::withOutput);
+            recipe.withEnergyCostPerTick(perTick);
+            recipe.withOperationDuration(time);
+
+            ModSupport.TECH_REBORN.get().compressor.add(recipe);
+            return recipe;
+        }
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/Compressor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/Compressor.java
@@ -80,7 +80,7 @@ public class Compressor extends AbstractPraescriptumRegistry {
             if (!validate()) return null;
 
             Recipe recipe = Recipes.compressor.createRecipe();
-            recipe.withInput(input.stream().map(TechReborn::toInputIngredient).collect(Collectors.toList()));
+            recipe.withInput(input.stream().map(Helper::toInputIngredient).collect(Collectors.toList()));
             output.forEach(recipe::withOutput);
             recipe.withEnergyCostPerTick(perTick);
             recipe.withOperationDuration(time);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/DieselGenerator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/DieselGenerator.java
@@ -1,0 +1,83 @@
+package com.cleanroommc.groovyscript.compat.mods.techreborn;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import org.jetbrains.annotations.Nullable;
+import reborncore.api.praescriptum.fuels.Fuel;
+import reborncore.api.praescriptum.fuels.FuelHandler;
+import techreborn.api.recipe.Fuels;
+
+@RegistryDescription
+public class DieselGenerator extends AbstractGeneratorRegistry {
+
+    @RecipeBuilderDescription(example = {
+            @Example(".fluidInput(fluid('water')).energy(10000).perTick(500)"),
+            @Example(".fluidInput(fluid('lava')).energy(200).perTick(10)")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @Override
+    public FuelHandler handler() {
+        return Fuels.dieselGenerator;
+    }
+
+    @Override
+    @MethodDescription(example = @Example("fluid('fluiddiesel')"))
+    public void removeByInput(IIngredient input) {
+        super.removeByInput(input);
+    }
+
+    @Property(property = "fluidInput", valid = @Comp("1"))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<Fuel> {
+
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GT))
+        private double energy;
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GT))
+        private double perTick;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder energy(double energy) {
+            this.energy = energy;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder perTick(double perTick) {
+            this.perTick = perTick;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Tech Reborn Diesel Generator recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg);
+            validateFluids(msg, 1, 1, 0, 0);
+            msg.add(energy <= 0, "energy must be greater than 0, yet it was {}", energy);
+            msg.add(perTick <= 0, "perTick must be greater than 0, yet it was {}", perTick);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable Fuel register() {
+            if (!validate()) return null;
+
+            Fuel recipe = Fuels.dieselGenerator.addFuel();
+            recipe.addFluidSource(fluidInput.get(0));
+            recipe.withEnergyPerTick(perTick);
+            recipe.withEnergyOutput(energy);
+
+            ModSupport.TECH_REBORN.get().dieselGenerator.add(recipe);
+            return recipe;
+        }
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/DistillationTower.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/DistillationTower.java
@@ -85,7 +85,7 @@ public class DistillationTower extends AbstractGenericTechRebornRegistry {
             ItemStack output2 = output.size() >= 2 ? output.get(1) : null;
             ItemStack output3 = output.size() >= 3 ? output.get(2) : null;
             ItemStack output4 = output.size() >= 4 ? output.get(3) : null;
-            DistillationTowerRecipe recipe = new DistillationTowerRecipe(TechReborn.getStackFromIIngredient(input.get(0)), input.size() >= 2 ? TechReborn.getStackFromIIngredient(input.get(1)) : null, output.get(0), output2, output3, output4, time, perTick, oreDict);
+            DistillationTowerRecipe recipe = new DistillationTowerRecipe(Helper.getStackFromIIngredient(input.get(0)), input.size() >= 2 ? Helper.getStackFromIIngredient(input.get(1)) : null, output.get(0), output2, output3, output4, time, perTick, oreDict);
             ModSupport.TECH_REBORN.get().distillationTower.add(recipe);
             return recipe;
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/DistillationTower.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/DistillationTower.java
@@ -1,0 +1,94 @@
+package com.cleanroommc.groovyscript.compat.mods.techreborn;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import net.minecraft.item.ItemStack;
+import org.jetbrains.annotations.Nullable;
+import techreborn.api.Reference;
+import techreborn.api.recipe.machines.DistillationTowerRecipe;
+
+@RegistryDescription
+public class DistillationTower extends AbstractGenericTechRebornRegistry {
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:clay'), item('minecraft:diamond') * 2).output(item('minecraft:gold_ingot'), item('minecraft:clay') * 5, item('minecraft:clay') * 2, item('minecraft:clay')).time(10).perTick(100)"),
+            @Example(".input(item('minecraft:diamond') * 3, item('minecraft:diamond') * 2).output(item('minecraft:clay') * 2).time(5).perTick(32)")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @Override
+    public String reference() {
+        return Reference.DISTILLATION_TOWER_RECIPE;
+    }
+
+    @Override
+    @MethodDescription(example = @Example("item('techreborn:dynamiccell').withNbt(['Fluid': ['FluidName': 'fluidoil', 'Amount': 1000]])"))
+    public void removeByInput(IIngredient input) {
+        super.removeByInput(input);
+    }
+
+    @Override
+    @MethodDescription(example = @Example(value = "item('techreborn:dynamiccell').withNbt(['Fluid': ['FluidName': 'fluidmethane', 'Amount': 1000]])", commented = true))
+    public void removeByOutput(IIngredient output) {
+        super.removeByOutput(output);
+    }
+
+    @Property(property = "input", valid = {@Comp(type = Comp.Type.GTE, value = "1"), @Comp(type = Comp.Type.LTE, value = "2")})
+    @Property(property = "output", valid = {@Comp(type = Comp.Type.GTE, value = "1"), @Comp(type = Comp.Type.LTE, value = "4")})
+    public static class RecipeBuilder extends AbstractRecipeBuilder<DistillationTowerRecipe> {
+
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GTE))
+        private int time;
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GTE))
+        private int perTick;
+        @Property
+        private boolean oreDict;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder time(int time) {
+            this.time = time;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder perTick(int perTick) {
+            this.perTick = perTick;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder oreDict(boolean oreDict) {
+            this.oreDict = oreDict;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Tech Reborn Distillation Tower recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 1, 2, 1, 4);
+            validateFluids(msg);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable DistillationTowerRecipe register() {
+            if (!validate()) return null;
+            ItemStack output2 = output.size() >= 2 ? output.get(1) : null;
+            ItemStack output3 = output.size() >= 3 ? output.get(2) : null;
+            ItemStack output4 = output.size() >= 4 ? output.get(3) : null;
+            DistillationTowerRecipe recipe = new DistillationTowerRecipe(TechReborn.getStackFromIIngredient(input.get(0)), input.size() >= 2 ? TechReborn.getStackFromIIngredient(input.get(1)) : null, output.get(0), output2, output3, output4, time, perTick, oreDict);
+            ModSupport.TECH_REBORN.get().distillationTower.add(recipe);
+            return recipe;
+        }
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/Extractor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/Extractor.java
@@ -1,0 +1,93 @@
+package com.cleanroommc.groovyscript.compat.mods.techreborn;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import org.jetbrains.annotations.Nullable;
+import reborncore.api.praescriptum.recipes.Recipe;
+import reborncore.api.praescriptum.recipes.RecipeHandler;
+import techreborn.api.recipe.Recipes;
+
+import java.util.stream.Collectors;
+
+@RegistryDescription
+public class Extractor extends AbstractPraescriptumRegistry {
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:clay')).output(item('minecraft:gold_ingot')).time(10).perTick(100)"),
+            @Example(".input(item('minecraft:diamond') * 3).output(item('minecraft:clay') * 2).time(5).perTick(32)")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @Override
+    public RecipeHandler handler() {
+        return Recipes.extractor;
+    }
+
+    @Override
+    @MethodDescription(example = @Example("item('minecraft:slime_ball')"))
+    public void removeByInput(IIngredient input) {
+        super.removeByInput(input);
+    }
+
+    @Override
+    @MethodDescription(example = @Example("item('minecraft:wool')"))
+    public void removeByOutput(IIngredient output) {
+        super.removeByOutput(output);
+    }
+
+    @Property(property = "input", valid = @Comp("1"))
+    @Property(property = "output", valid = @Comp("1"))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<Recipe> {
+
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GT))
+        private int time;
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GT))
+        private int perTick;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder time(int time) {
+            this.time = time;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder perTick(int perTick) {
+            this.perTick = perTick;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Tech Reborn Extractor recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 1, 1, 1, 1);
+            validateFluids(msg);
+            msg.add(time <= 0, "time must be greater than 0, yet it was {}", time);
+            msg.add(perTick <= 0, "perTick must be greater than 0, yet it was {}", perTick);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable Recipe register() {
+            if (!validate()) return null;
+
+            Recipe recipe = Recipes.extractor.createRecipe();
+            recipe.withInput(input.stream().map(TechReborn::toInputIngredient).collect(Collectors.toList()));
+            output.forEach(recipe::withOutput);
+            recipe.withEnergyCostPerTick(perTick);
+            recipe.withOperationDuration(time);
+
+            ModSupport.TECH_REBORN.get().extractor.add(recipe);
+            return recipe;
+        }
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/Extractor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/Extractor.java
@@ -80,7 +80,7 @@ public class Extractor extends AbstractPraescriptumRegistry {
             if (!validate()) return null;
 
             Recipe recipe = Recipes.extractor.createRecipe();
-            recipe.withInput(input.stream().map(TechReborn::toInputIngredient).collect(Collectors.toList()));
+            recipe.withInput(input.stream().map(Helper::toInputIngredient).collect(Collectors.toList()));
             output.forEach(recipe::withOutput);
             recipe.withEnergyCostPerTick(perTick);
             recipe.withOperationDuration(time);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/FluidReplicator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/FluidReplicator.java
@@ -1,0 +1,112 @@
+package com.cleanroommc.groovyscript.compat.mods.techreborn;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import net.minecraftforge.fluids.FluidStack;
+import org.jetbrains.annotations.Nullable;
+import techreborn.api.fluidreplicator.FluidReplicatorRecipe;
+import techreborn.api.fluidreplicator.FluidReplicatorRecipeList;
+
+@RegistryDescription
+public class FluidReplicator extends VirtualizedRegistry<FluidReplicatorRecipe> {
+
+    @RecipeBuilderDescription(example = {
+            @Example(".matter(10).fluidOutput(fluid('water')).time(100).perTick(10)"),
+            @Example(".matter(1).fluidOutput(fluid('fluidmethane')).time(5).perTick(1000)")
+    })
+    public static RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @Override
+    public void onReload() {
+        FluidReplicatorRecipeList.recipes.removeAll(removeScripted());
+        FluidReplicatorRecipeList.recipes.addAll(restoreFromBackup());
+    }
+
+    public void add(FluidReplicatorRecipe recipe) {
+        FluidReplicatorRecipeList.recipes.add(recipe);
+        addScripted(recipe);
+    }
+
+    public boolean remove(FluidReplicatorRecipe recipe) {
+        addBackup(recipe);
+        return FluidReplicatorRecipeList.recipes.remove(recipe);
+    }
+
+    @MethodDescription(example = @Example("fluid('water')"))
+    public boolean removeByOutput(FluidStack output) {
+        return FluidReplicatorRecipeList.recipes.removeIf(entry -> {
+            if (output.getFluid().equals(entry.getFluid())) {
+                addBackup(entry);
+                return true;
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
+    public void removeAll() {
+        FluidReplicatorRecipeList.recipes.forEach(this::addBackup);
+        FluidReplicatorRecipeList.recipes.clear();
+    }
+
+    @MethodDescription(type = MethodDescription.Type.QUERY)
+    public SimpleObjectStream<FluidReplicatorRecipe> streamRecipes() {
+        return new SimpleObjectStream<>(FluidReplicatorRecipeList.recipes).setRemover(this::remove);
+    }
+
+    @Property(property = "fluidOutput", valid = @Comp("1"))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<FluidReplicatorRecipe> {
+
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GTE))
+        private int matter;
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GTE))
+        private int time;
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GTE))
+        private int perTick;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder matter(int matter) {
+            this.matter = matter;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder time(int time) {
+            this.time = time;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder perTick(int perTick) {
+            this.perTick = perTick;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Tech Reborn Fluid Replicator recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg);
+            validateFluids(msg, 0, 0, 1, 1);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable FluidReplicatorRecipe register() {
+            if (!validate()) return null;
+            FluidReplicatorRecipe recipe = new FluidReplicatorRecipe(matter, fluidOutput.get(0).getFluid(), time, perTick);
+            ModSupport.TECH_REBORN.get().fluidReplicator.add(recipe);
+            return recipe;
+        }
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/FusionReactor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/FusionReactor.java
@@ -1,0 +1,139 @@
+package com.cleanroommc.groovyscript.compat.mods.techreborn;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import net.minecraft.item.ItemStack;
+import org.jetbrains.annotations.Nullable;
+import techreborn.api.reactor.FusionReactorRecipe;
+import techreborn.api.reactor.FusionReactorRecipeHelper;
+
+@RegistryDescription
+public class FusionReactor extends VirtualizedRegistry<FusionReactorRecipe> {
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:clay'), item('minecraft:diamond') * 2).output(item('minecraft:gold_ingot')).time(10).perTick(-25000).start(200).size(30)"),
+            @Example(".input(item('minecraft:diamond') * 3, item('minecraft:diamond') * 2).output(item('minecraft:clay') * 2).time(5).perTick(30000).start(1000000)")
+    })
+    public static RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @Override
+    public void onReload() {
+        FusionReactorRecipeHelper.reactorRecipes.removeAll(removeScripted());
+        FusionReactorRecipeHelper.reactorRecipes.addAll(restoreFromBackup());
+    }
+
+    public void add(FusionReactorRecipe recipe) {
+        FusionReactorRecipeHelper.reactorRecipes.add(recipe);
+        addScripted(recipe);
+    }
+
+    public boolean remove(FusionReactorRecipe recipe) {
+        addBackup(recipe);
+        return FusionReactorRecipeHelper.reactorRecipes.remove(recipe);
+    }
+
+    @MethodDescription(example = @Example("item('techreborn:part:17')"))
+    public boolean removeByInput(IIngredient input) {
+        return FusionReactorRecipeHelper.reactorRecipes.removeIf(entry -> {
+            if (input.test(entry.getTopInput()) || input.test(entry.getBottomInput())) {
+                addBackup(entry);
+                return true;
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(example = @Example("item('techreborn:ore:1')"))
+    public boolean removeByOutput(IIngredient output) {
+        return FusionReactorRecipeHelper.reactorRecipes.removeIf(entry -> {
+            if (output.test(entry.getOutput())) {
+                addBackup(entry);
+                return true;
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
+    public void removeAll() {
+        FusionReactorRecipeHelper.reactorRecipes.forEach(this::addBackup);
+        FusionReactorRecipeHelper.reactorRecipes.clear();
+    }
+
+    @MethodDescription(type = MethodDescription.Type.QUERY)
+    public SimpleObjectStream<FusionReactorRecipe> streamRecipes() {
+        return new SimpleObjectStream<>(FusionReactorRecipeHelper.reactorRecipes).setRemover(this::remove);
+    }
+
+    @Property(property = "input", valid = @Comp("2"))
+    @Property(property = "output", valid = @Comp("1"))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<FusionReactorRecipe> {
+
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GTE))
+        private int start;
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GTE))
+        private int time;
+        @Property
+        private int perTick;
+        @Property(valid = {@Comp(value = "0", type = Comp.Type.GTE), @Comp(value = "50", type = Comp.Type.LTE)})
+        private int size;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder start(int start) {
+            this.start = start;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder time(int time) {
+            this.time = time;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder perTick(int perTick) {
+            this.perTick = perTick;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder size(int size) {
+            this.size = size;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Tech Reborn Fusion Reactor recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 2, 2, 1, 1);
+            validateFluids(msg);
+            msg.add(size < 0 || size > 50, "size must greater than or equal to 0 and less than or equal to 50, yet it was {}", size);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable FusionReactorRecipe register() {
+            if (!validate()) return null;
+            FusionReactorRecipe recipe = null;
+            for (ItemStack top : input.get(0).getMatchingStacks()) {
+                for (ItemStack bottom : input.get(1).getMatchingStacks()) {
+                    recipe = new FusionReactorRecipe(top, bottom, output.get(0), start, perTick, time, size);
+                    ModSupport.TECH_REBORN.get().fusionReactor.add(recipe);
+                }
+            }
+            return recipe;
+        }
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/GasTurbine.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/GasTurbine.java
@@ -1,0 +1,83 @@
+package com.cleanroommc.groovyscript.compat.mods.techreborn;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import org.jetbrains.annotations.Nullable;
+import reborncore.api.praescriptum.fuels.Fuel;
+import reborncore.api.praescriptum.fuels.FuelHandler;
+import techreborn.api.recipe.Fuels;
+
+@RegistryDescription
+public class GasTurbine extends AbstractGeneratorRegistry {
+
+    @RecipeBuilderDescription(example = {
+            @Example(".fluidInput(fluid('water')).energy(10000).perTick(500)"),
+            @Example(".fluidInput(fluid('lava')).energy(200).perTick(10)")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @Override
+    public FuelHandler handler() {
+        return Fuels.gasTurbine;
+    }
+
+    @Override
+    @MethodDescription(example = @Example("fluid('fluidhydrogen')"))
+    public void removeByInput(IIngredient input) {
+        super.removeByInput(input);
+    }
+
+    @Property(property = "fluidInput", valid = @Comp("1"))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<Fuel> {
+
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GT))
+        private double energy;
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GT))
+        private double perTick;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder energy(double energy) {
+            this.energy = energy;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder perTick(double perTick) {
+            this.perTick = perTick;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Tech Reborn Gas Turbine recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg);
+            validateFluids(msg, 1, 1, 0, 0);
+            msg.add(energy <= 0, "energy must be greater than 0, yet it was {}", energy);
+            msg.add(perTick <= 0, "perTick must be greater than 0, yet it was {}", perTick);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable Fuel register() {
+            if (!validate()) return null;
+
+            Fuel recipe = Fuels.gasTurbine.addFuel();
+            recipe.addFluidSource(fluidInput.get(0));
+            recipe.withEnergyPerTick(perTick);
+            recipe.withEnergyOutput(energy);
+
+            ModSupport.TECH_REBORN.get().gasTurbine.add(recipe);
+            return recipe;
+        }
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/Grinder.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/Grinder.java
@@ -80,7 +80,7 @@ public class Grinder extends AbstractPraescriptumRegistry {
             if (!validate()) return null;
 
             Recipe recipe = Recipes.grinder.createRecipe();
-            recipe.withInput(input.stream().map(TechReborn::toInputIngredient).collect(Collectors.toList()));
+            recipe.withInput(input.stream().map(Helper::toInputIngredient).collect(Collectors.toList()));
             output.forEach(recipe::withOutput);
             recipe.withEnergyCostPerTick(perTick);
             recipe.withOperationDuration(time);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/Grinder.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/Grinder.java
@@ -1,0 +1,93 @@
+package com.cleanroommc.groovyscript.compat.mods.techreborn;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import org.jetbrains.annotations.Nullable;
+import reborncore.api.praescriptum.recipes.Recipe;
+import reborncore.api.praescriptum.recipes.RecipeHandler;
+import techreborn.api.recipe.Recipes;
+
+import java.util.stream.Collectors;
+
+@RegistryDescription
+public class Grinder extends AbstractPraescriptumRegistry {
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:clay')).output(item('minecraft:gold_ingot')).time(10).perTick(100)"),
+            @Example(".input(item('minecraft:diamond') * 3).output(item('minecraft:clay') * 2).time(5).perTick(32)")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @Override
+    public RecipeHandler handler() {
+        return Recipes.grinder;
+    }
+
+    @Override
+    @MethodDescription(example = @Example("item('minecraft:coal_ore')"))
+    public void removeByInput(IIngredient input) {
+        super.removeByInput(input);
+    }
+
+    @Override
+    @MethodDescription(example = @Example("item('minecraft:diamond')"))
+    public void removeByOutput(IIngredient output) {
+        super.removeByOutput(output);
+    }
+
+    @Property(property = "input", valid = @Comp("1"))
+    @Property(property = "output", valid = @Comp("1"))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<Recipe> {
+
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GT))
+        private int time;
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GT))
+        private int perTick;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder time(int time) {
+            this.time = time;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder perTick(int perTick) {
+            this.perTick = perTick;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Tech Reborn Grinder recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 1, 1, 1, 1);
+            validateFluids(msg);
+            msg.add(time <= 0, "time must be greater than 0, yet it was {}", time);
+            msg.add(perTick <= 0, "perTick must be greater than 0, yet it was {}", perTick);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable Recipe register() {
+            if (!validate()) return null;
+
+            Recipe recipe = Recipes.grinder.createRecipe();
+            recipe.withInput(input.stream().map(TechReborn::toInputIngredient).collect(Collectors.toList()));
+            output.forEach(recipe::withOutput);
+            recipe.withEnergyCostPerTick(perTick);
+            recipe.withOperationDuration(time);
+
+            ModSupport.TECH_REBORN.get().grinder.add(recipe);
+            return recipe;
+        }
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/Helper.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/Helper.java
@@ -1,0 +1,35 @@
+package com.cleanroommc.groovyscript.compat.mods.techreborn;
+
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
+import com.cleanroommc.groovyscript.helper.ingredient.OreDictIngredient;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.oredict.OreDictionary;
+import reborncore.api.praescriptum.ingredients.input.FluidStackInputIngredient;
+import reborncore.api.praescriptum.ingredients.input.InputIngredient;
+import reborncore.api.praescriptum.ingredients.input.ItemStackInputIngredient;
+import reborncore.api.praescriptum.ingredients.input.OreDictionaryInputIngredient;
+
+public class Helper {
+
+    public static ItemStack getStackFromIIngredient(IIngredient ingredient) {
+        if (ingredient instanceof OreDictIngredient oreDictIngredient) {
+            if (OreDictionary.doesOreNameExist(oreDictIngredient.getOreDict())) {
+                return OreDictionary.getOres(oreDictIngredient.getOreDict()).get(0).copy();
+            }
+        }
+        if (IngredientHelper.isItem(ingredient)) {
+            return IngredientHelper.toItemStack(ingredient);
+        }
+        if (ingredient.getMatchingStacks().length > 0) return ingredient.getMatchingStacks()[0];
+        return ItemStack.EMPTY;
+    }
+
+    public static InputIngredient<?> toInputIngredient(IIngredient ingredient) {
+        if (ingredient instanceof OreDictIngredient ore) return OreDictionaryInputIngredient.of(ore.getOreDict(), ore.getAmount());
+        if (ingredient instanceof FluidStack fluid) return FluidStackInputIngredient.of(fluid);
+        if (IngredientHelper.isItem(ingredient)) return ItemStackInputIngredient.of(IngredientHelper.toItemStack(ingredient));
+        return ItemStackInputIngredient.of(ItemStack.EMPTY);
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/ImplosionCompressor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/ImplosionCompressor.java
@@ -1,0 +1,84 @@
+package com.cleanroommc.groovyscript.compat.mods.techreborn;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import net.minecraft.item.ItemStack;
+import org.jetbrains.annotations.Nullable;
+import techreborn.api.Reference;
+import techreborn.api.recipe.machines.ImplosionCompressorRecipe;
+
+@RegistryDescription
+public class ImplosionCompressor extends AbstractGenericTechRebornRegistry {
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:clay'), item('minecraft:diamond') * 2).output(item('minecraft:gold_ingot')).time(10).perTick(100)"),
+            @Example(".input(item('minecraft:diamond') * 3, item('minecraft:diamond') * 2).output(item('minecraft:clay') * 2).time(5).perTick(32)")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @Override
+    public String reference() {
+        return Reference.IMPLOSION_COMPRESSOR_RECIPE;
+    }
+
+    @Override
+    @MethodDescription(example = @Example("item('techreborn:ingot:22')"))
+    public void removeByInput(IIngredient input) {
+        super.removeByInput(input);
+    }
+
+    @Override
+    @MethodDescription(example = @Example("item('minecraft:diamond')"))
+    public void removeByOutput(IIngredient output) {
+        super.removeByOutput(output);
+    }
+
+    @Property(property = "input", valid = {@Comp(type = Comp.Type.GTE, value = "1"), @Comp(type = Comp.Type.LTE, value = "2")})
+    @Property(property = "output", valid = {@Comp(type = Comp.Type.GTE, value = "1"), @Comp(type = Comp.Type.LTE, value = "2")})
+    public static class RecipeBuilder extends AbstractRecipeBuilder<ImplosionCompressorRecipe> {
+
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GTE))
+        private int time;
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GTE))
+        private int perTick;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder time(int time) {
+            this.time = time;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder perTick(int perTick) {
+            this.perTick = perTick;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Tech Reborn Implosion Compressor recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 1, 2, 1, 2);
+            validateFluids(msg);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable ImplosionCompressorRecipe register() {
+            if (!validate()) return null;
+            ItemStack output2 = output.size() >= 2 ? output.get(1) : null;
+            ImplosionCompressorRecipe recipe = new ImplosionCompressorRecipe(TechReborn.getStackFromIIngredient(input.get(0)), input.size() >= 2 ? TechReborn.getStackFromIIngredient(input.get(1)) : null, output.get(0), output2, time, perTick);
+            ModSupport.TECH_REBORN.get().implosionCompressor.add(recipe);
+            return recipe;
+        }
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/ImplosionCompressor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/ImplosionCompressor.java
@@ -75,7 +75,7 @@ public class ImplosionCompressor extends AbstractGenericTechRebornRegistry {
         public @Nullable ImplosionCompressorRecipe register() {
             if (!validate()) return null;
             ItemStack output2 = output.size() >= 2 ? output.get(1) : null;
-            ImplosionCompressorRecipe recipe = new ImplosionCompressorRecipe(TechReborn.getStackFromIIngredient(input.get(0)), input.size() >= 2 ? TechReborn.getStackFromIIngredient(input.get(1)) : null, output.get(0), output2, time, perTick);
+            ImplosionCompressorRecipe recipe = new ImplosionCompressorRecipe(Helper.getStackFromIIngredient(input.get(0)), input.size() >= 2 ? Helper.getStackFromIIngredient(input.get(1)) : null, output.get(0), output2, time, perTick);
             ModSupport.TECH_REBORN.get().implosionCompressor.add(recipe);
             return recipe;
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/IndustrialElectrolyzer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/IndustrialElectrolyzer.java
@@ -85,7 +85,7 @@ public class IndustrialElectrolyzer extends AbstractGenericTechRebornRegistry {
             ItemStack output2 = output.size() >= 2 ? output.get(1) : null;
             ItemStack output3 = output.size() >= 3 ? output.get(2) : null;
             ItemStack output4 = output.size() >= 4 ? output.get(3) : null;
-            IndustrialElectrolyzerRecipe recipe = new IndustrialElectrolyzerRecipe(TechReborn.getStackFromIIngredient(input.get(0)), TechReborn.getStackFromIIngredient(input.get(1)), output.get(0), output2, output3, output4, time, perTick, oreDict);
+            IndustrialElectrolyzerRecipe recipe = new IndustrialElectrolyzerRecipe(Helper.getStackFromIIngredient(input.get(0)), Helper.getStackFromIIngredient(input.get(1)), output.get(0), output2, output3, output4, time, perTick, oreDict);
             ModSupport.TECH_REBORN.get().industrialElectrolyzer.add(recipe);
             return recipe;
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/IndustrialElectrolyzer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/IndustrialElectrolyzer.java
@@ -1,0 +1,94 @@
+package com.cleanroommc.groovyscript.compat.mods.techreborn;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import net.minecraft.item.ItemStack;
+import org.jetbrains.annotations.Nullable;
+import techreborn.api.Reference;
+import techreborn.api.recipe.machines.IndustrialElectrolyzerRecipe;
+
+@RegistryDescription
+public class IndustrialElectrolyzer extends AbstractGenericTechRebornRegistry {
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:clay'), item('minecraft:diamond') * 2).output(item('minecraft:gold_ingot'), item('minecraft:clay') * 5, item('minecraft:clay') * 2, item('minecraft:clay')).time(10).perTick(100)"),
+            @Example(".input(item('minecraft:diamond') * 3, item('minecraft:diamond') * 2).output(item('minecraft:clay') * 2).time(5).perTick(32)")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @Override
+    public String reference() {
+        return Reference.INDUSTRIAL_ELECTROLYZER_RECIPE;
+    }
+
+    @Override
+    @MethodDescription(example = @Example("item('minecraft:dye:15')"))
+    public void removeByInput(IIngredient input) {
+        super.removeByInput(input);
+    }
+
+    @Override
+    @MethodDescription(example = @Example("item('techreborn:dust:1')"))
+    public void removeByOutput(IIngredient output) {
+        super.removeByOutput(output);
+    }
+
+    @Property(property = "input", valid = {@Comp(type = Comp.Type.GTE, value = "1"), @Comp(type = Comp.Type.LTE, value = "2")})
+    @Property(property = "output", valid = {@Comp(type = Comp.Type.GTE, value = "1"), @Comp(type = Comp.Type.LTE, value = "4")})
+    public static class RecipeBuilder extends AbstractRecipeBuilder<IndustrialElectrolyzerRecipe> {
+
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GTE))
+        private int time;
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GTE))
+        private int perTick;
+        @Property
+        private boolean oreDict;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder time(int time) {
+            this.time = time;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder perTick(int perTick) {
+            this.perTick = perTick;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder oreDict(boolean oreDict) {
+            this.oreDict = oreDict;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Tech Reborn Industrial Electrolyzer recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 1, 2, 1, 4);
+            validateFluids(msg);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable IndustrialElectrolyzerRecipe register() {
+            if (!validate()) return null;
+            ItemStack output2 = output.size() >= 2 ? output.get(1) : null;
+            ItemStack output3 = output.size() >= 3 ? output.get(2) : null;
+            ItemStack output4 = output.size() >= 4 ? output.get(3) : null;
+            IndustrialElectrolyzerRecipe recipe = new IndustrialElectrolyzerRecipe(TechReborn.getStackFromIIngredient(input.get(0)), TechReborn.getStackFromIIngredient(input.get(1)), output.get(0), output2, output3, output4, time, perTick, oreDict);
+            ModSupport.TECH_REBORN.get().industrialElectrolyzer.add(recipe);
+            return recipe;
+        }
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/IndustrialGrinder.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/IndustrialGrinder.java
@@ -99,7 +99,7 @@ public class IndustrialGrinder extends AbstractGenericTechRebornRegistry {
             ItemStack output2 = output.size() >= 2 ? output.get(1) : null;
             ItemStack output3 = output.size() >= 3 ? output.get(2) : null;
             ItemStack output4 = output.size() >= 4 ? output.get(3) : null;
-            IndustrialGrinderRecipe recipe = new IndustrialGrinderRecipe(TechReborn.getStackFromIIngredient(input.get(0)), fluidInput.get(0), output.get(0), output2, output3, output4, time, perTick, oreDict);
+            IndustrialGrinderRecipe recipe = new IndustrialGrinderRecipe(Helper.getStackFromIIngredient(input.get(0)), fluidInput.get(0), output.get(0), output2, output3, output4, time, perTick, oreDict);
             ModSupport.TECH_REBORN.get().industrialGrinder.add(recipe);
             return recipe;
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/IndustrialGrinder.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/IndustrialGrinder.java
@@ -1,0 +1,108 @@
+package com.cleanroommc.groovyscript.compat.mods.techreborn;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import net.minecraft.item.ItemStack;
+import org.jetbrains.annotations.Nullable;
+import reborncore.api.recipe.RecipeHandler;
+import techreborn.api.Reference;
+import techreborn.api.recipe.machines.IndustrialGrinderRecipe;
+
+@RegistryDescription
+public class IndustrialGrinder extends AbstractGenericTechRebornRegistry {
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:clay')).fluidInput(fluid('lava') * 50).output(item('minecraft:gold_ingot'), item('minecraft:clay') * 5, item('minecraft:clay') * 2, item('minecraft:clay')).time(10).perTick(100)"),
+            @Example(".input(item('minecraft:diamond') * 3).fluidInput(fluid('water') * 250).output(item('minecraft:clay') * 2).time(5).perTick(32)")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @Override
+    public String reference() {
+        return Reference.INDUSTRIAL_GRINDER_RECIPE;
+    }
+
+    @Override
+    @MethodDescription(example = {
+            @Example("fluid('water')"),
+            @Example("item('techreborn:ore2')")
+    })
+    public void removeByInput(IIngredient input) {
+        super.removeByInput(input);
+        RecipeHandler.recipeList.removeIf(recipe -> {
+            if (recipe.getRecipeName().equals(reference()) && recipe instanceof IndustrialGrinderRecipe grinderRecipe) {
+                if (input.test(grinderRecipe.fluidStack)) {
+                    addBackup(recipe);
+                    return true;
+                }
+            }
+            return false;
+        });
+    }
+
+    @Override
+    @MethodDescription(example = @Example("item('techreborn:dust:53')"))
+    public void removeByOutput(IIngredient output) {
+        super.removeByOutput(output);
+    }
+
+    @Property(property = "input", valid = @Comp("1"))
+    @Property(property = "fluidInput", valid = @Comp("1"))
+    @Property(property = "output", valid = {@Comp(type = Comp.Type.GTE, value = "1"), @Comp(type = Comp.Type.LTE, value = "4")})
+    public static class RecipeBuilder extends AbstractRecipeBuilder<IndustrialGrinderRecipe> {
+
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GTE))
+        private int time;
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GTE))
+        private int perTick;
+        @Property
+        private boolean oreDict;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder time(int time) {
+            this.time = time;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder perTick(int perTick) {
+            this.perTick = perTick;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder oreDict(boolean oreDict) {
+            this.oreDict = oreDict;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Tech Reborn Industrial Grinder recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 1, 1, 1, 4);
+            validateFluids(msg, 1, 1, 0, 0);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable IndustrialGrinderRecipe register() {
+            if (!validate()) return null;
+            ItemStack output2 = output.size() >= 2 ? output.get(1) : null;
+            ItemStack output3 = output.size() >= 3 ? output.get(2) : null;
+            ItemStack output4 = output.size() >= 4 ? output.get(3) : null;
+            IndustrialGrinderRecipe recipe = new IndustrialGrinderRecipe(TechReborn.getStackFromIIngredient(input.get(0)), fluidInput.get(0), output.get(0), output2, output3, output4, time, perTick, oreDict);
+            ModSupport.TECH_REBORN.get().industrialGrinder.add(recipe);
+            return recipe;
+        }
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/IndustrialSawmill.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/IndustrialSawmill.java
@@ -98,7 +98,7 @@ public class IndustrialSawmill extends AbstractGenericTechRebornRegistry {
             if (!validate()) return null;
             ItemStack output2 = output.size() >= 2 ? output.get(1) : null;
             ItemStack output3 = output.size() >= 3 ? output.get(2) : null;
-            IndustrialSawmillRecipe recipe = new IndustrialSawmillRecipe(TechReborn.getStackFromIIngredient(input.get(0)), fluidInput.get(0), output.get(0), output2, output3, time, perTick, oreDict);
+            IndustrialSawmillRecipe recipe = new IndustrialSawmillRecipe(Helper.getStackFromIIngredient(input.get(0)), fluidInput.get(0), output.get(0), output2, output3, time, perTick, oreDict);
             ModSupport.TECH_REBORN.get().industrialSawmill.add(recipe);
             return recipe;
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/IndustrialSawmill.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/IndustrialSawmill.java
@@ -1,0 +1,107 @@
+package com.cleanroommc.groovyscript.compat.mods.techreborn;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import net.minecraft.item.ItemStack;
+import org.jetbrains.annotations.Nullable;
+import reborncore.api.recipe.RecipeHandler;
+import techreborn.api.Reference;
+import techreborn.api.recipe.machines.IndustrialSawmillRecipe;
+
+@RegistryDescription
+public class IndustrialSawmill extends AbstractGenericTechRebornRegistry {
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:clay')).fluidInput(fluid('lava') * 100).output(item('minecraft:gold_ingot'), item('minecraft:clay') * 5, item('minecraft:clay')).time(10).perTick(100)"),
+            @Example(".input(item('minecraft:diamond') * 3).fluidInput(fluid('water') * 500).output(item('minecraft:clay') * 2).time(5).perTick(32)")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @Override
+    public String reference() {
+        return Reference.INDUSTRIAL_SAWMILL_RECIPE;
+    }
+
+    @Override
+    @MethodDescription(example = {
+            @Example("fluid('water')"),
+            @Example("item('minecraft:log')")
+    })
+    public void removeByInput(IIngredient input) {
+        super.removeByInput(input);
+        RecipeHandler.recipeList.removeIf(recipe -> {
+            if (recipe.getRecipeName().equals(reference()) && recipe instanceof IndustrialSawmillRecipe sawmillRecipe) {
+                if (input.test(sawmillRecipe.fluidStack)) {
+                    addBackup(recipe);
+                    return true;
+                }
+            }
+            return false;
+        });
+    }
+
+    @Override
+    @MethodDescription(example = @Example("item('minecraft:planks:4')"))
+    public void removeByOutput(IIngredient output) {
+        super.removeByOutput(output);
+    }
+
+    @Property(property = "input", valid = @Comp("1"))
+    @Property(property = "fluidInput", valid = @Comp("1"))
+    @Property(property = "output", valid = {@Comp(type = Comp.Type.GTE, value = "1"), @Comp(type = Comp.Type.LTE, value = "3")})
+    public static class RecipeBuilder extends AbstractRecipeBuilder<IndustrialSawmillRecipe> {
+
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GTE))
+        private int time;
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GTE))
+        private int perTick;
+        @Property
+        private boolean oreDict;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder time(int time) {
+            this.time = time;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder perTick(int perTick) {
+            this.perTick = perTick;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder oreDict(boolean oreDict) {
+            this.oreDict = oreDict;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Tech Reborn Industrial Sawmill recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 1, 1, 1, 3);
+            validateFluids(msg, 1, 1, 0, 0);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable IndustrialSawmillRecipe register() {
+            if (!validate()) return null;
+            ItemStack output2 = output.size() >= 2 ? output.get(1) : null;
+            ItemStack output3 = output.size() >= 3 ? output.get(2) : null;
+            IndustrialSawmillRecipe recipe = new IndustrialSawmillRecipe(TechReborn.getStackFromIIngredient(input.get(0)), fluidInput.get(0), output.get(0), output2, output3, time, perTick, oreDict);
+            ModSupport.TECH_REBORN.get().industrialSawmill.add(recipe);
+            return recipe;
+        }
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/PlasmaGenerator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/PlasmaGenerator.java
@@ -1,0 +1,83 @@
+package com.cleanroommc.groovyscript.compat.mods.techreborn;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import org.jetbrains.annotations.Nullable;
+import reborncore.api.praescriptum.fuels.Fuel;
+import reborncore.api.praescriptum.fuels.FuelHandler;
+import techreborn.api.recipe.Fuels;
+
+@RegistryDescription
+public class PlasmaGenerator extends AbstractGeneratorRegistry {
+
+    @RecipeBuilderDescription(example = {
+            @Example(".fluidInput(fluid('water')).energy(10000).perTick(500)"),
+            @Example(".fluidInput(fluid('lava')).energy(200).perTick(10)")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @Override
+    public FuelHandler handler() {
+        return Fuels.plasmaGenerator;
+    }
+
+    @Override
+    @MethodDescription(example = @Example("fluid('fluidheliumplasma')"))
+    public void removeByInput(IIngredient input) {
+        super.removeByInput(input);
+    }
+
+    @Property(property = "fluidInput", valid = @Comp("1"))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<Fuel> {
+
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GT))
+        private double energy;
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GT))
+        private double perTick;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder energy(double energy) {
+            this.energy = energy;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder perTick(double perTick) {
+            this.perTick = perTick;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Tech Reborn Plasma Generator recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg);
+            validateFluids(msg, 1, 1, 0, 0);
+            msg.add(energy <= 0, "energy must be greater than 0, yet it was {}", energy);
+            msg.add(perTick <= 0, "perTick must be greater than 0, yet it was {}", perTick);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable Fuel register() {
+            if (!validate()) return null;
+
+            Fuel recipe = Fuels.plasmaGenerator.addFuel();
+            recipe.addFluidSource(fluidInput.get(0));
+            recipe.withEnergyPerTick(perTick);
+            recipe.withEnergyOutput(energy);
+
+            ModSupport.TECH_REBORN.get().plasmaGenerator.add(recipe);
+            return recipe;
+        }
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/PlateBendingMachine.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/PlateBendingMachine.java
@@ -1,0 +1,93 @@
+package com.cleanroommc.groovyscript.compat.mods.techreborn;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import org.jetbrains.annotations.Nullable;
+import reborncore.api.praescriptum.recipes.Recipe;
+import reborncore.api.praescriptum.recipes.RecipeHandler;
+import techreborn.api.recipe.Recipes;
+
+import java.util.stream.Collectors;
+
+@RegistryDescription
+public class PlateBendingMachine extends AbstractPraescriptumRegistry {
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:clay')).output(item('minecraft:gold_ingot')).time(10).perTick(100)"),
+            @Example(".input(item('minecraft:diamond') * 3).output(item('minecraft:clay') * 2).time(5).perTick(32)")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @Override
+    public RecipeHandler handler() {
+        return Recipes.plateBendingMachine;
+    }
+
+    @Override
+    @MethodDescription(example = @Example("item('minecraft:gold_ingot')"))
+    public void removeByInput(IIngredient input) {
+        super.removeByInput(input);
+    }
+
+    @Override
+    @MethodDescription(example = @Example("item('techreborn:plates:36')"))
+    public void removeByOutput(IIngredient output) {
+        super.removeByOutput(output);
+    }
+
+    @Property(property = "input", valid = @Comp("1"))
+    @Property(property = "output", valid = @Comp("1"))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<Recipe> {
+
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GT))
+        private int time;
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GT))
+        private int perTick;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder time(int time) {
+            this.time = time;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder perTick(int perTick) {
+            this.perTick = perTick;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Tech Reborn Plate Bending Machine recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 1, 1, 1, 1);
+            validateFluids(msg);
+            msg.add(time <= 0, "time must be greater than 0, yet it was {}", time);
+            msg.add(perTick <= 0, "perTick must be greater than 0, yet it was {}", perTick);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable Recipe register() {
+            if (!validate()) return null;
+
+            Recipe recipe = Recipes.plateBendingMachine.createRecipe();
+            recipe.withInput(input.stream().map(TechReborn::toInputIngredient).collect(Collectors.toList()));
+            output.forEach(recipe::withOutput);
+            recipe.withEnergyCostPerTick(perTick);
+            recipe.withOperationDuration(time);
+
+            ModSupport.TECH_REBORN.get().plateBendingMachine.add(recipe);
+            return recipe;
+        }
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/PlateBendingMachine.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/PlateBendingMachine.java
@@ -80,7 +80,7 @@ public class PlateBendingMachine extends AbstractPraescriptumRegistry {
             if (!validate()) return null;
 
             Recipe recipe = Recipes.plateBendingMachine.createRecipe();
-            recipe.withInput(input.stream().map(TechReborn::toInputIngredient).collect(Collectors.toList()));
+            recipe.withInput(input.stream().map(Helper::toInputIngredient).collect(Collectors.toList()));
             output.forEach(recipe::withOutput);
             recipe.withEnergyCostPerTick(perTick);
             recipe.withOperationDuration(time);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/RollingMachine.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/RollingMachine.java
@@ -7,7 +7,6 @@ import com.cleanroommc.groovyscript.api.documentation.annotations.RecipeBuilderD
 import com.cleanroommc.groovyscript.api.documentation.annotations.RegistryDescription;
 import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
-import mezz.jei.api.IJeiHelpers;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.util.ResourceLocation;
@@ -17,19 +16,6 @@ import techreborn.api.RollingMachineRecipe;
 import java.util.List;
 import java.util.Map;
 
-/**
- * TODO:
- *  {@link techreborn.compat.jei.rollingMachine.RollingMachineRecipeWrapper#create(IJeiHelpers, IRecipe)}
- *  specifies what recipe wrappers can be used
- *  and our custom recipe wrapper isnt on that
- *  list :(
- *  <br>
- *  i think the only viable solutions are
- *  <br>
- *  1. don't use a custom recipe wrapper :(
- *  <br>
- *  2. mixin and fix it
- */
 @RegistryDescription
 public class RollingMachine extends VirtualizedRegistry<Pair<ResourceLocation, IRecipe>> {
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/RollingMachine.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/RollingMachine.java
@@ -1,0 +1,117 @@
+package com.cleanroommc.groovyscript.compat.mods.techreborn;
+
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.Example;
+import com.cleanroommc.groovyscript.api.documentation.annotations.MethodDescription;
+import com.cleanroommc.groovyscript.api.documentation.annotations.RecipeBuilderDescription;
+import com.cleanroommc.groovyscript.api.documentation.annotations.RegistryDescription;
+import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
+import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import mezz.jei.api.IJeiHelpers;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.util.ResourceLocation;
+import org.apache.commons.lang3.tuple.Pair;
+import techreborn.api.RollingMachineRecipe;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * TODO:
+ *  {@link techreborn.compat.jei.rollingMachine.RollingMachineRecipeWrapper#create(IJeiHelpers, IRecipe)}
+ *  specifies what recipe wrappers can be used
+ *  and our custom recipe wrapper isnt on that
+ *  list :(
+ *  <br>
+ *  i think the only viable solutions are
+ *  <br>
+ *  1. don't use a custom recipe wrapper :(
+ *  <br>
+ *  2. mixin and fix it
+ */
+@RegistryDescription
+public class RollingMachine extends VirtualizedRegistry<Pair<ResourceLocation, IRecipe>> {
+
+    @RecipeBuilderDescription(example = {
+            @Example(".output(item('minecraft:stone')).matrix('BXX', 'X B').key('B', item('minecraft:stone')).key('X', item('minecraft:gold_ingot')).mirrored()"),
+            @Example(".output(item('minecraft:diamond') * 32).matrix([[item('minecraft:gold_ingot'), item('minecraft:gold_ingot'), item('minecraft:gold_ingot')],[item('minecraft:gold_ingot'), item('minecraft:gold_ingot'), item('minecraft:gold_ingot')],[item('minecraft:gold_ingot'), item('minecraft:gold_ingot'), item('minecraft:gold_ingot')]])")
+    })
+    public RollingMachineRecipeBuilder.Shaped shapedBuilder() {
+        return new RollingMachineRecipeBuilder.Shaped();
+    }
+
+    @RecipeBuilderDescription(example = {
+            @Example(".output(item('minecraft:clay') * 8).input(item('minecraft:stone'), item('minecraft:stone'), item('minecraft:stone'))"),
+            @Example(".output(item('minecraft:clay') * 32).input(item('minecraft:diamond'), item('minecraft:diamond'), item('minecraft:diamond'), item('minecraft:diamond'), item('minecraft:diamond'), item('minecraft:diamond'), item('minecraft:diamond'), item('minecraft:diamond'))")
+    })
+    public RollingMachineRecipeBuilder.Shapeless shapelessBuilder() {
+        return new RollingMachineRecipeBuilder.Shapeless();
+    }
+
+    @Override
+    public void onReload() {
+        removeScripted().forEach(r -> RollingMachineRecipe.instance.getRecipeList().remove(r.getKey()));
+        restoreFromBackup().forEach(r -> RollingMachineRecipe.instance.getRecipeList().put(r.getKey(), r.getValue()));
+    }
+
+    @MethodDescription(type = MethodDescription.Type.ADDITION)
+    public IRecipe addShaped(ItemStack output, List<List<IIngredient>> input) {
+        return shapedBuilder()
+                .matrix(input)
+                .output(output)
+                .register();
+    }
+
+    @MethodDescription(type = MethodDescription.Type.ADDITION)
+    public IRecipe addShapeless(ItemStack output, List<IIngredient> input) {
+        return shapelessBuilder()
+                .input(input)
+                .output(output)
+                .register();
+    }
+
+    public IRecipe add(ResourceLocation key, IRecipe recipe) {
+        if (recipe != null) {
+            addScripted(Pair.of(key, recipe));
+            RollingMachineRecipe.instance.getRecipeList().put(key, recipe);
+        }
+        return recipe;
+    }
+
+    @MethodDescription(example = @Example("item('minecraft:tripwire_hook')"))
+    public boolean removeByOutput(IIngredient output) {
+        return RollingMachineRecipe.instance.getRecipeList().entrySet().removeIf(r -> {
+            if (output.test(r.getValue().getRecipeOutput())) {
+                addBackup(Pair.of(r.getKey(), r.getValue()));
+                return true;
+            }
+            return false;
+        });
+    }
+
+    public boolean remove(ResourceLocation key) {
+        return RollingMachineRecipe.instance.getRecipeList().remove(key) != null;
+    }
+
+    public boolean remove(IRecipe recipe) {
+        return RollingMachineRecipe.instance.getRecipeList().entrySet().removeIf(r -> {
+            if (r.getValue() == recipe) {
+                addBackup(Pair.of(r.getKey(), r.getValue()));
+                return true;
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(type = MethodDescription.Type.QUERY)
+    public SimpleObjectStream<Map.Entry<ResourceLocation, IRecipe>> streamRecipes() {
+        return new SimpleObjectStream<>(RollingMachineRecipe.instance.getRecipeList().entrySet()).setRemover(x -> remove(x.getKey()));
+    }
+
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
+    public void removeAll() {
+        RollingMachineRecipe.instance.getRecipeList().forEach((a, b) -> addBackup(Pair.of(a, b)));
+        RollingMachineRecipe.instance.getRecipeList().clear();
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/RollingMachineRecipeBuilder.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/RollingMachineRecipeBuilder.java
@@ -1,0 +1,88 @@
+package com.cleanroommc.groovyscript.compat.mods.techreborn;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.documentation.annotations.RecipeBuilderRegistrationMethod;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.compat.vanilla.ShapedCraftingRecipe;
+import com.cleanroommc.groovyscript.compat.vanilla.ShapelessCraftingRecipe;
+import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
+import com.cleanroommc.groovyscript.registry.AbstractCraftingRecipeBuilder;
+import net.minecraft.item.crafting.IRecipe;
+
+public interface RollingMachineRecipeBuilder {
+
+    class Shaped extends AbstractCraftingRecipeBuilder.AbstractShaped<IRecipe> implements RollingMachineRecipeBuilder {
+
+        public Shaped() {
+            super(3, 3);
+        }
+
+        @Override
+        public String getRecipeNamePrefix() {
+            return "groovyscript_rolling_machine_shaped_";
+        }
+
+        public boolean validate() {
+            GroovyLog.Msg msg = GroovyLog.msg("Error adding shaped Rolling Machine recipe").error();
+            validateName();
+            msg.add((keyBasedMatrix == null || keyBasedMatrix.length == 0) && (ingredientMatrix == null || ingredientMatrix.isEmpty()), () -> "No matrix was defined");
+            msg.add(keyBasedMatrix != null && ingredientMatrix != null, () -> "A key based matrix AND a ingredient based matrix was defined. This is not allowed!");
+            msg.add(IngredientHelper.isEmpty(this.output), () -> "Output must not be empty");
+            return !msg.postIfNotEmpty();
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public IRecipe register() {
+            if (!validate()) return null;
+            GroovyLog.Msg msg = GroovyLog.msg("Error adding shaped Rolling Machine recipe").error();
+
+            ShapedCraftingRecipe recipe = null;
+            if (keyBasedMatrix != null) {
+                recipe = validateShape(msg, errors, keyBasedMatrix, keyMap, ((width1, height1, ingredients) -> new ShapedCraftingRecipe(output, ingredients, width1, height1, mirrored, recipeFunction, recipeAction)));
+            } else if (ingredientMatrix != null) {
+                recipe = validateShape(msg, ingredientMatrix, ((width1, height1, ingredients) -> new ShapedCraftingRecipe(output.copy(), ingredients, width1, height1, mirrored, recipeFunction, recipeAction)));
+            }
+            if (recipe == null) {
+                msg.add("The recipe could not be parsed!");
+            } else {
+                recipe.setRegistryName(name);
+            }
+            if (msg.postIfNotEmpty()) return null;
+
+            ModSupport.TECH_REBORN.get().rollingMachine.add(name, recipe);
+            return recipe;
+        }
+    }
+
+    class Shapeless extends AbstractCraftingRecipeBuilder.AbstractShapeless<IRecipe> implements RollingMachineRecipeBuilder {
+
+        public Shapeless() {
+            super(3, 3);
+        }
+
+        @Override
+        public String getRecipeNamePrefix() {
+            return "groovyscript_rolling_machine_shapeless_";
+        }
+
+        public boolean validate() {
+            GroovyLog.Msg msg = GroovyLog.msg("Error adding shapeless Rolling Machine recipe").error();
+            validateName();
+            msg.add(IngredientHelper.isEmpty(this.output), () -> "Output must not be empty");
+            msg.add(ingredients.isEmpty(), () -> "inputs must not be empty");
+            msg.add(ingredients.size() > width * height, () -> "maximum inputs are " + (width * height) + " but found " + ingredients.size());
+            return !msg.postIfNotEmpty();
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public IRecipe register() {
+            if (!validate()) return null;
+            ShapelessCraftingRecipe recipe = new ShapelessCraftingRecipe(output.copy(), ingredients, recipeFunction, recipeAction);
+            recipe.setRegistryName(name);
+            ModSupport.TECH_REBORN.get().rollingMachine.add(name, recipe);
+            return recipe;
+        }
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/Scrapbox.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/Scrapbox.java
@@ -1,0 +1,75 @@
+package com.cleanroommc.groovyscript.compat.mods.techreborn;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import org.jetbrains.annotations.Nullable;
+import techreborn.api.Reference;
+import techreborn.api.recipe.machines.ScrapboxRecipe;
+
+@RegistryDescription
+public class Scrapbox extends AbstractGenericTechRebornRegistry {
+
+    @RecipeBuilderDescription(example = {
+            @Example(".output(item('minecraft:clay'))"),
+            @Example(".output(item('minecraft:gold_block')).time(2).perTick(100)")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @Override
+    public String reference() {
+        return Reference.SCRAPBOX_RECIPE;
+    }
+
+    @Override
+    @MethodDescription(example = @Example("item('minecraft:diamond')"))
+    public void removeByOutput(IIngredient output) {
+        super.removeByOutput(output);
+    }
+
+    @Property(property = "output", valid = @Comp("1"))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<ScrapboxRecipe> {
+
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GTE))
+        private int time;
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GTE))
+        private int perTick;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder time(int time) {
+            this.time = time;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder perTick(int perTick) {
+            this.perTick = perTick;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Tech Reborn Scrapbox recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 0, 0, 1, 1);
+            validateFluids(msg);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable ScrapboxRecipe register() {
+            if (!validate()) return null;
+            ScrapboxRecipe recipe = new ScrapboxRecipe(output.get(0), time, perTick);
+            ModSupport.TECH_REBORN.get().blastFurnace.add(recipe);
+            return recipe;
+        }
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/SemiFluidGenerator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/SemiFluidGenerator.java
@@ -1,0 +1,83 @@
+package com.cleanroommc.groovyscript.compat.mods.techreborn;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import org.jetbrains.annotations.Nullable;
+import reborncore.api.praescriptum.fuels.Fuel;
+import reborncore.api.praescriptum.fuels.FuelHandler;
+import techreborn.api.recipe.Fuels;
+
+@RegistryDescription
+public class SemiFluidGenerator extends AbstractGeneratorRegistry {
+
+    @RecipeBuilderDescription(example = {
+            @Example(".fluidInput(fluid('water')).energy(10000).perTick(500)"),
+            @Example(".fluidInput(fluid('lava')).energy(200).perTick(10)")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @Override
+    public FuelHandler handler() {
+        return Fuels.semiFluidGenerator;
+    }
+
+    @Override
+    @MethodDescription(example = @Example("fluid('fluidbiofuel')"))
+    public void removeByInput(IIngredient input) {
+        super.removeByInput(input);
+    }
+
+    @Property(property = "fluidInput", valid = @Comp("1"))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<Fuel> {
+
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GT))
+        private double energy;
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GT))
+        private double perTick;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder energy(double energy) {
+            this.energy = energy;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder perTick(double perTick) {
+            this.perTick = perTick;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Tech Reborn Semi Fluid Generator recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg);
+            validateFluids(msg, 1, 1, 0, 0);
+            msg.add(energy <= 0, "energy must be greater than 0, yet it was {}", energy);
+            msg.add(perTick <= 0, "perTick must be greater than 0, yet it was {}", perTick);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable Fuel register() {
+            if (!validate()) return null;
+
+            Fuel recipe = Fuels.semiFluidGenerator.addFuel();
+            recipe.addFluidSource(fluidInput.get(0));
+            recipe.withEnergyPerTick(perTick);
+            recipe.withEnergyOutput(energy);
+
+            ModSupport.TECH_REBORN.get().semiFluidGenerator.add(recipe);
+            return recipe;
+        }
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/SolidCanningMachine.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/SolidCanningMachine.java
@@ -80,7 +80,7 @@ public class SolidCanningMachine extends AbstractPraescriptumRegistry {
             if (!validate()) return null;
 
             Recipe recipe = Recipes.solidCanningMachine.createRecipe();
-            recipe.withInput(input.stream().map(TechReborn::toInputIngredient).collect(Collectors.toList()));
+            recipe.withInput(input.stream().map(Helper::toInputIngredient).collect(Collectors.toList()));
             output.forEach(recipe::withOutput);
             recipe.withEnergyCostPerTick(perTick);
             recipe.withOperationDuration(time);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/SolidCanningMachine.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/SolidCanningMachine.java
@@ -1,0 +1,93 @@
+package com.cleanroommc.groovyscript.compat.mods.techreborn;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import org.jetbrains.annotations.Nullable;
+import reborncore.api.praescriptum.recipes.Recipe;
+import reborncore.api.praescriptum.recipes.RecipeHandler;
+import techreborn.api.recipe.Recipes;
+
+import java.util.stream.Collectors;
+
+@RegistryDescription
+public class SolidCanningMachine extends AbstractPraescriptumRegistry {
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:clay'), item('minecraft:diamond') * 2).output(item('minecraft:gold_ingot')).time(10).perTick(100)"),
+            @Example(".input(item('minecraft:diamond') * 3, item('minecraft:diamond') * 2).output(item('minecraft:clay') * 2).time(5).perTick(32)")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @Override
+    public RecipeHandler handler() {
+        return Recipes.solidCanningMachine;
+    }
+
+    @Override
+    @MethodDescription(example = @Example("item('techreborn:ingot:23')"))
+    public void removeByInput(IIngredient input) {
+        super.removeByInput(input);
+    }
+
+    @Override
+    @MethodDescription(example = @Example("item('techreborn:part:46')"))
+    public void removeByOutput(IIngredient output) {
+        super.removeByOutput(output);
+    }
+
+    @Property(property = "input", valid = @Comp("2"))
+    @Property(property = "output", valid = @Comp("1"))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<Recipe> {
+
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GT))
+        private int time;
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GT))
+        private int perTick;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder time(int time) {
+            this.time = time;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder perTick(int perTick) {
+            this.perTick = perTick;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Tech Reborn Solid Canning Machine recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 2, 2, 1, 1);
+            validateFluids(msg);
+            msg.add(time <= 0, "time must be greater than 0, yet it was {}", time);
+            msg.add(perTick <= 0, "perTick must be greater than 0, yet it was {}", perTick);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable Recipe register() {
+            if (!validate()) return null;
+
+            Recipe recipe = Recipes.solidCanningMachine.createRecipe();
+            recipe.withInput(input.stream().map(TechReborn::toInputIngredient).collect(Collectors.toList()));
+            output.forEach(recipe::withOutput);
+            recipe.withEnergyCostPerTick(perTick);
+            recipe.withOperationDuration(time);
+
+            ModSupport.TECH_REBORN.get().solidCanningMachine.add(recipe);
+            return recipe;
+        }
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/TechReborn.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/TechReborn.java
@@ -1,0 +1,93 @@
+package com.cleanroommc.groovyscript.compat.mods.techreborn;
+
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.compat.mods.ModPropertyContainer;
+import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
+import com.cleanroommc.groovyscript.helper.ingredient.OreDictIngredient;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.oredict.OreDictionary;
+import reborncore.api.praescriptum.ingredients.input.FluidStackInputIngredient;
+import reborncore.api.praescriptum.ingredients.input.InputIngredient;
+import reborncore.api.praescriptum.ingredients.input.ItemStackInputIngredient;
+import reborncore.api.praescriptum.ingredients.input.OreDictionaryInputIngredient;
+
+public class TechReborn extends ModPropertyContainer {
+
+    public final AlloySmelter alloySmelter = new AlloySmelter();
+    public final AssemblingMachine assemblingMachine = new AssemblingMachine();
+    public final BlastFurnace blastFurnace = new BlastFurnace();
+    public final Centrifuge centrifuge = new Centrifuge();
+    public final ChemicalReactor chemicalReactor = new ChemicalReactor();
+    public final Compressor compressor = new Compressor();
+    public final DieselGenerator dieselGenerator = new DieselGenerator();
+    public final DistillationTower distillationTower = new DistillationTower();
+    public final Extractor extractor = new Extractor();
+    public final FluidReplicator fluidReplicator = new FluidReplicator();
+    public final FusionReactor fusionReactor = new FusionReactor();
+    public final GasTurbine gasTurbine = new GasTurbine();
+    public final Grinder grinder = new Grinder();
+    public final ImplosionCompressor implosionCompressor = new ImplosionCompressor();
+    public final IndustrialElectrolyzer industrialElectrolyzer = new IndustrialElectrolyzer();
+    public final IndustrialGrinder industrialGrinder = new IndustrialGrinder();
+    public final IndustrialSawmill industrialSawmill = new IndustrialSawmill();
+    public final PlasmaGenerator plasmaGenerator = new PlasmaGenerator();
+    public final PlateBendingMachine plateBendingMachine = new PlateBendingMachine();
+    public final RollingMachine rollingMachine = new RollingMachine();
+    public final Scrapbox scrapbox = new Scrapbox();
+    public final SemiFluidGenerator semiFluidGenerator = new SemiFluidGenerator();
+    public final SolidCanningMachine solidCanningMachine = new SolidCanningMachine();
+    public final ThermalGenerator thermalGenerator = new ThermalGenerator();
+    public final VacuumFreezer vacuumFreezer = new VacuumFreezer();
+    public final WireMill wireMill = new WireMill();
+
+    public TechReborn() {
+        addRegistry(alloySmelter);
+        addRegistry(assemblingMachine);
+        addRegistry(blastFurnace);
+        addRegistry(centrifuge);
+        addRegistry(chemicalReactor);
+        addRegistry(compressor);
+        addRegistry(dieselGenerator);
+        addRegistry(distillationTower);
+        addRegistry(extractor);
+        addRegistry(fluidReplicator);
+        addRegistry(fusionReactor);
+        addRegistry(gasTurbine);
+        addRegistry(grinder);
+        addRegistry(implosionCompressor);
+        addRegistry(industrialElectrolyzer);
+        addRegistry(industrialGrinder);
+        addRegistry(industrialSawmill);
+        addRegistry(plasmaGenerator);
+        addRegistry(plateBendingMachine);
+        addRegistry(rollingMachine);
+        addRegistry(scrapbox);
+        addRegistry(semiFluidGenerator);
+        addRegistry(solidCanningMachine);
+        addRegistry(thermalGenerator);
+        addRegistry(vacuumFreezer);
+        addRegistry(wireMill);
+    }
+
+    public static ItemStack getStackFromIIngredient(IIngredient ingredient) {
+        if (ingredient instanceof OreDictIngredient oreDictIngredient) {
+            if (OreDictionary.doesOreNameExist(oreDictIngredient.getOreDict())) {
+                return OreDictionary.getOres(oreDictIngredient.getOreDict()).get(0).copy();
+            }
+        }
+        if (IngredientHelper.isItem(ingredient)) {
+            return IngredientHelper.toItemStack(ingredient);
+        }
+        if (ingredient.getMatchingStacks().length > 0) return ingredient.getMatchingStacks()[0];
+        return ItemStack.EMPTY;
+    }
+
+    public static InputIngredient<?> toInputIngredient(IIngredient ingredient) {
+        if (ingredient instanceof OreDictIngredient ore) return OreDictionaryInputIngredient.of(ore.getOreDict(), ore.getAmount());
+        if (ingredient instanceof FluidStack fluid) return FluidStackInputIngredient.of(fluid);
+        if (IngredientHelper.isItem(ingredient)) return ItemStackInputIngredient.of(IngredientHelper.toItemStack(ingredient));
+        return ItemStackInputIngredient.of(ItemStack.EMPTY);
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/TechReborn.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/TechReborn.java
@@ -1,16 +1,6 @@
 package com.cleanroommc.groovyscript.compat.mods.techreborn;
 
-import com.cleanroommc.groovyscript.api.IIngredient;
 import com.cleanroommc.groovyscript.compat.mods.ModPropertyContainer;
-import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
-import com.cleanroommc.groovyscript.helper.ingredient.OreDictIngredient;
-import net.minecraft.item.ItemStack;
-import net.minecraftforge.fluids.FluidStack;
-import net.minecraftforge.oredict.OreDictionary;
-import reborncore.api.praescriptum.ingredients.input.FluidStackInputIngredient;
-import reborncore.api.praescriptum.ingredients.input.InputIngredient;
-import reborncore.api.praescriptum.ingredients.input.ItemStackInputIngredient;
-import reborncore.api.praescriptum.ingredients.input.OreDictionaryInputIngredient;
 
 public class TechReborn extends ModPropertyContainer {
 
@@ -68,26 +58,6 @@ public class TechReborn extends ModPropertyContainer {
         addRegistry(thermalGenerator);
         addRegistry(vacuumFreezer);
         addRegistry(wireMill);
-    }
-
-    public static ItemStack getStackFromIIngredient(IIngredient ingredient) {
-        if (ingredient instanceof OreDictIngredient oreDictIngredient) {
-            if (OreDictionary.doesOreNameExist(oreDictIngredient.getOreDict())) {
-                return OreDictionary.getOres(oreDictIngredient.getOreDict()).get(0).copy();
-            }
-        }
-        if (IngredientHelper.isItem(ingredient)) {
-            return IngredientHelper.toItemStack(ingredient);
-        }
-        if (ingredient.getMatchingStacks().length > 0) return ingredient.getMatchingStacks()[0];
-        return ItemStack.EMPTY;
-    }
-
-    public static InputIngredient<?> toInputIngredient(IIngredient ingredient) {
-        if (ingredient instanceof OreDictIngredient ore) return OreDictionaryInputIngredient.of(ore.getOreDict(), ore.getAmount());
-        if (ingredient instanceof FluidStack fluid) return FluidStackInputIngredient.of(fluid);
-        if (IngredientHelper.isItem(ingredient)) return ItemStackInputIngredient.of(IngredientHelper.toItemStack(ingredient));
-        return ItemStackInputIngredient.of(ItemStack.EMPTY);
     }
 
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/ThermalGenerator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/ThermalGenerator.java
@@ -1,0 +1,83 @@
+package com.cleanroommc.groovyscript.compat.mods.techreborn;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import org.jetbrains.annotations.Nullable;
+import reborncore.api.praescriptum.fuels.Fuel;
+import reborncore.api.praescriptum.fuels.FuelHandler;
+import techreborn.api.recipe.Fuels;
+
+@RegistryDescription
+public class ThermalGenerator extends AbstractGeneratorRegistry {
+
+    @RecipeBuilderDescription(example = {
+            @Example(".fluidInput(fluid('water')).energy(10000).perTick(500)"),
+            @Example(".fluidInput(fluid('lava')).energy(200).perTick(10)")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @Override
+    public FuelHandler handler() {
+        return Fuels.thermalGenerator;
+    }
+
+    @Override
+    @MethodDescription(example = @Example("fluid('lava')"))
+    public void removeByInput(IIngredient input) {
+        super.removeByInput(input);
+    }
+
+    @Property(property = "fluidInput", valid = @Comp("1"))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<Fuel> {
+
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GT))
+        private double energy;
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GT))
+        private double perTick;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder energy(double energy) {
+            this.energy = energy;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder perTick(double perTick) {
+            this.perTick = perTick;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Tech Reborn Thermal Generator recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg);
+            validateFluids(msg, 1, 1, 0, 0);
+            msg.add(energy <= 0, "energy must be greater than 0, yet it was {}", energy);
+            msg.add(perTick <= 0, "perTick must be greater than 0, yet it was {}", perTick);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable Fuel register() {
+            if (!validate()) return null;
+
+            Fuel recipe = Fuels.thermalGenerator.addFuel();
+            recipe.addFluidSource(fluidInput.get(0));
+            recipe.withEnergyPerTick(perTick);
+            recipe.withEnergyOutput(energy);
+
+            ModSupport.TECH_REBORN.get().thermalGenerator.add(recipe);
+            return recipe;
+        }
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/VacuumFreezer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/VacuumFreezer.java
@@ -1,0 +1,82 @@
+package com.cleanroommc.groovyscript.compat.mods.techreborn;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import org.jetbrains.annotations.Nullable;
+import techreborn.api.Reference;
+import techreborn.api.recipe.machines.VacuumFreezerRecipe;
+
+@RegistryDescription
+public class VacuumFreezer extends AbstractGenericTechRebornRegistry {
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:clay')).output(item('minecraft:gold_ingot')).time(10).perTick(100)"),
+            @Example(".input(item('minecraft:diamond') * 3).output(item('minecraft:clay') * 2).time(5).perTick(32)")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @Override
+    public String reference() {
+        return Reference.VACUUM_FREEZER_RECIPE;
+    }
+
+    @Override
+    @MethodDescription(example = @Example("item('techreborn:dynamiccell').withNbt(['Fluid': ['FluidName': 'water', 'Amount': 1000]])"))
+    public void removeByInput(IIngredient input) {
+        super.removeByInput(input);
+    }
+
+    @Override
+    @MethodDescription(example = @Example("item('minecraft:packed_ice')"))
+    public void removeByOutput(IIngredient output) {
+        super.removeByOutput(output);
+    }
+
+    @Property(property = "input", valid = @Comp("1"))
+    @Property(property = "output", valid = @Comp("1"))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<VacuumFreezerRecipe> {
+
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GTE))
+        private int time;
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GTE))
+        private int perTick;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder time(int time) {
+            this.time = time;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder perTick(int perTick) {
+            this.perTick = perTick;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Tech Reborn Vacuum Freezer recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 1, 1, 1, 1);
+            validateFluids(msg);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable VacuumFreezerRecipe register() {
+            if (!validate()) return null;
+            VacuumFreezerRecipe recipe = new VacuumFreezerRecipe(TechReborn.getStackFromIIngredient(input.get(0)), output.get(0), time, perTick);
+            ModSupport.TECH_REBORN.get().vacuumFreezer.add(recipe);
+            return recipe;
+        }
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/VacuumFreezer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/VacuumFreezer.java
@@ -73,7 +73,7 @@ public class VacuumFreezer extends AbstractGenericTechRebornRegistry {
         @RecipeBuilderRegistrationMethod
         public @Nullable VacuumFreezerRecipe register() {
             if (!validate()) return null;
-            VacuumFreezerRecipe recipe = new VacuumFreezerRecipe(TechReborn.getStackFromIIngredient(input.get(0)), output.get(0), time, perTick);
+            VacuumFreezerRecipe recipe = new VacuumFreezerRecipe(Helper.getStackFromIIngredient(input.get(0)), output.get(0), time, perTick);
             ModSupport.TECH_REBORN.get().vacuumFreezer.add(recipe);
             return recipe;
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/WireMill.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/WireMill.java
@@ -80,7 +80,7 @@ public class WireMill extends AbstractPraescriptumRegistry {
             if (!validate()) return null;
 
             Recipe recipe = Recipes.wireMill.createRecipe();
-            recipe.withInput(input.stream().map(TechReborn::toInputIngredient).collect(Collectors.toList()));
+            recipe.withInput(input.stream().map(Helper::toInputIngredient).collect(Collectors.toList()));
             output.forEach(recipe::withOutput);
             recipe.withEnergyCostPerTick(perTick);
             recipe.withOperationDuration(time);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/WireMill.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/techreborn/WireMill.java
@@ -1,0 +1,93 @@
+package com.cleanroommc.groovyscript.compat.mods.techreborn;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import org.jetbrains.annotations.Nullable;
+import reborncore.api.praescriptum.recipes.Recipe;
+import reborncore.api.praescriptum.recipes.RecipeHandler;
+import techreborn.api.recipe.Recipes;
+
+import java.util.stream.Collectors;
+
+@RegistryDescription
+public class WireMill extends AbstractPraescriptumRegistry {
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:clay')).output(item('minecraft:gold_ingot')).time(10).perTick(100)"),
+            @Example(".input(item('minecraft:diamond') * 3).output(item('minecraft:clay') * 2).time(5).perTick(32)")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @Override
+    public RecipeHandler handler() {
+        return Recipes.wireMill;
+    }
+
+    @Override
+    @MethodDescription(example = @Example("item('minecraft:gold_ingot')"))
+    public void removeByInput(IIngredient input) {
+        super.removeByInput(input);
+    }
+
+    @Override
+    @MethodDescription(example = @Example("item('techreborn:cable')"))
+    public void removeByOutput(IIngredient output) {
+        super.removeByOutput(output);
+    }
+
+    @Property(property = "input", valid = @Comp("1"))
+    @Property(property = "output", valid = @Comp("1"))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<Recipe> {
+
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GT))
+        private int time;
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GT))
+        private int perTick;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder time(int time) {
+            this.time = time;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder perTick(int perTick) {
+            this.perTick = perTick;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Tech Reborn Wire Mill recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 1, 1, 1, 1);
+            validateFluids(msg);
+            msg.add(time <= 0, "time must be greater than 0, yet it was {}", time);
+            msg.add(perTick <= 0, "perTick must be greater than 0, yet it was {}", perTick);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable Recipe register() {
+            if (!validate()) return null;
+
+            Recipe recipe = Recipes.wireMill.createRecipe();
+            recipe.withInput(input.stream().map(TechReborn::toInputIngredient).collect(Collectors.toList()));
+            output.forEach(recipe::withOutput);
+            recipe.withEnergyCostPerTick(perTick);
+            recipe.withOperationDuration(time);
+
+            ModSupport.TECH_REBORN.get().wireMill.add(recipe);
+            return recipe;
+        }
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/core/LateMixin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/LateMixin.java
@@ -29,6 +29,7 @@ public class LateMixin implements ILateMixinLoader {
             "industrialforegoing",
             "inspirations",
             "jei",
+            "techreborn",
             "mekanism",
             "pneumaticcraft",
             "primal_tech",

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/techreborn/RollingMachineRecipeWrapperMixin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/techreborn/RollingMachineRecipeWrapperMixin.java
@@ -1,0 +1,24 @@
+package com.cleanroommc.groovyscript.core.mixin.techreborn;
+
+import com.cleanroommc.groovyscript.compat.mods.jei.ShapedRecipeWrapper;
+import com.cleanroommc.groovyscript.compat.vanilla.ShapedCraftingRecipe;
+import com.cleanroommc.groovyscript.compat.vanilla.ShapelessCraftingRecipe;
+import mezz.jei.api.IJeiHelpers;
+import mezz.jei.plugins.vanilla.crafting.ShapelessRecipeWrapper;
+import net.minecraft.item.crafting.IRecipe;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import techreborn.compat.jei.rollingMachine.RollingMachineRecipeWrapper;
+
+@Mixin(value = RollingMachineRecipeWrapper.class, remap = false)
+public abstract class RollingMachineRecipeWrapperMixin {
+
+    @Inject(method = "create", at = @At(value = "RETURN", ordinal = 0), cancellable = true)
+    private static void useCustomGroovyScriptRecipe(IJeiHelpers jeiHelpers, IRecipe baseRecipe, CallbackInfoReturnable<RollingMachineRecipeWrapper> cir) {
+        if (baseRecipe instanceof ShapelessCraftingRecipe r) cir.setReturnValue(new RollingMachineRecipeWrapper(new ShapelessRecipeWrapper<>(jeiHelpers, r)));
+        if (baseRecipe instanceof ShapedCraftingRecipe r) cir.setReturnValue(new RollingMachineRecipeWrapper(new ShapedRecipeWrapper(jeiHelpers, r)));
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/helper/recipe/AbstractRecipeBuilder.java
+++ b/src/main/java/com/cleanroommc/groovyscript/helper/recipe/AbstractRecipeBuilder.java
@@ -158,16 +158,16 @@ public abstract class AbstractRecipeBuilder<T> implements IRecipeBuilder<T> {
     public void validateFluids(GroovyLog.Msg msg, int minFluidInput, int maxFluidInput, int minFluidOutput, int maxFluidOutput) {
         fluidInput.trim();
         fluidOutput.trim();
-        msg.add(fluidInput.size() < minFluidInput || fluidInput.size() > maxFluidInput, () -> getRequiredString(minFluidInput, maxFluidInput, "fluid input") + ", but found " + fluidInput.size());
-        msg.add(fluidOutput.size() < minFluidOutput || fluidOutput.size() > maxFluidOutput, () -> getRequiredString(minFluidOutput, maxFluidOutput, "fluid output") + ", but found " + fluidOutput.size());
+        validateCustom(msg, fluidInput, minFluidInput, maxFluidInput, "fluid input");
+        validateCustom(msg, fluidOutput, minFluidOutput, maxFluidOutput, "fluid output");
     }
 
     @GroovyBlacklist
     public void validateItems(GroovyLog.Msg msg, int minInput, int maxInput, int minOutput, int maxOutput) {
         input.trim();
         output.trim();
-        msg.add(input.size() < minInput || input.size() > maxInput, () -> getRequiredString(minInput, maxInput, "item input") + ", but found " + input.size());
-        msg.add(output.size() < minOutput || output.size() > maxOutput, () -> getRequiredString(minOutput, maxOutput, "item output") + ", but found " + output.size());
+        validateCustom(msg, input, minInput, maxInput, "item input");
+        validateCustom(msg, output, minOutput, maxOutput, "item output");
     }
 
     @GroovyBlacklist
@@ -181,8 +181,13 @@ public abstract class AbstractRecipeBuilder<T> implements IRecipeBuilder<T> {
     }
 
     @GroovyBlacklist
-    public void validateCustom(GroovyLog.Msg msg, Collection<?> collection, int min, int max, String type) {
-        msg.add(collection.size() < min || collection.size() > max, () -> getRequiredString(min, max, type) + ", but found " + collection.size());
+    public static void validateCustom(GroovyLog.Msg msg, Collection<?> collection, int min, int max, String type) {
+        validateCustom(msg, collection.size(), min, max, type);
+    }
+
+    @GroovyBlacklist
+    public static void validateCustom(GroovyLog.Msg msg, int size, int min, int max, String type) {
+        msg.add(size < min || size > max, () -> getRequiredString(min, max, type) + ", but found " + size);
     }
 
     protected static String getRequiredString(int min, int max, String type) {

--- a/src/main/resources/assets/groovyscript/lang/en_us.lang
+++ b/src/main/resources/assets/groovyscript/lang/en_us.lang
@@ -1864,6 +1864,147 @@ groovyscript.wiki.rustic.evaporating_basin.description=Converts fluids into item
 groovyscript.wiki.rustic.evaporating_basin.time.value=Sets the time in ticks the recipe will take
 
 
+# Tech Reborn
+groovyscript.wiki.techreborn.alloy_smelter.title=Alloy Smelter
+groovyscript.wiki.techreborn.alloy_smelter.description=Converts two itemstack inputs into an itemstack output after a given process time, consuming energy per tick.
+groovyscript.wiki.techreborn.alloy_smelter.time.value=Sets the time in ticks the recipe takes to complete
+groovyscript.wiki.techreborn.alloy_smelter.perTick.value=Sets the power consumed per tick
+
+groovyscript.wiki.techreborn.assembling_machine.title=Assembling Machine
+groovyscript.wiki.techreborn.assembling_machine.description=Converts two itemstack inputs into an itemstack output after a given process time, consuming energy per tick.
+groovyscript.wiki.techreborn.assembling_machine.time.value=Sets the time in ticks the recipe takes to complete
+groovyscript.wiki.techreborn.assembling_machine.perTick.value=Sets the power consumed per tick
+
+groovyscript.wiki.techreborn.blast_furnace.title=Industrial Blast Furnace
+groovyscript.wiki.techreborn.blast_furnace.description=Converts one or two itemstack inputs into one or two itemstack outputs after a given process time, requiring at least a given amount of heat and consuming energy per tick.
+groovyscript.wiki.techreborn.blast_furnace.note0=Heat is increased by applying Kanthal and Nichrome Coils, improving the quality of the Machine Casing, and filling the center of the multiblock with lava.
+groovyscript.wiki.techreborn.blast_furnace.time.value=Sets the time in ticks the recipe takes to complete
+groovyscript.wiki.techreborn.blast_furnace.perTick.value=Sets the power consumed per tick
+groovyscript.wiki.techreborn.blast_furnace.neededHeat.value=Sets the heat required for the recipe to be crafted
+
+groovyscript.wiki.techreborn.centrifuge.title=Industrial Centrifuge
+groovyscript.wiki.techreborn.centrifuge.description=Converts one or two itemstack inputs into up to four an itemstack output after a given process time, consuming energy per tick.
+groovyscript.wiki.techreborn.centrifuge.time.value=Sets the time in ticks the recipe takes to complete
+groovyscript.wiki.techreborn.centrifuge.perTick.value=Sets the power consumed per tick
+
+groovyscript.wiki.techreborn.chemical_reactor.title=Chemical Reactor
+groovyscript.wiki.techreborn.chemical_reactor.description=Converts two itemstack inputs into an itemstack output after a given process time, consuming energy per tick.
+groovyscript.wiki.techreborn.chemical_reactor.time.value=Sets the time in ticks the recipe takes to complete
+groovyscript.wiki.techreborn.chemical_reactor.perTick.value=Sets the power consumed per tick
+
+groovyscript.wiki.techreborn.compressor.title=Compressor
+groovyscript.wiki.techreborn.compressor.description=Converts an itemstack input into an itemstack output after a given process time, consuming energy per tick.
+groovyscript.wiki.techreborn.compressor.time.value=Sets the time in ticks the recipe takes to complete
+groovyscript.wiki.techreborn.compressor.perTick.value=Sets the power consumed per tick
+
+groovyscript.wiki.techreborn.diesel_generator.title=Diesel Generator
+groovyscript.wiki.techreborn.diesel_generator.description=Converts a fluidstack input into power, at a given rate per tick.
+groovyscript.wiki.techreborn.diesel_generator.energy.value=Sets the total amount of energy generated from a bucket
+groovyscript.wiki.techreborn.diesel_generator.perTick.value=Sets the FE generated per tick
+
+groovyscript.wiki.techreborn.distillation_tower.title=Distillation Tower
+groovyscript.wiki.techreborn.distillation_tower.description=Converts one or two itemstack inputs into up to four an itemstack output after a given process time, consuming energy per tick.
+groovyscript.wiki.techreborn.distillation_tower.oreDict.value=Sets if the recipe matches based on the oredict of inputs
+groovyscript.wiki.techreborn.distillation_tower.time.value=Sets the time in ticks the recipe takes to complete
+groovyscript.wiki.techreborn.distillation_tower.perTick.value=Sets the power consumed per tick
+
+groovyscript.wiki.techreborn.extractor.title=Extractor
+groovyscript.wiki.techreborn.extractor.description=Converts an itemstack input into an itemstack output after a given process time, consuming energy per tick.
+groovyscript.wiki.techreborn.extractor.time.value=Sets the time in ticks the recipe takes to complete
+groovyscript.wiki.techreborn.extractor.perTick.value=Sets the power consumed per tick
+
+groovyscript.wiki.techreborn.fluid_replicator.title=Fluid Replicator
+groovyscript.wiki.techreborn.fluid_replicator.description=Converts a configurable amount of UU-Matter into a output fluidstack of 1000mb after a given process time, replicating a fluid source block placed in-world and consuming energy per tick.
+groovyscript.wiki.techreborn.fluid_replicator.matter.value=Sets the amount of UU-Matter consumed to create a bucket of the fluid
+groovyscript.wiki.techreborn.fluid_replicator.time.value=Sets the time in ticks the recipe takes to complete
+groovyscript.wiki.techreborn.fluid_replicator.perTick.value=Sets the power consumed per tick
+
+groovyscript.wiki.techreborn.fusion_reactor.title=Fusion Reactor
+groovyscript.wiki.techreborn.fusion_reactor.description=Converts two itemstack inputs into an itemstack output after a given process time, requiring a cost to start the recipe and either generating or consuming power while the recipe runs.
+groovyscript.wiki.techreborn.fusion_reactor.size.value=Sets the minimum size required to start the recipe
+groovyscript.wiki.techreborn.fusion_reactor.start.value=Sets the amount of power consumed to
+groovyscript.wiki.techreborn.fusion_reactor.time.value=Sets the time in ticks the recipe takes to complete
+groovyscript.wiki.techreborn.fusion_reactor.perTick.value=Sets the FE consumed or generated per tick
+
+groovyscript.wiki.techreborn.gas_turbine.title=Gas Turbine
+groovyscript.wiki.techreborn.gas_turbine.description=Converts a fluidstack input into power, at a given rate per tick.
+groovyscript.wiki.techreborn.gas_turbine.energy.value=Sets the total amount of energy generated from a bucket
+groovyscript.wiki.techreborn.gas_turbine.perTick.value=Sets the power consumed per tick
+
+groovyscript.wiki.techreborn.grinder.title=Grinder
+groovyscript.wiki.techreborn.grinder.description=Converts an itemstack input into an itemstack output after a given process time, consuming energy per tick.
+groovyscript.wiki.techreborn.grinder.time.value=Sets the time in ticks the recipe takes to complete
+groovyscript.wiki.techreborn.grinder.perTick.value=Sets the power consumed per tick
+
+groovyscript.wiki.techreborn.implosion_compressor.title=Implosion Compressor
+groovyscript.wiki.techreborn.implosion_compressor.description=Converts two itemstack inputs into up to two itemstack outputs after a given process time, consuming energy per tick.
+groovyscript.wiki.techreborn.implosion_compressor.time.value=Sets the time in ticks the recipe takes to complete
+groovyscript.wiki.techreborn.implosion_compressor.perTick.value=Sets the power consumed per tick
+
+groovyscript.wiki.techreborn.industrial_electrolyzer.title=Industrial Electrolyzer
+groovyscript.wiki.techreborn.industrial_electrolyzer.description=Converts up to two itemstack inputs into up to four itemstack outputs after a given process time, consuming energy per tick.
+groovyscript.wiki.techreborn.industrial_electrolyzer.oreDict.value=Sets if the recipe matches based on the oredict of inputs
+groovyscript.wiki.techreborn.industrial_electrolyzer.time.value=Sets the time in ticks the recipe takes to complete
+groovyscript.wiki.techreborn.industrial_electrolyzer.perTick.value=Sets the power consumed per tick
+
+groovyscript.wiki.techreborn.industrial_grinder.title=Industrial Grinder
+groovyscript.wiki.techreborn.industrial_grinder.description=Converts an itemstack input and fluidstack input into up to four itemstack outputs after a given process time, consuming energy per tick.
+groovyscript.wiki.techreborn.industrial_grinder.oreDict.value=Sets if the recipe matches based on the oredict of inputs
+groovyscript.wiki.techreborn.industrial_grinder.time.value=Sets the time in ticks the recipe takes to complete
+groovyscript.wiki.techreborn.industrial_grinder.perTick.value=Sets the power consumed per tick
+
+groovyscript.wiki.techreborn.industrial_sawmill.title=Sawmill
+groovyscript.wiki.techreborn.industrial_sawmill.description=Converts an itemstack input and fluidstack output into three itemstack outputs after a given process time, consuming energy per tick.
+groovyscript.wiki.techreborn.industrial_sawmill.oreDict.value=Sets if the recipe matches based on the oredict of inputs
+groovyscript.wiki.techreborn.industrial_sawmill.time.value=Sets the time in ticks the recipe takes to complete
+groovyscript.wiki.techreborn.industrial_sawmill.perTick.value=Sets the power consumed per tick
+
+groovyscript.wiki.techreborn.plasma_generator.title=Plasma Generator
+groovyscript.wiki.techreborn.plasma_generator.description=Converts a fluidstack input into power, at a given rate per tick.
+groovyscript.wiki.techreborn.plasma_generator.energy.value=Sets the total amount of energy generated from a bucket
+groovyscript.wiki.techreborn.plasma_generator.perTick.value=Sets the FE generated per tick
+
+groovyscript.wiki.techreborn.plate_bending_machine.title=Plate Bending Machine
+groovyscript.wiki.techreborn.plate_bending_machine.description=Converts an itemstack input into an itemstack output after a given process time, consuming energy per tick.
+groovyscript.wiki.techreborn.plate_bending_machine.time.value=Sets the time in ticks the recipe takes to complete
+groovyscript.wiki.techreborn.plate_bending_machine.perTick.value=Sets the power consumed per tick
+
+groovyscript.wiki.techreborn.rolling_machine.title=Rolling Machine
+groovyscript.wiki.techreborn.rolling_machine.description=Converts a custom crafting recipe into an output itemstack.
+groovyscript.wiki.techreborn.rolling_machine.addShaped=Adds a shaped crafting recipe in the format `output`, `input`
+groovyscript.wiki.techreborn.rolling_machine.addShapeless=Adds a shapeless crafting recipe in the format `output`, `input`
+
+groovyscript.wiki.techreborn.scrapbox.title=Scrapbox
+groovyscript.wiki.techreborn.scrapbox.description=Converts a scrapbox into a random itemstack output, either via manual player interaction or via a machine with a given process time, consuming energy per tick.
+groovyscript.wiki.techreborn.scrapbox.time.value=Sets the time in ticks the recipe takes to complete
+groovyscript.wiki.techreborn.scrapbox.perTick.value=Sets the power consumed per tick
+
+groovyscript.wiki.techreborn.semi_fluid_generator.title=Semi-Fluid Generator
+groovyscript.wiki.techreborn.semi_fluid_generator.description=Converts a fluidstack input into power, at a given rate per tick.
+groovyscript.wiki.techreborn.semi_fluid_generator.energy.value=Sets the total amount of energy generated from a bucket
+groovyscript.wiki.techreborn.semi_fluid_generator.perTick.value=Sets the FE generated per tick
+
+groovyscript.wiki.techreborn.solid_canning_machine.title=Solid Canning Machine
+groovyscript.wiki.techreborn.solid_canning_machine.description=Converts two itemstack inputs into an itemstack output after a given process time, consuming energy per tick.
+groovyscript.wiki.techreborn.solid_canning_machine.time.value=Sets the time in ticks the recipe takes to complete
+groovyscript.wiki.techreborn.solid_canning_machine.perTick.value=Sets the power consumed per tick
+
+groovyscript.wiki.techreborn.thermal_generator.title=Thermal Generator
+groovyscript.wiki.techreborn.thermal_generator.description=Converts a fluidstack input into power, at a given rate per tick.
+groovyscript.wiki.techreborn.thermal_generator.energy.value=Sets the total amount of energy generated from a bucket
+groovyscript.wiki.techreborn.thermal_generator.perTick.value=Sets the FE generated per tick
+
+groovyscript.wiki.techreborn.vacuum_freezer.title=Vacuum Freezer
+groovyscript.wiki.techreborn.vacuum_freezer.description=Converts an itemstack input into an itemstack output after a given process time, consuming energy per tick.
+groovyscript.wiki.techreborn.vacuum_freezer.time.value=Sets the time in ticks the recipe takes to complete
+groovyscript.wiki.techreborn.vacuum_freezer.perTick.value=Sets the power consumed per tick
+
+groovyscript.wiki.techreborn.wire_mill.title=Wire Mill
+groovyscript.wiki.techreborn.wire_mill.description=Converts an itemstack input into an itemstack output after a given process time, consuming energy per tick.
+groovyscript.wiki.techreborn.wire_mill.time.value=Sets the time in ticks the recipe takes to complete
+groovyscript.wiki.techreborn.wire_mill.perTick.value=Sets the power consumed per tick
+
+
 # Tinkers
 groovyscript.wiki.tconstruct.smeltery_fuel.title=Smeltery Fuel
 groovyscript.wiki.tconstruct.smeltery_fuel.description=Modifies what fluids are accepted as fuels for the Smeltery and how long each fuels the Smeltery.

--- a/src/main/resources/mixin.groovyscript.techreborn.json
+++ b/src/main/resources/mixin.groovyscript.techreborn.json
@@ -1,0 +1,10 @@
+{
+  "package": "com.cleanroommc.groovyscript.core.mixin.techreborn",
+  "refmap": "mixins.groovyscript.refmap.json",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": [
+    "RollingMachineRecipeWrapperMixin"
+  ]
+}


### PR DESCRIPTION
changes in this PR:
- adds `compileOnly "io.github.classgraph:classgraph:4.8.165"` to make it so mods that shade classgraph don't override our version in the dev environment.
- notes what the maven repos get in a comment next to the maven repo.
- adds the https://modmaven.dev maven repo.
- reduces some duplication in the `AbstractRecipeBuilder.validateXYZ` code
- adds compat to multiple different types of Tech Reborn processes (total of 26):
	- some basic machines: `AlloySmelter`, `AssemblingMachine`, `Centrifuge`, `ChemicalReactor`, `Compressor`, `Extractor`, `Grinder`, `PlateBendingMachine`, `SolidCanningMachine`, and `WireMill`.
	- some advanced machines: `BlastFurnace`, `DistillationTower`, `ImplosionCompressor`, `IndustrialElectrolyzer`, `IndustrialGrinder`, `IndustrialSawmill`, `Scrapbox`, and `VacuumFreezer`.
	- powergens: `DieselGenerator`, `GasTurbine`, `PlasmaGenerator`, `SemiFluidGenerator`, and `ThermalGenerator`.
	- some unique machines: `RollingMachine`, `FluidReplicator`, and `FusionReactor`.
- adds examples file and i18n wiki keys for the above compat.



<details><summary>Note: this was resolved via mixin</summary>
<p>
currently, due to how the `RollingMachine` is implemented, custom recipes do not display in JEI, as they do not implement one of the specifically handled classes in `RollingMachineRecipeWrapper.create`. the recipes are still craftable, only JEI is broken. i am unsure of how to best resolve this.
</p>
</details> 
