### PR TITLE
Minor Cleanup of IDE warnings, also small bugfixes

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -143,4 +143,16 @@ minecraft {
     if (project.debug_run_ls.toBoolean()) {
         extraRunJvmArguments.add('-Dgroovyscript.run_ls=true')
     }
+    if (project.debug_generate_examples.toBoolean()) {
+        extraRunJvmArguments.add('-Dgroovyscript.generate_examples=true')
+    }
+    if (project.debug_generate_wiki.toBoolean()) {
+        extraRunJvmArguments.add('-Dgroovyscript.generate_wiki=true')
+    }
+    if (project.debug_generate_and_crash.toBoolean()) {
+        extraRunJvmArguments.add('-Dgroovyscript.generate_and_crash=true')
+    }
+    if (project.debug_log_missing_lang_keys.toBoolean()) {
+        extraRunJvmArguments.add('-Dgroovyscript.log_missing_lang_keys=true')
+    }
 }

--- a/examples/postInit/mekanism.groovy
+++ b/examples/postInit/mekanism.groovy
@@ -8,13 +8,13 @@ println 'mod \'mekanism\' detected, running script'
 // Add new infusion types and itemstacks to those types.
 
 mods.mekanism.infusion.remove(ore('dustDiamond'))
-mods.mekanism.infusion.removeByType(infusion('carbon'))
-// mods.mekanism.infusion.removeByType(infusion('diamond'))
+mods.mekanism.infusion.removeByType(infusionType('carbon'))
+// mods.mekanism.infusion.removeByType(infusionType('diamond'))
 // mods.mekanism.infusion.removeAll()
 
 mods.mekanism.infusion.addType('groovy_example', resource('placeholdername:blocks/mekanism_infusion_texture'))
-mods.mekanism.infusion.add(infusion('diamond'), 100, item('minecraft:clay'))
-mods.mekanism.infusion.add(infusion('carbon'), 100, item('minecraft:gold_ingot'))
+mods.mekanism.infusion.add(infusionType('diamond'), 100, item('minecraft:clay'))
+mods.mekanism.infusion.add(infusionType('carbon'), 100, item('minecraft:gold_ingot'))
 mods.mekanism.infusion.add('groovy_example', 10, item('minecraft:ice'))
 mods.mekanism.infusion.add('groovy_example', 20, item('minecraft:packed_ice'))
 
@@ -155,13 +155,13 @@ mods.mekanism.metallurgic_infuser.removeByInput(ore('dustObsidian'), 'DIAMOND')
 
 mods.mekanism.metallurgic_infuser.recipeBuilder()
     .input(item('minecraft:nether_star'))
-    .infuse(infusion('groovy_example'))
+    .infuse(infusionType('groovy_example'))
     .amount(50)
     .output(item('minecraft:clay'))
     .register()
 
 
-// mods.mekanism.metallurgic_infuser.add(item('minecraft:nether_star'), infusion('groovy_example'), 50, item('minecraft:clay'))
+// mods.mekanism.metallurgic_infuser.add(item('minecraft:nether_star'), infusionType('groovy_example'), 50, item('minecraft:clay'))
 
 // Osmium Compressor:
 // Converts an input itemstack and 200 of a gasstack into an output itemstack. By default, will use Liquid Osmium as the

--- a/examples/postInit/thermalexpansion.groovy
+++ b/examples/postInit/thermalexpansion.groovy
@@ -108,10 +108,10 @@ mods.thermalexpansion.charger.recipeBuilder()
 // Converts an input itemstack into an output itemstack, with different modes each requiring a different augment to be
 // installed, costing power and taking time based on the power cost.
 
-mods.thermalexpansion.compactor.removeByInput(mode('coin'), item('thermalfoundation:material:130'))
+mods.thermalexpansion.compactor.removeByInput(compactorMode('coin'), item('thermalfoundation:material:130'))
 mods.thermalexpansion.compactor.removeByInput(item('minecraft:iron_ingot'))
-// mods.thermalexpansion.compactor.removeByMode(mode('plate'))
-mods.thermalexpansion.compactor.removeByOutput(mode('coin'), item('thermalfoundation:coin:102'))
+// mods.thermalexpansion.compactor.removeByMode(compactorMode('plate'))
+mods.thermalexpansion.compactor.removeByOutput(compactorMode('coin'), item('thermalfoundation:coin:102'))
 mods.thermalexpansion.compactor.removeByOutput(item('minecraft:blaze_rod'))
 mods.thermalexpansion.compactor.removeByOutput(item('thermalfoundation:material:24'))
 // mods.thermalexpansion.compactor.removeAll()
@@ -119,24 +119,24 @@ mods.thermalexpansion.compactor.removeByOutput(item('thermalfoundation:material:
 mods.thermalexpansion.compactor.recipeBuilder()
     .input(item('minecraft:clay'))
     .output(item('minecraft:diamond') * 2)
-    .mode(mode('coin'))
+    .mode(compactorMode('coin'))
     .register()
 
 mods.thermalexpansion.compactor.recipeBuilder()
     .input(item('minecraft:clay'))
     .output(item('minecraft:diamond'))
-    .mode(mode('all'))
+    .mode(compactorMode('all'))
     .register()
 
 mods.thermalexpansion.compactor.recipeBuilder()
     .input(item('minecraft:diamond') * 2)
     .output(item('minecraft:gold_ingot'))
-    .mode(mode('plate'))
+    .mode(compactorMode('plate'))
     .energy(1000)
     .register()
 
 
-// mods.thermalexpansion.compactor.add(1000, mode('plate'), item('minecraft:obsidian') * 2, item('minecraft:gold_ingot'))
+// mods.thermalexpansion.compactor.add(1000, compactorMode('plate'), item('minecraft:obsidian') * 2, item('minecraft:gold_ingot'))
 
 // Compression Dynamo:
 // Converts an input fluidstack into power, taking time based on the power.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,17 @@
-# Debug mod compat
+
+# SECTION: development environment settings
+
+debug_run_ls = false
+debug_use_examples_folder = true
+debug_log_missing_lang_keys = true
+debug_generate_examples = false
+debug_generate_wiki = false
+debug_generate_and_crash = false
+
+# END SECTION: development environment settings
+
+# SECTION: debug mod compat
+
 debug_actually_additions = false
 debug_adv_mortars = false
 debug_aether = false
@@ -35,6 +48,16 @@ debug_thermal = false
 debug_tinkers = false
 debug_woot = false
 
+# END SECTION: debug mod compat
+
+# SECTION: custom injected tags
+
+groovy_version = 4.0.21
+
+# END SECTION: custom injected tags
+
+# SECTION: GTCEu Buildscript
+
 modName = GroovyScript
 
 # This is a case-sensitive string to identify your mod. Convention is to use lower case.
@@ -45,13 +68,6 @@ modGroup = com.cleanroommc.groovyscript
 # Version of your mod.
 # This field can be left empty if you want your mod's version to be determined by the latest git tag instead.
 modVersion = 1.0.2
-groovy_version = 4.0.21
-debug_use_examples_folder = true
-debug_run_ls = false
-debug_generate_examples = false
-debug_generate_wiki = false
-debug_generate_and_crash = false
-debug_log_missing_lang_keys = true
 
 # Whether to use the old jar naming structure (modid-mcversion-version) instead of the new version (modid-version)
 includeMCVersionJar = false

--- a/gradle.properties
+++ b/gradle.properties
@@ -48,6 +48,10 @@ modVersion = 1.0.2
 groovy_version = 4.0.21
 debug_use_examples_folder = true
 debug_run_ls = false
+debug_generate_examples = false
+debug_generate_wiki = false
+debug_generate_and_crash = false
+debug_log_missing_lang_keys = true
 
 # Whether to use the old jar naming structure (modid-mcversion-version) instead of the new version (modid-version)
 includeMCVersionJar = false

--- a/src/main/java/com/cleanroommc/groovyscript/GroovyScript.java
+++ b/src/main/java/com/cleanroommc/groovyscript/GroovyScript.java
@@ -95,7 +95,7 @@ public class GroovyScript {
     private static Thread languageServerThread;
 
     private static KeyBinding reloadKey;
-    private static long timeSinceLastUse = 0;
+    private static long timeSinceLastUse;
 
     public static final Random RND = new Random();
 

--- a/src/main/java/com/cleanroommc/groovyscript/api/documentation/annotations/Admonition.java
+++ b/src/main/java/com/cleanroommc/groovyscript/api/documentation/annotations/Admonition.java
@@ -74,7 +74,7 @@ public @interface Admonition {
         /**
          * A box which can be toggled between only rendering the title and the full text. Defaults to the expanded form (both title and text visible).
          */
-        EXPANDED;
+        EXPANDED
     }
 
 

--- a/src/main/java/com/cleanroommc/groovyscript/command/GSCommand.java
+++ b/src/main/java/com/cleanroommc/groovyscript/command/GSCommand.java
@@ -83,8 +83,7 @@ public class GSCommand extends CommandTreeBase {
         addSubcommand(new PackmodeCommand());
 
         addSubcommand(new SimpleCommand("hand", (server, sender, args) -> {
-            if (sender instanceof EntityPlayer) {
-                EntityPlayer player = (EntityPlayer) sender;
+            if (sender instanceof EntityPlayer player) {
                 ItemStack stack = player.getHeldItem(EnumHand.MAIN_HAND);
                 if (stack.isEmpty()) stack = player.getHeldItem(EnumHand.OFF_HAND);
                 BlockPos pos = null;

--- a/src/main/java/com/cleanroommc/groovyscript/command/GSMekanismCommand.java
+++ b/src/main/java/com/cleanroommc/groovyscript/command/GSMekanismCommand.java
@@ -37,7 +37,7 @@ public class GSMekanismCommand extends CommandTreeBase {
     }
 
     @Override
-    public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException {
+    public void execute(@NotNull MinecraftServer server, @NotNull ICommandSender sender, String @NotNull [] args) throws CommandException {
         if (!ModSupport.MEKANISM.isLoaded()) {
             sender.sendMessage(new TextComponentString(TextFormatting.RED + "Mekanism is not loaded!"));
             return;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/WarningScreen.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/WarningScreen.java
@@ -32,7 +32,10 @@ public class WarningScreen extends GuiScreen {
         drawString(this.fontRenderer, this.title, this.width / 2 - this.fontRenderer.getStringWidth(this.title) / 2, 14, 0xFFFFFFFF);
         int titleHeight = 14 + this.fontRenderer.FONT_HEIGHT;
 
-        int x, y, w, h;
+        int x;
+        int y;
+        int w;
+        int h;
         if (this.width <= 110) {
             x = 10;
             w = this.width - 10;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/WarningScreen.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/WarningScreen.java
@@ -15,12 +15,12 @@ import java.util.List;
 @SideOnly(Side.CLIENT)
 public class WarningScreen extends GuiScreen {
 
-    public static boolean wasOpened = false;
+    public static boolean wasOpened;
 
     public final String title = TextFormatting.BOLD + "! Warning from GroovyScript !";
     public final List<String> messages;
     private List<String> lines;
-    private int lastWidth = 0;
+    private int lastWidth;
 
     public WarningScreen(List<String> messages) {
         this.messages = messages;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/content/GroovyBlock.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/content/GroovyBlock.java
@@ -28,7 +28,7 @@ import java.util.Map;
 
 public class GroovyBlock extends Block {
 
-    private static boolean initialised = false;
+    private static boolean initialised;
     private static final String nullTranslationKey = "tile.null";
 
     private static final Map<String, Pair<Block, ItemBlock>> BLOCKS = new Object2ObjectLinkedOpenHashMap<>();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/content/GroovyFluid.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/content/GroovyFluid.java
@@ -101,7 +101,7 @@ public class GroovyFluid extends Fluid {
         private SoundEvent fillSound;
         private SoundEvent emptySound;
 
-        private int luminosity = 0;
+        private int luminosity;
         private int density = 1000;
         private int temperature = 300;
         private int viscosity = 1000;
@@ -110,7 +110,7 @@ public class GroovyFluid extends Fluid {
 
         private Material material = Material.WATER;
         private boolean createBlock = true;
-        private boolean finiteFluidBlock = false;
+        private boolean finiteFluidBlock;
 
         public Builder(String name) {
             this.name = name;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/content/GroovyFluid.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/content/GroovyFluid.java
@@ -93,7 +93,9 @@ public class GroovyFluid extends Fluid {
     public static class Builder {
 
         private final String name;
-        private ResourceLocation still = DEFAULT_STILL, flowing = DEFAULT_FLOWING, overlay;
+        private ResourceLocation still = DEFAULT_STILL;
+        private ResourceLocation flowing = DEFAULT_FLOWING;
+        private ResourceLocation overlay;
         private int color = 0xFFFFFF;
 
         private SoundEvent fillSound;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/content/GroovyItem.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/content/GroovyItem.java
@@ -24,7 +24,7 @@ import java.util.Map;
 
 public class GroovyItem extends Item {
 
-    private static boolean initialised = false;
+    private static boolean initialised;
     private static final String nullTranslationKey = "item.null";
 
     @GroovyBlacklist
@@ -71,9 +71,9 @@ public class GroovyItem extends Item {
         initialised = true;
     }
 
-    private boolean effect = false;
-    private int enchantability = 0;
-    private IRarity rarity = null;
+    private boolean effect;
+    private int enchantability;
+    private IRarity rarity;
 
     public GroovyItem(String loc) {
         setRegistryName(GroovyScript.getRunConfig().getPackId(), loc);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/Explosion.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/Explosion.java
@@ -88,7 +88,7 @@ public class Explosion extends VirtualizedRegistry<Explosion.ExplosionRecipe> {
             if (this.startCondition != null && !ClosureHelper.call(true, this.startCondition, entityItem, itemStack)) return false;
             int count = itemStack.getCount();
             int amountToReplace;
-            if (this.chance >= 1f) {
+            if (this.chance >= 1.0f) {
                 amountToReplace = count;
             } else {
                 // only get 1 random value and approximate a normal distribution (instead of for each item in the stack)
@@ -114,7 +114,7 @@ public class Explosion extends VirtualizedRegistry<Explosion.ExplosionRecipe> {
 
     public static class RecipeBuilder extends AbstractRecipeBuilder<ExplosionRecipe> {
 
-        private float chance = 1f;
+        private float chance = 1.0f;
         private Closure<Boolean> startCondition;
 
         public RecipeBuilder chance(float chance) {
@@ -138,7 +138,7 @@ public class Explosion extends VirtualizedRegistry<Explosion.ExplosionRecipe> {
             validateFluids(msg);
             if (this.chance < 0 || this.chance > 1) {
                 GroovyLog.get().warn("Explosion recipe chance should be greater than 0 and equal or less than 1.");
-                this.chance = 1f;
+                this.chance = 1.0f;
             }
         }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/FluidRecipe.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/FluidRecipe.java
@@ -253,7 +253,7 @@ public abstract class FluidRecipe {
 
         private final EntityItem entityItem;
         private final ItemStack item;
-        private int amountToKill = 0;
+        private int amountToKill;
 
         private ItemContainer(EntityItem entityItem) {
             this.entityItem = entityItem;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/FluidRecipe.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/FluidRecipe.java
@@ -280,13 +280,13 @@ public abstract class FluidRecipe {
 
         public RecipeBuilder<T> input(IIngredient ingredient, float consumeChance) {
             this.input.add(ingredient);
-            this.chances.add(MathHelper.clamp(consumeChance, 0f, 1f));
+            this.chances.add(MathHelper.clamp(consumeChance, 0.0f, 1.0f));
             return this;
         }
 
         @Override
         public AbstractRecipeBuilder<T> input(IIngredient ingredient) {
-            return input(ingredient, 1f);
+            return input(ingredient, 1.0f);
         }
 
         public RecipeBuilder<T> startCondition(Closure<Boolean> startCondition) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/jei/BurningRecipeCategory.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/jei/BurningRecipeCategory.java
@@ -80,7 +80,8 @@ public class BurningRecipeCategory extends BaseCategory<BurningRecipeCategory.Re
             int ticks = this.burningRecipe.getTicks();
             String ticksS = ticks + " ticks";
             int w = minecraft.fontRenderer.getStringWidth(ticksS);
-            int x = 88 - w / 2, y = 44;
+            int x = 88 - w / 2;
+            int y = 44;
             minecraft.fontRenderer.drawString(ticksS, x, y, 0x404040);
         }
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/jei/BurningRecipeCategory.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/jei/BurningRecipeCategory.java
@@ -43,7 +43,7 @@ public class BurningRecipeCategory extends BaseCategory<BurningRecipeCategory.Re
     @Override
     public void drawExtras(@NotNull Minecraft minecraft) {
         minecraft.fontRenderer.drawSplitString(I18n.format("groovyscript.recipe.burning"), 4, 4, 168, 0x404040);
-        GlStateManager.color(1f, 1f, 1f, 1f);
+        GlStateManager.color(1.0f, 1.0f, 1.0f, 1.0f);
         rightArrow.draw(minecraft, 76, 26);
         float tntScale = 0.5f;
         GlStateManager.pushMatrix();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/jei/ExplosionRecipeCategory.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/jei/ExplosionRecipeCategory.java
@@ -82,7 +82,8 @@ public class ExplosionRecipeCategory extends BaseCategory<ExplosionRecipeCategor
             if (chance < 1) {
                 String chanceS = FluidRecipeCategory.numberFormat.format(chance);
                 int w = minecraft.fontRenderer.getStringWidth(chanceS);
-                int x = 88 - w / 2, y = 44;
+                int x = 88 - w / 2;
+                int y = 44;
                 minecraft.fontRenderer.drawString(chanceS, x, y, 0x404040);
             }
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/jei/ExplosionRecipeCategory.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/jei/ExplosionRecipeCategory.java
@@ -44,7 +44,7 @@ public class ExplosionRecipeCategory extends BaseCategory<ExplosionRecipeCategor
     @Override
     public void drawExtras(@NotNull Minecraft minecraft) {
         minecraft.fontRenderer.drawSplitString(I18n.format("groovyscript.recipe.explosion"), 4, 4, 168, 0x404040);
-        GlStateManager.color(1f, 1f, 1f, 1f);
+        GlStateManager.color(1.0f, 1.0f, 1.0f, 1.0f);
         rightArrow.draw(minecraft, 76, 26);
         float tntScale = 0.5f;
         GlStateManager.pushMatrix();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/jei/FluidRecipeCategory.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/jei/FluidRecipeCategory.java
@@ -90,7 +90,7 @@ public class FluidRecipeCategory extends BaseCategory<FluidRecipeCategory.Recipe
     @Override
     public void drawExtras(@NotNull Minecraft minecraft) {
         drawLine(minecraft, "groovyscript.recipe.fluid_recipe", 4, 4, 0x404040);
-        GlStateManager.color(1f, 1f, 1f, 1f);
+        GlStateManager.color(1.0f, 1.0f, 1.0f, 1.0f);
         this.downRightArrow.draw(minecraft, 23, outputY - 3);
         rightArrow.draw(minecraft, 76, outputY + 1);
     }
@@ -134,7 +134,7 @@ public class FluidRecipeCategory extends BaseCategory<FluidRecipeCategory.Recipe
                 if (chance == 1.0f) continue;
                 String chanceS = numberFormat.format(chance);
                 float w = minecraft.fontRenderer.getStringWidth(chanceS) * scale;
-                float xx = 9 - w / 2f;
+                float xx = 9 - w / 2.0f;
                 GlStateManager.pushMatrix();
                 GlStateManager.translate(x + xx, y - 1, 0);
                 GlStateManager.translate(xx, yOff, 0);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/jei/FluidRecipeCategory.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/jei/FluidRecipeCategory.java
@@ -126,7 +126,8 @@ public class FluidRecipeCategory extends BaseCategory<FluidRecipeCategory.Recipe
 
             float scale = 0.6f;
             float yOff = 9 * scale;
-            int y = inputY + 18, x = 7 - 18;
+            int y = inputY + 18;
+            int x = 7 - 18;
             for (int i = 0, n = this.recipe.getItemInputs().length; i < n; i++) {
                 x += 18;
                 float chance = this.recipe.getItemConsumeChance()[i];

--- a/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/jei/PistonPushRecipeCategory.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/jei/PistonPushRecipeCategory.java
@@ -43,7 +43,7 @@ public class PistonPushRecipeCategory extends BaseCategory<PistonPushRecipeCateg
     @Override
     public void drawExtras(@NotNull Minecraft minecraft) {
         minecraft.fontRenderer.drawSplitString(I18n.format("groovyscript.recipe.piston_push"), 4, 4, 168, 0x404040);
-        GlStateManager.color(1f, 1f, 1f, 1f);
+        GlStateManager.color(1.0f, 1.0f, 1.0f, 1.0f);
         rightArrow.draw(minecraft, 76, 26);
         float tntScale = 0.5f;
         GlStateManager.pushMatrix();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/loot/Loot.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/loot/Loot.java
@@ -19,6 +19,7 @@ public class Loot extends NamedRegistry implements IScriptReloadable {
 
     // TODO add event shortcut here
 
+    @Override
     @GroovyBlacklist
     @ApiStatus.Internal
     public void onReload() {
@@ -31,6 +32,7 @@ public class Loot extends NamedRegistry implements IScriptReloadable {
         }
     }
 
+    @Override
     @GroovyBlacklist
     @ApiStatus.Internal
     public void afterScriptLoad() {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/loot/Loot.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/loot/Loot.java
@@ -15,7 +15,7 @@ import java.util.Map;
 
 public class Loot extends NamedRegistry implements IScriptReloadable {
 
-    public Map<ResourceLocation, LootTable> tables = new Object2ObjectOpenHashMap<>();
+    public final Map<ResourceLocation, LootTable> tables = new Object2ObjectOpenHashMap<>();
 
     // TODO add event shortcut here
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ModSupport.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ModSupport.java
@@ -56,7 +56,7 @@ public class ModSupport {
     private static final Map<String, GroovyContainer<? extends GroovyPropertyContainer>> containersView = Collections.unmodifiableMap(containers);
     private static final List<GroovyContainer<? extends GroovyPropertyContainer>> containerList = new ArrayList<>();
     private static final Set<Class<?>> externalPluginClasses = new ObjectOpenHashSet<>();
-    private static boolean frozen = false;
+    private static boolean frozen;
 
     public static final ModSupport INSTANCE = new ModSupport(); // Just for Binding purposes
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/actuallyadditions/Empowerer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/actuallyadditions/Empowerer.java
@@ -154,9 +154,9 @@ public class Empowerer extends VirtualizedRegistry<EmpowererRecipe> {
         @RecipeBuilderMethodDescription(field = {"red", "green", "blue"})
         public RecipeBuilder particleColor(int hex) {
             Color color = new Color(hex);
-            this.red = color.getRed() / 255f;
-            this.green = color.getGreen() / 255f;
-            this.blue = color.getBlue() / 255f;
+            this.red = color.getRed() / 255.0f;
+            this.green = color.getGreen() / 255.0f;
+            this.blue = color.getBlue() / 255.0f;
             return this;
         }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/actuallyadditions/OilGen.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/actuallyadditions/OilGen.java
@@ -96,6 +96,7 @@ public class OilGen extends VirtualizedRegistry<OilGenRecipe> {
         @Property(valid = @Comp(type = Comp.Type.GTE, value = "0"))
         private int time;
 
+        @Override
         @RecipeBuilderMethodDescription(field = {"fluidInput", "amount"})
         public RecipeBuilder fluidInput(FluidStack fluid) {
             this.fluidInput.add(fluid);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Dissolver.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Dissolver.java
@@ -114,11 +114,13 @@ public class Dissolver extends VirtualizedRegistry<DissolverRecipe> {
             return this.probabilityOutput(100, probabilityOutputs);
         }
 
+        @Override
         @RecipeBuilderMethodDescription(field = "probabilityGroup")
         public RecipeBuilder output(ItemStack... probabilityOutputs) {
             return this.probabilityOutput(100, probabilityOutputs);
         }
 
+        @Override
         @RecipeBuilderMethodDescription(field = "probabilityGroup")
         public RecipeBuilder output(Collection<ItemStack> probabilityOutputs) {
             return this.probabilityOutput(100, probabilityOutputs);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Dissolver.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Dissolver.java
@@ -84,7 +84,7 @@ public class Dissolver extends VirtualizedRegistry<DissolverRecipe> {
     public static class RecipeBuilder extends AbstractRecipeBuilder<DissolverRecipe> {
 
         @Property(valid = @Comp(value = "1", type = Comp.Type.GTE))
-        private final ArrayList<ProbabilityGroup> probabilityGroup = new ArrayList<>();
+        private final List<ProbabilityGroup> probabilityGroup = new ArrayList<>();
         @Property
         private boolean reversible;
         @Property

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/appliedenergistics2/Spatial.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/appliedenergistics2/Spatial.java
@@ -20,6 +20,7 @@ public class Spatial extends VirtualizedRegistry<Class<? extends TileEntity>> {
         restoreFromBackup().forEach(AEApi.instance().registries().movable()::whiteListTileEntity);
     }
 
+    @Override
     public void afterScriptLoad() {
         ((MovableTileRegistryAccessor) AEApi.instance().registries().movable()).getValid().clear();
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/arcanearchives/GemCuttingTable.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/arcanearchives/GemCuttingTable.java
@@ -117,7 +117,7 @@ public class GemCuttingTable extends VirtualizedRegistry<IGCTRecipe> {
         @RecipeBuilderRegistrationMethod
         public @Nullable IGCTRecipe register() {
             if (!validate()) return null;
-            IGCTRecipe recipe = new GCTRecipe(name, output.get(0), input.stream().map(x -> new IngredientStack(x.toMcIngredient(), x.getAmount())).collect(Collectors.toList()));
+            IGCTRecipe recipe = new GCTRecipe(super.name, output.get(0), input.stream().map(x -> new IngredientStack(x.toMcIngredient(), x.getAmount())).collect(Collectors.toList()));
             ModSupport.ARCANE_ARCHIVES.get().gemCuttingTable.add(recipe);
             return recipe;
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/ChaliceInteraction.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/ChaliceInteraction.java
@@ -140,6 +140,7 @@ public class ChaliceInteraction extends VirtualizedRegistry<LiquidInteraction> {
             return this.result(item, weight);
         }
 
+        @Override
         @RecipeBuilderMethodDescription(field = {"output", "probabilities"})
         public RecipeBuilder output(ItemStack item) {
             return this.result(item, 1);
@@ -162,6 +163,7 @@ public class ChaliceInteraction extends VirtualizedRegistry<LiquidInteraction> {
             return this.component(fluid, chance);
         }
 
+        @Override
         @RecipeBuilderMethodDescription(field = {"fluidInput", "chances"})
         public RecipeBuilder fluidInput(FluidStack fluid) {
             return this.component(fluid, 1.0F);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/Constellation.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/Constellation.java
@@ -251,7 +251,7 @@ public class Constellation extends VirtualizedRegistry<IConstellation> {
         @Property(ignoresInheritedMethods = true, valid = @Comp(value = "null", type = Comp.Type.NOT))
         private String name;
         @Property(defaultValue = "Major: #2843CC, Weak: #432CB0, Minor: #5D197F")
-        private Color color = null;
+        private Color color;
         @Property
         private ConstellationBuilder.Type type;
 
@@ -398,7 +398,7 @@ public class Constellation extends VirtualizedRegistry<IConstellation> {
         @Property(valid = @Comp(value = "0", type = Comp.Type.GTE)) // TODO note that this is only if other is empty
         private final List<ConstellationMapEffectRegistry.PotionMapEffect> potionEffect = new ArrayList<>();
         @Property(valid = @Comp(value = "null", type = Comp.Type.NOT))
-        private IConstellation constellation = null;
+        private IConstellation constellation;
 
         @RecipeBuilderMethodDescription
         public ConstellationMapEffectBuilder constellation(IConstellation constellation) {
@@ -440,9 +440,9 @@ public class Constellation extends VirtualizedRegistry<IConstellation> {
         @Property
         private final List<IIngredient> items = new ArrayList<>();
         @Property(valid = @Comp(value = "null", type = Comp.Type.NOT))
-        private IConstellation constellation = null;
+        private IConstellation constellation;
         @Property
-        private boolean doStrip = false;
+        private boolean doStrip;
 
         @RecipeBuilderMethodDescription
         public SignatureItemsHelper constellation(IConstellation constellation) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/Constellation.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/Constellation.java
@@ -331,16 +331,11 @@ public class Constellation extends VirtualizedRegistry<IConstellation> {
             }
 
             if (this.color == null) {
-                switch (this.type) {
-                    case MAJOR:
-                        this.color = new Color(40, 67, 204);
-                        break;
-                    case WEAK:
-                        this.color = new Color(67, 44, 176);
-                        break;
-                    case MINOR:
-                        this.color = new Color(93, 25, 127);
-                }
+                this.color = switch (this.type) {
+                    case MAJOR -> new Color(40, 67, 204);
+                    case WEAK -> new Color(67, 44, 176);
+                    case MINOR -> new Color(93, 25, 127);
+                };
             }
 
             return true;
@@ -349,20 +344,11 @@ public class Constellation extends VirtualizedRegistry<IConstellation> {
         @RecipeBuilderRegistrationMethod
         public void register() {
             if (!validate()) return;
-            IConstellation constellation;
-            switch (this.type) {
-                case MAJOR:
-                    constellation = new ConstellationBase.Major(name, color);
-                    break;
-                case WEAK:
-                    constellation = new ConstellationBase.Minor(name, color, phases.toArray(new MoonPhase[0]));
-                    break;
-                case MINOR:
-                    constellation = new ConstellationBase.Weak(name, color);
-                    break;
-                default:
-                    return;
-            }
+            IConstellation constellation = switch (this.type) {
+                case MAJOR -> new ConstellationBase.Major(name, color);
+                case WEAK -> new ConstellationBase.Minor(name, color, phases.toArray(new MoonPhase[0]));
+                case MINOR -> new ConstellationBase.Weak(name, color);
+            };
             Map<Point, StarLocation> addedStars = new Object2ObjectOpenHashMap<>();
             this.connections.forEach(connection -> {
                 StarLocation s1;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/Constellation.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/Constellation.java
@@ -81,6 +81,7 @@ public class Constellation extends VirtualizedRegistry<IConstellation> {
         this.signatureItemsRemoved.clear();
     }
 
+    @Override
     public void afterScriptLoad() {
         ConstellationRegistryAccessor.getConstellationList().forEach(constellation -> {
             if (!(constellation instanceof IMinorConstellation)) updateDefaultCapeRecipe(constellation);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/Constellation.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/Constellation.java
@@ -492,9 +492,8 @@ public class Constellation extends VirtualizedRegistry<IConstellation> {
 
         @Override
         public boolean equals(Object o) {
-            if (!(o instanceof Point2PointConnection)) return false;
+            if (!(o instanceof Point2PointConnection other)) return false;
             if (o == this) return true;
-            Point2PointConnection other = (Point2PointConnection) o;
             return ((p1.equals(other.p1) && p2.equals(other.p2)) || (p2.equals(other.p1) && p1.equals(other.p2)));
         }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/Constellation.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/Constellation.java
@@ -364,7 +364,8 @@ public class Constellation extends VirtualizedRegistry<IConstellation> {
             }
             Map<Point, StarLocation> addedStars = new Object2ObjectOpenHashMap<>();
             this.connections.forEach(connection -> {
-                StarLocation s1, s2;
+                StarLocation s1;
+                StarLocation s2;
                 if (addedStars.containsKey(connection.p1)) {
                     s1 = addedStars.get(connection.p1);
                 } else {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/Constellation.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/Constellation.java
@@ -44,10 +44,10 @@ import java.util.*;
 )
 public class Constellation extends VirtualizedRegistry<IConstellation> {
 
-    private final HashMap<IConstellation, ConstellationMapEffectRegistry.MapEffect> constellationMapEffectsAdded = new HashMap<>();
-    private final HashMap<IConstellation, ConstellationMapEffectRegistry.MapEffect> constellationMapEffectsRemoved = new HashMap<>();
-    private final HashMap<IConstellation, List<ItemHandle>> signatureItemsAdded = new HashMap<>();
-    private final HashMap<IConstellation, List<ItemHandle>> signatureItemsRemoved = new HashMap<>();
+    private final Map<IConstellation, ConstellationMapEffectRegistry.MapEffect> constellationMapEffectsAdded = new HashMap<>();
+    private final Map<IConstellation, ConstellationMapEffectRegistry.MapEffect> constellationMapEffectsRemoved = new HashMap<>();
+    private final Map<IConstellation, List<ItemHandle>> signatureItemsAdded = new HashMap<>();
+    private final Map<IConstellation, List<ItemHandle>> signatureItemsRemoved = new HashMap<>();
 
     @Override
     @GroovyBlacklist
@@ -245,9 +245,9 @@ public class Constellation extends VirtualizedRegistry<IConstellation> {
     public static class ConstellationBuilder {
 
         @Property(valid = @Comp(value = "0", type = Comp.Type.GTE))
-        private final ArrayList<Point2PointConnection> connections = new ArrayList<>();
+        private final List<Point2PointConnection> connections = new ArrayList<>();
         @Property(valid = @Comp(value = "0", type = Comp.Type.GTE)) // TODO note that this is only if type is MINOR
-        private final ArrayList<MoonPhase> phases = new ArrayList<>();
+        private final List<MoonPhase> phases = new ArrayList<>();
         @Property(ignoresInheritedMethods = true, valid = @Comp(value = "null", type = Comp.Type.NOT))
         private String name;
         @Property(defaultValue = "Major: #2843CC, Weak: #432CB0, Minor: #5D197F")
@@ -437,7 +437,7 @@ public class Constellation extends VirtualizedRegistry<IConstellation> {
     public static class SignatureItemsHelper {
 
         @Property
-        private final ArrayList<IIngredient> items = new ArrayList<>();
+        private final List<IIngredient> items = new ArrayList<>();
         @Property(valid = @Comp(value = "null", type = Comp.Type.NOT))
         private IConstellation constellation = null;
         @Property

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/Fountain.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/Fountain.java
@@ -31,6 +31,7 @@ public class Fountain extends VirtualizedRegistry<FluidRarityRegistry.FluidRarit
         restoreFromBackup().forEach(((FluidRarityRegistryAccessor) FluidRarityRegistry.INSTANCE).getRarityList()::add);
     }
 
+    @Override
     public void afterScriptLoad() {
         // If the rarity list is empty, generating new chunks will cause a NPE. To prevent this, we add a "water" entry that will always have 0mb inside,
         // which causes it to be marked as empty, and thus not be interactable.
@@ -154,6 +155,7 @@ public class Fountain extends VirtualizedRegistry<FluidRarityRegistry.FluidRarit
             return out.getLevel() != Level.ERROR;
         }
 
+        @Override
         @RecipeBuilderRegistrationMethod
         public FluidRarityRegistry.FluidRarityEntry register() {
             if (!validate()) return null;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/Fountain.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/Fountain.java
@@ -132,6 +132,7 @@ public class Fountain extends VirtualizedRegistry<FluidRarityRegistry.FluidRarit
             return this;
         }
 
+        @Override
         public boolean validate() {
             GroovyLog.Msg out = GroovyLog.msg("Error adding fluid to Astral Sorcery Fountain").warn();
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/Fountain.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/Fountain.java
@@ -94,13 +94,13 @@ public class Fountain extends VirtualizedRegistry<FluidRarityRegistry.FluidRarit
     public static class FountainChanceHelper implements IRecipeBuilder<FluidRarityRegistry.FluidRarityEntry> {
 
         @Property(valid = @Comp(value = "null", type = Comp.Type.NOT))
-        private Fluid fluid = null;
+        private Fluid fluid;
         @Property(valid = @Comp(value = "0", type = Comp.Type.GTE))
-        private int rarity = 0;
+        private int rarity;
         @Property(valid = @Comp(value = "0", type = Comp.Type.GTE))
-        private int minimumAmount = 0;
+        private int minimumAmount;
         @Property(valid = @Comp(value = "0", type = Comp.Type.GTE))
-        private int variance = 0;
+        private int variance;
 
         @RecipeBuilderMethodDescription
         public FountainChanceHelper fluid(Fluid fluid) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/Grindstone.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/Grindstone.java
@@ -100,9 +100,9 @@ public class Grindstone extends VirtualizedRegistry<GrindstoneRecipe> {
     public static class RecipeBuilder extends AbstractRecipeBuilder<GrindstoneRecipe> {
 
         @Property(valid = @Comp(value = "0", type = Comp.Type.GTE))
-        private int weight = 0;
+        private int weight;
         @Property(valid = {@Comp(value = "0", type = Comp.Type.GTE), @Comp(value = "1", type = Comp.Type.LTE)})
-        private float secondaryChance = 0.0F;
+        private float secondaryChance;
 
         @RecipeBuilderMethodDescription
         public RecipeBuilder weight(int weight) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/Grindstone.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/Grindstone.java
@@ -128,6 +128,7 @@ public class Grindstone extends VirtualizedRegistry<GrindstoneRecipe> {
             msg.add(secondaryChance < 0 || secondaryChance > 1, () -> "Secondary chance must be between [0,1]. Instead found " + secondaryChance + ".");
         }
 
+        @Override
         @RecipeBuilderRegistrationMethod
         public GrindstoneRecipe register() {
             if (!validate()) return null;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/InfusionAltar.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/InfusionAltar.java
@@ -105,7 +105,7 @@ public class InfusionAltar extends VirtualizedRegistry<BasicInfusionRecipe> {
         @Property
         private boolean chalice = true;
         @Property
-        private boolean consumeMultiple = false;
+        private boolean consumeMultiple;
         @Property(valid = @Comp(value = "0", type = Comp.Type.GT))
         private int time = 200;
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/InfusionAltar.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/InfusionAltar.java
@@ -35,6 +35,7 @@ public class InfusionAltar extends VirtualizedRegistry<BasicInfusionRecipe> {
         restoreFromBackup().forEach(InfusionRecipeRegistry::registerInfusionRecipe);
     }
 
+    @Override
     public void afterScriptLoad() {
         InfusionRecipeRegistry.compileRecipes();
     }
@@ -163,6 +164,7 @@ public class InfusionAltar extends VirtualizedRegistry<BasicInfusionRecipe> {
         public @Nullable BasicInfusionRecipe register() {
             if (!validate()) return null;
             BasicInfusionRecipe recipe = new BasicInfusionRecipe(output.get(0), AstralSorcery.toItemHandle(input.get(0))) {
+                @Override
                 public int craftingTickTime() {
                     return time;
                 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/LightTransmutation.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/LightTransmutation.java
@@ -193,6 +193,7 @@ public class LightTransmutation extends VirtualizedRegistry<LightOreTransmutatio
             if (outStack == null && output != null) outStack = new ItemStack(output.getBlock());
         }
 
+        @Override
         @RecipeBuilderRegistrationMethod
         public LightOreTransmutations.Transmutation register() {
             if (!validate()) return null;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/LightTransmutation.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/LightTransmutation.java
@@ -16,7 +16,6 @@ import net.minecraft.item.ItemStack;
 import org.jetbrains.annotations.ApiStatus;
 
 import javax.annotation.Nonnull;
-import java.util.ArrayList;
 import java.util.List;
 
 @RegistryDescription

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/LightTransmutation.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/LightTransmutation.java
@@ -116,19 +116,19 @@ public class LightTransmutation extends VirtualizedRegistry<LightOreTransmutatio
     public static class RecipeBuilder extends AbstractRecipeBuilder<LightOreTransmutations.Transmutation> {
 
         @Property(valid = {@Comp(value = "null", type = Comp.Type.NOT), @Comp(value = "input", type = Comp.Type.NOT)})
-        private Block inBlock = null;
+        private Block inBlock;
         @Property(ignoresInheritedMethods = true, valid = {@Comp(value = "null", type = Comp.Type.NOT), @Comp(value = "inBlock", type = Comp.Type.NOT)})
-        private IBlockState input = null;
+        private IBlockState input;
         @Property(ignoresInheritedMethods = true, valid = @Comp(value = "null", type = Comp.Type.NOT))
-        private IBlockState output = null;
+        private IBlockState output;
         @Property(valid = @Comp(value = "0", type = Comp.Type.GTE))
-        private double cost = 0;
+        private double cost;
         @Property
-        private ItemStack outStack = null;
+        private ItemStack outStack;
         @Property
-        private ItemStack inStack = null;
+        private ItemStack inStack;
         @Property
-        private IWeakConstellation constellation = null;
+        private IWeakConstellation constellation;
 
         @RecipeBuilderMethodDescription(field = "inStack")
         public RecipeBuilder inputDisplayStack(ItemStack item) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/Lightwell.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/Lightwell.java
@@ -105,15 +105,15 @@ public class Lightwell extends VirtualizedRegistry<WellLiquefaction.Liquefaction
     public static class RecipeBuilder implements IRecipeBuilder<WellLiquefaction.LiquefactionEntry> {
 
         @Property(valid = @Comp(value = "null", type = Comp.Type.NOT))
-        private ItemStack catalyst = null;
+        private ItemStack catalyst;
         @Property(ignoresInheritedMethods = true, valid = @Comp(value = "null", type = Comp.Type.NOT))
-        private Fluid output = null;
+        private Fluid output;
         @Property(valid = @Comp(value = "0", type = Comp.Type.GTE))
-        private float productionMultiplier = 0.0F;
+        private float productionMultiplier;
         @Property(valid = @Comp(value = "0", type = Comp.Type.GTE))
-        private float shatterMultiplier = 0.0F;
+        private float shatterMultiplier;
         @Property
-        private Color color = null;
+        private Color color;
 
         @RecipeBuilderMethodDescription
         public RecipeBuilder catalyst(ItemStack catalyst) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/Lightwell.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/Lightwell.java
@@ -163,6 +163,7 @@ public class Lightwell extends VirtualizedRegistry<WellLiquefaction.Liquefaction
             return this;
         }
 
+        @Override
         public boolean validate() {
             GroovyLog.Msg out = GroovyLog.msg("Error adding recipe to Astral Sorcery Lightwell");
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/Lightwell.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/Lightwell.java
@@ -181,6 +181,7 @@ public class Lightwell extends VirtualizedRegistry<WellLiquefaction.Liquefaction
             return out.getLevel() != Level.ERROR;
         }
 
+        @Override
         @RecipeBuilderRegistrationMethod
         public WellLiquefaction.LiquefactionEntry register() {
             if (!validate()) return null;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/Research.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/Research.java
@@ -21,6 +21,8 @@ import org.jetbrains.annotations.ApiStatus;
 import java.awt.*;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 @RegistryDescription(
@@ -28,11 +30,11 @@ import java.util.concurrent.atomic.AtomicReference;
 )
 public class Research extends VirtualizedRegistry<ResearchNode> {
 
-    private final HashMap<ResearchNode, ResearchProgression> scriptedCategories = new HashMap<>();
-    private final HashMap<ResearchNode, ResearchProgression> removedCategories = new HashMap<>();
-    private final HashMap<ResearchNode, ArrayList<ResearchNode>> scriptedConnections = new HashMap<>();
-    private final HashMap<ResearchNode, ArrayList<ResearchNode>> removedConnections = new HashMap<>();
-    private final HashMap<ResearchNode, Point> movedNodes = new HashMap<>();
+    private final Map<ResearchNode, ResearchProgression> scriptedCategories = new HashMap<>();
+    private final Map<ResearchNode, ResearchProgression> removedCategories = new HashMap<>();
+    private final Map<ResearchNode, ArrayList<ResearchNode>> scriptedConnections = new HashMap<>();
+    private final Map<ResearchNode, ArrayList<ResearchNode>> removedConnections = new HashMap<>();
+    private final Map<ResearchNode, Point> movedNodes = new HashMap<>();
 
     @Override
     @GroovyBlacklist
@@ -171,9 +173,9 @@ public class Research extends VirtualizedRegistry<ResearchNode> {
     public static class ResearchNodeBuilder {
 
         @Property
-        private final ArrayList<IJournalPage> pages = new ArrayList<>();
+        private final List<IJournalPage> pages = new ArrayList<>();
         @Property
-        private final ArrayList<ResearchNode> connections = new ArrayList<>();
+        private final List<ResearchNode> connections = new ArrayList<>();
         @Property(valid = @Comp(value = "null", type = Comp.Type.NOT))
         private ResearchProgression category;
         @Property(valid = @Comp(value = "null", type = Comp.Type.NOT))

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/perktree/AttributeModifierPerkBuilder.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/perktree/AttributeModifierPerkBuilder.java
@@ -10,12 +10,13 @@ import org.jetbrains.annotations.Nullable;
 
 import java.awt.*;
 import java.util.ArrayList;
+import java.util.List;
 
 public class AttributeModifierPerkBuilder {
 
     ResourceLocation name;
     Point point = new Point();
-    ArrayList<PerkModifierBuilder> modifiers = new ArrayList<>();
+    List<PerkModifierBuilder> modifiers = new ArrayList<>();
     ArrayList<ResourceLocation> connections = new ArrayList<>();
 
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/perktree/AttributeModifierPerkBuilder.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/perktree/AttributeModifierPerkBuilder.java
@@ -90,17 +90,12 @@ public class AttributeModifierPerkBuilder {
         }
 
         public PerkModifierBuilder mode(int mode) {
-            switch (mode) {
-                case 0:
-                    this.mode = PerkAttributeModifier.Mode.ADDITION;
-                    break;
-                case 1:
-                    this.mode = PerkAttributeModifier.Mode.ADDED_MULTIPLY;
-                    break;
-                case 2:
-                    this.mode = PerkAttributeModifier.Mode.STACKING_MULTIPLY;
-                    break;
-            }
+            this.mode = switch (mode) {
+                case 0 -> PerkAttributeModifier.Mode.ADDITION;
+                case 1 -> PerkAttributeModifier.Mode.ADDED_MULTIPLY;
+                case 2 -> PerkAttributeModifier.Mode.STACKING_MULTIPLY;
+                default -> null;
+            };
             return this;
         }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/perktree/GroovyPerkTree.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/perktree/GroovyPerkTree.java
@@ -15,6 +15,7 @@ import org.jetbrains.annotations.ApiStatus;
 import java.awt.*;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Map;
 
 import static hellfirepvp.astralsorcery.common.constellation.perk.tree.PerkTree.PERK_TREE;
 
@@ -24,9 +25,9 @@ import static hellfirepvp.astralsorcery.common.constellation.perk.tree.PerkTree.
 )
 public class GroovyPerkTree extends VirtualizedRegistry<AbstractPerk> {
 
-    private final HashMap<AbstractPerk, ArrayList<ResourceLocation>> scriptedConnections = new HashMap<>();
-    private final HashMap<AbstractPerk, ArrayList<ResourceLocation>> removedConnections = new HashMap<>();
-    private final HashMap<AbstractPerk, Point> movedPerks = new HashMap<>();
+    private final Map<AbstractPerk, ArrayList<ResourceLocation>> scriptedConnections = new HashMap<>();
+    private final Map<AbstractPerk, ArrayList<ResourceLocation>> removedConnections = new HashMap<>();
+    private final Map<AbstractPerk, Point> movedPerks = new HashMap<>();
 
     public GroovyPerkTree() {
         super(Alias.generateOf("PerkTree"));
@@ -64,7 +65,7 @@ public class GroovyPerkTree extends VirtualizedRegistry<AbstractPerk> {
 
     void remove(AbstractPerk perk, boolean doBackup) {
         if (!PERK_TREE.getConnectedPerks(perk).isEmpty()) {
-            ArrayList<AbstractPerk> connectedPerks = new ArrayList<>(PERK_TREE.getConnectedPerks(perk));
+            Iterable<AbstractPerk> connectedPerks = new ArrayList<>(PERK_TREE.getConnectedPerks(perk));
             connectedPerks.forEach(connectedPerk -> this.removeConnection(perk, connectedPerk, doBackup));
         }
         if (doBackup) this.addBackup(perk);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/perktree/PerkTreeConfig.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/perktree/PerkTreeConfig.java
@@ -24,7 +24,7 @@ public class PerkTreeConfig extends VirtualizedRegistry<Closure<Long>> {
         this.setLevelCap(30);
     }
 
-    public Closure<Long> xpFunction = null;
+    public Closure<Long> xpFunction;
 
     @MethodDescription(example = @Example(value = "{ int i, long prev -> prev + 1000L + MathHelper.lfloor(Math.pow(2.0, i / 2.0F + 3)) }", imports = "net.minecraft.util.math.MathHelper"), type = MethodDescription.Type.VALUE)
     public void setXpFunction(Closure<Long> func) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/starlightaltar/AltarInputOrder.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/starlightaltar/AltarInputOrder.java
@@ -35,35 +35,23 @@ public class AltarInputOrder {
     };
 
     public static int[][] getMap(TileAltar.AltarLevel level) {
-        switch (level) {
-            case DISCOVERY:
-                return AltarInputOrder.DISCOVERY;
-            case ATTUNEMENT:
-                return AltarInputOrder.ATTUNEMENT;
-            case CONSTELLATION_CRAFT:
-                return AltarInputOrder.CONSTELLATION_CRAFT;
-            case TRAIT_CRAFT:
-                return AltarInputOrder.TRAIT_CRAFT;
-            default:
-                return null;
-        }
+        return switch (level) {
+            case DISCOVERY -> AltarInputOrder.DISCOVERY;
+            case ATTUNEMENT -> AltarInputOrder.ATTUNEMENT;
+            case CONSTELLATION_CRAFT -> AltarInputOrder.CONSTELLATION_CRAFT;
+            case TRAIT_CRAFT -> AltarInputOrder.TRAIT_CRAFT;
+            case BRILLIANCE -> null;
+        };
     }
 
     public static ItemHandle[] initInputList(TileAltar.AltarLevel level) {
-        ItemHandle[] rVal = null;
-        switch (level) {
-            case DISCOVERY:
-                rVal = new ItemHandle[9];
-                break;
-            case ATTUNEMENT:
-                rVal = new ItemHandle[13];
-                break;
-            case CONSTELLATION_CRAFT:
-                rVal = new ItemHandle[21];
-                break;
-            case TRAIT_CRAFT:
-                rVal = new ItemHandle[25];
-        }
+        ItemHandle[] rVal = switch (level) {
+            case DISCOVERY -> new ItemHandle[9];
+            case ATTUNEMENT -> new ItemHandle[13];
+            case CONSTELLATION_CRAFT -> new ItemHandle[21];
+            case TRAIT_CRAFT -> new ItemHandle[25];
+            case BRILLIANCE -> null;
+        };
         if (rVal != null) Arrays.fill(rVal, null);
         return rVal;
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/starlightaltar/AltarRecipeBuilder.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/starlightaltar/AltarRecipeBuilder.java
@@ -224,7 +224,7 @@ public class AltarRecipeBuilder {
 
         private final TileAltar.AltarLevel altarLevel;
         @Property(needsOverride = true)
-        private final ArrayList<IIngredient> outerIngredients = new ArrayList<>();
+        private final List<IIngredient> outerIngredients = new ArrayList<>();
         @Property(ignoresInheritedMethods = true)
         protected String name;
         @Property(defaultValue = "1")

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/avaritia/Compressor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/avaritia/Compressor.java
@@ -25,9 +25,9 @@ public class Compressor extends VirtualizedRegistry<ICompressorRecipe> {
     }
 
     public boolean remove(ICompressorRecipe recipe) {
-        recipe = AvaritiaRecipeManager.COMPRESSOR_RECIPES.remove(recipe.getRegistryName());
-        if (recipe != null) {
-            addBackup(recipe);
+        ICompressorRecipe remove = AvaritiaRecipeManager.COMPRESSOR_RECIPES.remove(recipe.getRegistryName());
+        if (remove != null) {
+            addBackup(remove);
             return true;
         }
         return false;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/avaritia/ExtremeCrafting.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/avaritia/ExtremeCrafting.java
@@ -71,11 +71,11 @@ public class ExtremeCrafting extends VirtualizedRegistry<IExtremeRecipe> {
     }
 
     public boolean remove(IExtremeRecipe recipe) {
-        recipe = AvaritiaRecipeManager.EXTREME_RECIPES.remove(recipe.getRegistryName());
-        if (recipe != null) {
-            addBackup(recipe);
+        IExtremeRecipe remove = AvaritiaRecipeManager.EXTREME_RECIPES.remove(recipe.getRegistryName());
+        if (remove != null) {
+            addBackup(remove);
         }
-        return recipe != null;
+        return remove != null;
     }
 
     @MethodDescription(type = MethodDescription.Type.QUERY)

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/AnvilCrafting.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/AnvilCrafting.java
@@ -8,7 +8,6 @@ import com.cleanroommc.groovyscript.api.documentation.annotations.RecipeBuilderD
 import com.cleanroommc.groovyscript.api.documentation.annotations.RegistryDescription;
 import com.cleanroommc.groovyscript.helper.Alias;
 import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
-import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.IRecipe;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/Hopper.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/Hopper.java
@@ -121,7 +121,7 @@ public class Hopper extends VirtualizedRegistry<HopperInteractions.HopperRecipe>
 
         @Override
         public void validate(GroovyLog.Msg msg) {
-            msg.add(name == null, "name cannot be null");
+            msg.add(super.name == null, "name cannot be null");
             validateItems(msg, 1, 1, 0, 2);
             validateCustom(msg, inWorldItemOutput, 0, 2, "item in world output");
             validateFluids(msg);
@@ -132,7 +132,7 @@ public class Hopper extends VirtualizedRegistry<HopperInteractions.HopperRecipe>
         public @Nullable HopperInteractions.HopperRecipe register() {
             if (!validate()) return null;
 
-            HopperInteractions.HopperRecipe recipe = new HopperInteractions.HopperRecipe(name.toString(), input.get(0).toMcIngredient(), output, inWorldItemOutput);
+            HopperInteractions.HopperRecipe recipe = new HopperInteractions.HopperRecipe(super.name.toString(), input.get(0).toMcIngredient(), output, inWorldItemOutput);
             ModSupport.BETTER_WITH_MODS.get().hopper.add(recipe);
             return recipe;
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/HopperFilters.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/HopperFilters.java
@@ -132,7 +132,7 @@ public class HopperFilters extends VirtualizedRegistry<IHopperFilter> {
         public @Nullable IHopperFilter register() {
             if (!validate()) return null;
 
-            IHopperFilter recipe = new HopperFilter(name.toString(), filter.toMcIngredient(), input.stream().map(IIngredient::toMcIngredient).collect(Collectors.toList()));
+            IHopperFilter recipe = new HopperFilter(super.name.toString(), filter.toMcIngredient(), input.stream().map(IIngredient::toMcIngredient).collect(Collectors.toList()));
             ModSupport.BETTER_WITH_MODS.get().hopperFilters.add(recipe);
             return recipe;
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/Kiln.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/Kiln.java
@@ -119,6 +119,7 @@ public class Kiln extends VirtualizedRegistry<KilnRecipe> {
             return this;
         }
 
+        @Override
         @RecipeBuilderMethodDescription
         public RecipeBuilder input(IIngredient input) {
             this.input = new BlockIngredient(input.toMcIngredient());

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/Saw.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/Saw.java
@@ -113,6 +113,7 @@ public class Saw extends VirtualizedRegistry<SawRecipe> {
             return this;
         }
 
+        @Override
         @RecipeBuilderMethodDescription
         public RecipeBuilder input(IIngredient input) {
             this.input = new BlockIngredient(input.toMcIngredient());

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/Turntable.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/Turntable.java
@@ -122,6 +122,7 @@ public class Turntable extends VirtualizedRegistry<TurntableRecipe> {
             return this;
         }
 
+        @Override
         @RecipeBuilderMethodDescription
         public RecipeBuilder input(IIngredient input) {
             this.input = new BlockIngredient(input.toMcIngredient());

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/bloodmagic/AlchemyArray.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/bloodmagic/AlchemyArray.java
@@ -163,7 +163,7 @@ public class AlchemyArray extends VirtualizedRegistry<RecipeAlchemyArray> {
         @Property
         private IIngredient catalyst;
         @Property
-        private ResourceLocation texture = null;
+        private ResourceLocation texture;
 
         @RecipeBuilderMethodDescription
         public RecipeBuilder catalyst(IIngredient catalyst) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/bloodmagic/AlchemyArray.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/bloodmagic/AlchemyArray.java
@@ -198,7 +198,8 @@ public class AlchemyArray extends VirtualizedRegistry<RecipeAlchemyArray> {
         @RecipeBuilderRegistrationMethod
         public @Nullable RecipeAlchemyArray register() {
             if (!validate()) return null;
-            RecipeAlchemyArray recipe = ModSupport.BLOOD_MAGIC.get().alchemyArray.add(input.get(0).toMcIngredient(), catalyst.toMcIngredient(), output.get(0), texture);
+            RecipeAlchemyArray recipe = new RecipeAlchemyArray(input.get(0).toMcIngredient(), catalyst.toMcIngredient(), output.get(0), texture);
+            ModSupport.BLOOD_MAGIC.get().alchemyArray.add(recipe);
             return recipe;
         }
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/bloodmagic/AlchemyTable.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/bloodmagic/AlchemyTable.java
@@ -188,7 +188,8 @@ public class AlchemyTable extends VirtualizedRegistry<RecipeAlchemyTable> {
         @RecipeBuilderRegistrationMethod
         public @Nullable RecipeAlchemyTable register() {
             if (!validate()) return null;
-            RecipeAlchemyTable recipe = ModSupport.BLOOD_MAGIC.get().alchemyTable.add(IngredientHelper.toIngredientNonNullList(input), output.get(0), syphon, ticks, minimumTier);
+            RecipeAlchemyTable recipe = new RecipeAlchemyTable(IngredientHelper.toIngredientNonNullList(input), output.get(0), syphon, ticks, minimumTier);
+            ModSupport.BLOOD_MAGIC.get().alchemyTable.add(recipe);
             return recipe;
         }
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/bloodmagic/BloodAltar.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/bloodmagic/BloodAltar.java
@@ -174,7 +174,8 @@ public class BloodAltar extends VirtualizedRegistry<RecipeBloodAltar> {
         @RecipeBuilderRegistrationMethod
         public @Nullable RecipeBloodAltar register() {
             if (!validate()) return null;
-            RecipeBloodAltar recipe = ModSupport.BLOOD_MAGIC.get().bloodAltar.add(input.get(0).toMcIngredient(), output.get(0), minimumTier, syphon, consumeRate, drainRate);
+            RecipeBloodAltar recipe = new RecipeBloodAltar(input.get(0).toMcIngredient(), output.get(0), minimumTier, syphon, consumeRate, drainRate);
+            ModSupport.BLOOD_MAGIC.get().bloodAltar.add(recipe);
             return recipe;
         }
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/bloodmagic/Meteor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/bloodmagic/Meteor.java
@@ -168,7 +168,9 @@ public class Meteor extends VirtualizedRegistry<WayofTime.bloodmagic.meteor.Mete
         @RecipeBuilderRegistrationMethod
         public @Nullable WayofTime.bloodmagic.meteor.Meteor register() {
             if (!validate()) return null;
-            WayofTime.bloodmagic.meteor.Meteor recipe = ModSupport.BLOOD_MAGIC.get().meteor.add(catalyst, components, explosionStrength, radius, cost);
+            WayofTime.bloodmagic.meteor.Meteor recipe = new WayofTime.bloodmagic.meteor.Meteor(catalyst, components, explosionStrength, radius);
+            recipe.setCost(cost);
+            ModSupport.BLOOD_MAGIC.get().meteor.add(recipe);
             return recipe;
         }
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/bloodmagic/Sacrificial.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/bloodmagic/Sacrificial.java
@@ -137,10 +137,10 @@ public class Sacrificial extends VirtualizedRegistry<Pair<ResourceLocation, Inte
         }
 
         @RecipeBuilderRegistrationMethod
-        public @Nullable Object register() {
+        public @Nullable Pair<ResourceLocation, Integer> register() {
             if (!validate()) return null;
             ModSupport.BLOOD_MAGIC.get().sacrificial.add(entity, value);
-            return null;
+            return Pair.of(entity, value);
         }
     }
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/bloodmagic/TartaricForge.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/bloodmagic/TartaricForge.java
@@ -178,7 +178,8 @@ public class TartaricForge extends VirtualizedRegistry<RecipeTartaricForge> {
         @RecipeBuilderRegistrationMethod
         public @Nullable RecipeTartaricForge register() {
             if (!validate()) return null;
-            RecipeTartaricForge recipe = ModSupport.BLOOD_MAGIC.get().tartaricForge.add(IngredientHelper.toIngredientNonNullList(input), output.get(0), minimumSouls, soulDrain);
+            RecipeTartaricForge recipe = new RecipeTartaricForge(IngredientHelper.toIngredientNonNullList(input), output.get(0), minimumSouls, soulDrain);
+            ModSupport.BLOOD_MAGIC.get().tartaricForge.add(recipe);
             return recipe;
         }
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/bloodmagic/Tranquility.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/bloodmagic/Tranquility.java
@@ -207,11 +207,16 @@ public class Tranquility extends VirtualizedRegistry<Pair<IBlockState, Tranquili
         }
 
         @RecipeBuilderRegistrationMethod
-        public @Nullable Object register() {
+        public @Nullable Pair<?, TranquilityStack> register() {
             if (!validate()) return null;
             TranquilityStack stack = new TranquilityStack(tranquility, value);
-            if (block != null) ModSupport.BLOOD_MAGIC.get().tranquility.add(block, stack);
-            else if (blockstate != null) ModSupport.BLOOD_MAGIC.get().tranquility.add(blockstate, stack);
+            if (block != null) {
+                ModSupport.BLOOD_MAGIC.get().tranquility.add(block, stack);
+                return Pair.of(block, stack);
+            } else if (blockstate != null) {
+                ModSupport.BLOOD_MAGIC.get().tranquility.add(blockstate, stack);
+                return Pair.of(blockstate, stack);
+            }
             return null;
         }
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/Brew.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/Brew.java
@@ -77,7 +77,7 @@ public class Brew extends VirtualizedRegistry<vazkii.botania.api.brew.Brew> {
         @Property(defaultValue = "true", priority = 1200)
         protected boolean canInfuseBloodPendant = true;
         @Property(valid = @Comp(value = "1", type = Comp.Type.GTE))
-        protected List<PotionEffect> effects = new ArrayList<>();
+        protected final List<PotionEffect> effects = new ArrayList<>();
 
         @RecipeBuilderMethodDescription
         public BrewBuilder key(String key) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/Brew.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/Brew.java
@@ -85,6 +85,7 @@ public class Brew extends VirtualizedRegistry<vazkii.botania.api.brew.Brew> {
             return this;
         }
 
+        @Override
         @RecipeBuilderMethodDescription
         public BrewBuilder name(String name) {
             this.name = name;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/Lexicon.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/Lexicon.java
@@ -361,6 +361,7 @@ public class Lexicon {
                 return this;
             }
 
+            @Override
             @RecipeBuilderMethodDescription
             public EntryBuilder name(String name) {
                 this.name = name;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/Lexicon.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/Lexicon.java
@@ -347,7 +347,7 @@ public class Lexicon {
             @Property(defaultValue = "ItemStack.EMPTY")
             protected ItemStack icon = ItemStack.EMPTY;
             @Property
-            protected boolean priority = false;
+            protected boolean priority;
 
             @RecipeBuilderMethodDescription(field = "priority")
             public EntryBuilder isPriority() {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/compactmachines/Miniaturization.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/compactmachines/Miniaturization.java
@@ -194,7 +194,7 @@ public class Miniaturization extends VirtualizedRegistry<org.dave.compactmachine
             if (!validate()) return null;
 
             org.dave.compactmachines3.miniaturization.MultiblockRecipe recipe = new org.dave.compactmachines3.miniaturization.MultiblockRecipe(
-                    name.toString(),
+                    super.name.toString(),
                     output.get(0),
                     input.get(0).getMatchingStacks()[0].getItem(),
                     input.get(0).getMatchingStacks()[0].getMetadata(),

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/draconicevolution/EnergyCore.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/draconicevolution/EnergyCore.java
@@ -21,7 +21,7 @@ import java.util.Collection;
 @RegistryDescription
 public class EnergyCore implements IScriptReloadable {
 
-    private int version = 0;
+    private int version;
     private BlockStates[][][][] original;
     private BlockStates[][][][] edited;
     private BlockStates[] inner;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/draconicevolution/helpers/BlockStateEnergyCoreStructure.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/draconicevolution/helpers/BlockStateEnergyCoreStructure.java
@@ -287,7 +287,11 @@ public class BlockStateEnergyCoreStructure extends EnergyCoreStructure {
 
     private BlockStateMultiblockStorage buildTier1() {
         BlockStateMultiblockStorage storage = new BlockStateMultiblockStorage(1, helper, this);
-        BlockStates e = BlockStates.ANY, X = coreBlock(), R = BlockStates.redstone(), D = BlockStates.draconium(), A = BlockStates.draconic();
+        BlockStates e = BlockStates.ANY;
+        BlockStates X = coreBlock();
+        BlockStates R = BlockStates.redstone();
+        BlockStates D = BlockStates.draconium();
+        BlockStates A = BlockStates.draconic();
         storage.addRow(X);
 
         return storage;
@@ -296,7 +300,11 @@ public class BlockStateEnergyCoreStructure extends EnergyCoreStructure {
     @SuppressWarnings("DuplicatedCode")
     private BlockStateMultiblockStorage buildTier2() {
         BlockStateMultiblockStorage storage = new BlockStateMultiblockStorage(3, helper, this);
-        BlockStates e = BlockStates.ANY, X = coreBlock(), R = BlockStates.redstone(), D = BlockStates.draconium(), A = BlockStates.draconic();
+        BlockStates e = BlockStates.ANY;
+        BlockStates X = coreBlock();
+        BlockStates R = BlockStates.redstone();
+        BlockStates D = BlockStates.draconium();
+        BlockStates A = BlockStates.draconic();
 
         storage.addRow(e, e, e);
         storage.addRow(e, D, e);
@@ -315,7 +323,11 @@ public class BlockStateEnergyCoreStructure extends EnergyCoreStructure {
     @SuppressWarnings("DuplicatedCode")
     private BlockStateMultiblockStorage buildTier3() {
         BlockStateMultiblockStorage storage = new BlockStateMultiblockStorage(3, helper, this);
-        BlockStates e = BlockStates.ANY, X = coreBlock(), R = BlockStates.redstone(), D = BlockStates.draconium(), A = BlockStates.draconic();
+        BlockStates e = BlockStates.ANY;
+        BlockStates X = coreBlock();
+        BlockStates R = BlockStates.redstone();
+        BlockStates D = BlockStates.draconium();
+        BlockStates A = BlockStates.draconic();
 
         storage.addRow(D, D, D);
         storage.addRow(D, D, D);
@@ -334,7 +346,11 @@ public class BlockStateEnergyCoreStructure extends EnergyCoreStructure {
     @SuppressWarnings("DuplicatedCode")
     private BlockStateMultiblockStorage buildTier4() {
         BlockStateMultiblockStorage storage = new BlockStateMultiblockStorage(5, helper, this);
-        BlockStates e = BlockStates.ANY, X = coreBlock(), R = BlockStates.redstone(), D = BlockStates.draconium(), A = BlockStates.draconic();
+        BlockStates e = BlockStates.ANY;
+        BlockStates X = coreBlock();
+        BlockStates R = BlockStates.redstone();
+        BlockStates D = BlockStates.draconium();
+        BlockStates A = BlockStates.draconic();
 
         storage.addRow(e, e, e, e, e);
         storage.addRow(e, D, D, D, e);
@@ -364,7 +380,11 @@ public class BlockStateEnergyCoreStructure extends EnergyCoreStructure {
     @SuppressWarnings("DuplicatedCode")
     private BlockStateMultiblockStorage buildTier5() {
         BlockStateMultiblockStorage storage = new BlockStateMultiblockStorage(7, helper, this);
-        BlockStates e = BlockStates.ANY, X = coreBlock(), R = BlockStates.redstone(), D = BlockStates.draconium(), A = BlockStates.draconic();
+        BlockStates e = BlockStates.ANY;
+        BlockStates X = coreBlock();
+        BlockStates R = BlockStates.redstone();
+        BlockStates D = BlockStates.draconium();
+        BlockStates A = BlockStates.draconic();
 
         storage.addRow(e, e, e, e, e, e, e);
         storage.addRow(e, e, e, e, e, e, e);
@@ -409,7 +429,11 @@ public class BlockStateEnergyCoreStructure extends EnergyCoreStructure {
     @SuppressWarnings("DuplicatedCode")
     private BlockStateMultiblockStorage buildTier6() {
         BlockStateMultiblockStorage storage = new BlockStateMultiblockStorage(9, helper, this);
-        BlockStates e = BlockStates.ANY, X = coreBlock(), R = BlockStates.redstone(), D = BlockStates.draconium(), A = BlockStates.draconic();
+        BlockStates e = BlockStates.ANY;
+        BlockStates X = coreBlock();
+        BlockStates R = BlockStates.redstone();
+        BlockStates D = BlockStates.draconium();
+        BlockStates A = BlockStates.draconic();
 
         storage.addRow(e, e, e, e, e, e, e, e, e);
         storage.addRow(e, e, e, e, e, e, e, e, e);
@@ -473,7 +497,11 @@ public class BlockStateEnergyCoreStructure extends EnergyCoreStructure {
     @SuppressWarnings("DuplicatedCode")
     private BlockStateMultiblockStorage buildTier7() {
         BlockStateMultiblockStorage storage = new BlockStateMultiblockStorage(11, helper, this);
-        BlockStates e = BlockStates.ANY, X = coreBlock(), R = BlockStates.redstone(), D = BlockStates.draconium(), A = BlockStates.draconic();
+        BlockStates e = BlockStates.ANY;
+        BlockStates X = coreBlock();
+        BlockStates R = BlockStates.redstone();
+        BlockStates D = BlockStates.draconium();
+        BlockStates A = BlockStates.draconic();
 
         storage.addRow(e, e, e, e, e, e, e, e, e, e, e);
         storage.addRow(e, e, e, e, e, e, e, e, e, e, e);
@@ -559,7 +587,11 @@ public class BlockStateEnergyCoreStructure extends EnergyCoreStructure {
 
     private BlockStateMultiblockStorage buildTierOMG() {
         BlockStateMultiblockStorage storage = new BlockStateMultiblockStorage(13, helper, this);
-        BlockStates e = BlockStates.ANY, X = coreBlock(), R = BlockStates.redstone(), D = BlockStates.draconium(), A = BlockStates.draconic();
+        BlockStates e = BlockStates.ANY;
+        BlockStates X = coreBlock();
+        BlockStates R = BlockStates.redstone();
+        BlockStates D = BlockStates.draconium();
+        BlockStates A = BlockStates.draconic();
 
         //region Hard
         if (DEConfig.hardMode) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/draconicevolution/helpers/BlockStateEnergyCoreStructure.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/draconicevolution/helpers/BlockStateEnergyCoreStructure.java
@@ -133,6 +133,7 @@ public class BlockStateEnergyCoreStructure extends EnergyCoreStructure {
         }
     }
 
+    @Override
     public BlockStateMultiblockStorage getStorageForTier(int tier) {
         return structureTiers[tier - 1];
     }
@@ -268,6 +269,7 @@ public class BlockStateEnergyCoreStructure extends EnergyCoreStructure {
         return states.matches(state, false);
     }
 
+    @Override
     public BlockPos getCoreOffset(int tier) {
         int offset = tier == 1 ? 0 : tier == 2 || tier == 3 ? -1 : -(tier - 2);
         return new BlockPos(offset, offset, offset);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/draconicevolution/helpers/BlockStateEnergyCoreStructure.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/draconicevolution/helpers/BlockStateEnergyCoreStructure.java
@@ -37,7 +37,7 @@ public class BlockStateEnergyCoreStructure extends EnergyCoreStructure {
     private final TileEnergyStorageCore core;
     private final BlockStateMultiblockHelper helper;
     private final BlockStateMultiblockStorage[] structureTiers;
-    private int version = 0;
+    private int version;
 
     private static BlockStates coreBlock;
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/draconicevolution/helpers/BlockStateEnergyCoreStructure.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/draconicevolution/helpers/BlockStateEnergyCoreStructure.java
@@ -122,14 +122,14 @@ public class BlockStateEnergyCoreStructure extends EnergyCoreStructure {
     }
 
     private void forTier(int tier, int flag) {
+        int checkTier = tier - 1;
         checkVersion();
-        tier -= 1;
-        if (tier < 0) {
+        if (checkTier < 0) {
             GroovyScript.LOGGER.error("[EnergyCoreStructure] Tier value to small. As far as TileEnergyStorageCore is concerned the tiers now start at 1 not 0. This class automatically handles the conversion now");
-        } else if (tier >= structureTiers.length) {
-            GroovyScript.LOGGER.error("[EnergyCoreStructure#placeTier] There are only 8 tiers, but tried to use tier {}", tier);
+        } else if (checkTier >= structureTiers.length) {
+            GroovyScript.LOGGER.error("[EnergyCoreStructure#placeTier] There are only 8 tiers, but tried to use tier {}", checkTier);
         } else {
-            structureTiers[tier].forEachInStructure(core.getWorld(), core.getPos().add(getCoreOffset(tier + 1)), flag);
+            structureTiers[checkTier].forEachInStructure(core.getWorld(), core.getPos().add(getCoreOffset(checkTier + 1)), flag);
         }
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/draconicevolution/helpers/BlockStateEnergyCoreStructure.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/draconicevolution/helpers/BlockStateEnergyCoreStructure.java
@@ -210,15 +210,15 @@ public class BlockStateEnergyCoreStructure extends EnergyCoreStructure {
 
         int alpha = 0xFF000000;
         if (invalid) {
-            alpha = (int) (((Math.sin(ClientEventHandler.elapsedTicks / 20D) + 1D) / 2D) * 255D) << 24;
+            alpha = (int) (((Math.sin(ClientEventHandler.elapsedTicks / 20.0D) + 1.0D) / 2.0D) * 255.0D) << 24;
         }
 
         GlStateManager.pushMatrix();
         GlStateManager.translate(translation.getX(), translation.getY(), translation.getZ());
         if (invalid) {
             GlStateManager.disableDepth();
-            GlStateManager.alphaFunc(GL11.GL_GREATER, 0F);
-            double s = Math.sin(ClientEventHandler.elapsedTicks / 10D) * 0.1D;
+            GlStateManager.alphaFunc(GL11.GL_GREATER, 0.0F);
+            double s = Math.sin(ClientEventHandler.elapsedTicks / 10.0D) * 0.1D;
             GlStateManager.scale(0.8 + s, 0.8 + s, 0.8 + s);
             GlStateManager.translate(0.1 - s, 0.1 - s, 0.1 - s);
         } else {
@@ -228,7 +228,7 @@ public class BlockStateEnergyCoreStructure extends EnergyCoreStructure {
 
         float brightnessX = OpenGlHelper.lastBrightnessX;
         float brightnessY = OpenGlHelper.lastBrightnessY;
-        OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 150f, 150f);
+        OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 150.0f, 150.0f);
 
         List<BakedQuad> blockQuads = ModelUtils.getModelQuads(states.getDefault());
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/draconicevolution/helpers/BlockStateEnergyCoreStructure.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/draconicevolution/helpers/BlockStateEnergyCoreStructure.java
@@ -150,7 +150,7 @@ public class BlockStateEnergyCoreStructure extends EnergyCoreStructure {
 
         if (flag == FLAG_RENDER) {
             if (world.isRemote) {
-                renderBuildGuide(states, world, pos, startPos, flag);
+                renderBuildGuide(states, world, pos, startPos, FLAG_RENDER);
             }
         }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/draconicevolution/helpers/BlockStateMultiblockHelper.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/draconicevolution/helpers/BlockStateMultiblockHelper.java
@@ -7,7 +7,7 @@ import net.minecraft.world.World;
 
 public class BlockStateMultiblockHelper extends MultiBlockHelper {
 
-    public IBlockState expectedBlockState = null;
+    public IBlockState expectedBlockState;
 
     public void setBlock(BlockStates states, World world, BlockPos pos) {
         if (states.isWildcard()) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/draconicevolution/helpers/BlockStateMultiblockStorage.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/draconicevolution/helpers/BlockStateMultiblockStorage.java
@@ -13,8 +13,8 @@ public class BlockStateMultiblockStorage extends MultiBlockStorage {
     private final int size;
     private final BlockStateMultiblockHelper helper;
     private final BlockStateEnergyCoreStructure energyCoreStructure;
-    private int xPos = 0;
-    private int yPos = 0;
+    private int xPos;
+    private int yPos;
 
     public BlockStateMultiblockStorage(int size, BlockStateMultiblockHelper helper, BlockStateEnergyCoreStructure energyCoreStructure) {
         super(size, helper);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/draconicevolution/helpers/BlockStates.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/draconicevolution/helpers/BlockStates.java
@@ -28,7 +28,9 @@ public class BlockStates {
         }
     };
 
-    private static BlockStates redstone, draconium, draconic;
+    private static BlockStates redstone;
+    private static BlockStates draconium;
+    private static BlockStates draconic;
 
     public static BlockStates redstone() {
         if (redstone == null) redstone = of(Blocks.REDSTONE_BLOCK);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/AlloySmelter.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/AlloySmelter.java
@@ -52,6 +52,7 @@ public class AlloySmelter extends VirtualizedRegistry<IManyToOneRecipe> {
         return new RecipeBuilder();
     }
 
+    @Override
     @GroovyBlacklist
     public void onReload() {
         AlloyRecipeManagerAccessor accessor = (AlloyRecipeManagerAccessor) AlloyRecipeManager.getInstance();
@@ -71,6 +72,7 @@ public class AlloySmelter extends VirtualizedRegistry<IManyToOneRecipe> {
         }
     }
 
+    @Override
     @GroovyBlacklist
     @ApiStatus.Internal
     public void afterScriptLoad() {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/Enchanter.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/Enchanter.java
@@ -35,6 +35,7 @@ public class Enchanter extends VirtualizedRegistry<EnchanterRecipe> {
         return new RecipeBuilder();
     }
 
+    @Override
     @GroovyBlacklist
     public void onReload() {
         removeScripted().forEach(MachineRecipeRegistry.instance::removeRecipe);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/Enchanter.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/Enchanter.java
@@ -102,7 +102,7 @@ public class Enchanter extends VirtualizedRegistry<EnchanterRecipe> {
         @Property(ignoresInheritedMethods = true, valid = @Comp(type = Comp.Type.NOT, value = "null"))
         private IIngredient input;
         @Property(valid = @Comp(type = Comp.Type.GT, value = "0"))
-        private int amount = 0;
+        private int amount;
         @Property(defaultValue = "1")
         private double costMultiplier = 1;
         @Property(defaultValue = "ore('gemLapis')", valid = @Comp(type = Comp.Type.NOT, value = "null"))

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/FluidCoolant.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/FluidCoolant.java
@@ -90,6 +90,7 @@ public class FluidCoolant extends VirtualizedRegistry<IFluidCoolant> {
         return ((FluidFuelRegisterAccessor) FluidFuelRegister.instance).getCoolants().get(fluid.getName());
     }
 
+    @Override
     @GroovyBlacklist
     public void onReload() {
         FluidFuelRegisterAccessor accessor = (FluidFuelRegisterAccessor) FluidFuelRegister.instance;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/FluidFuel.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/FluidFuel.java
@@ -85,6 +85,7 @@ public class FluidFuel extends VirtualizedRegistry<IFluidFuel> {
         return FluidFuelRegister.instance.getFuel(fluid);
     }
 
+    @Override
     @GroovyBlacklist
     public void onReload() {
         FluidFuelRegisterAccessor accessor = (FluidFuelRegisterAccessor) FluidFuelRegister.instance;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/SagMill.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/SagMill.java
@@ -101,7 +101,7 @@ public class SagMill extends VirtualizedRegistry<Recipe> {
         @Override
         @RecipeBuilderMethodDescription(field = {"output", "chances"})
         public AbstractRecipeBuilder<Recipe> output(ItemStack output) {
-            return output(output, 1f);
+            return output(output, 1.0f);
         }
 
         @RecipeBuilderMethodDescription(field = "bonusType")

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/SagMill.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/SagMill.java
@@ -61,6 +61,7 @@ public class SagMill extends VirtualizedRegistry<Recipe> {
         }
     }
 
+    @Override
     @GroovyBlacklist
     public void onReload() {
         removeScripted().forEach(SagMillRecipeManager.getInstance().getRecipes()::remove);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/SagMillGrinding.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/SagMillGrinding.java
@@ -49,6 +49,7 @@ public class SagMillGrinding extends VirtualizedRegistry<GrindingBall> {
         return false;
     }
 
+    @Override
     @GroovyBlacklist
     public void onReload() {
         removeScripted().forEach(SagMillRecipeManager.getInstance().getBalls()::remove);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/SliceNSplice.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/SliceNSplice.java
@@ -91,6 +91,7 @@ public class SliceNSplice extends VirtualizedRegistry<IManyToOneRecipe> {
         }
     }
 
+    @Override
     @GroovyBlacklist
     public void onReload() {
         removeScripted().forEach(SliceAndSpliceRecipeManager.getInstance().getRecipes()::remove);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/SoulBinder.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/SoulBinder.java
@@ -64,6 +64,7 @@ public class SoulBinder extends VirtualizedRegistry<ISoulBinderRecipe> {
         }
     }
 
+    @Override
     @GroovyBlacklist
     public void onReload() {
         removeScripted().forEach(MachineRecipeRegistry.instance::removeRecipe);
@@ -96,6 +97,7 @@ public class SoulBinder extends VirtualizedRegistry<ISoulBinderRecipe> {
         private final NNList<ResourceLocation> entities = new NNList<>();
         private final List<String> entityErrors = new ArrayList<>();
 
+        @Override
         @RecipeBuilderMethodDescription
         public RecipeBuilder name(String name) {
             this.name = name;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/Tank.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/Tank.java
@@ -247,8 +247,8 @@ public class Tank extends VirtualizedRegistry<TankMachineRecipe> {
             if (!validate()) return null;
             Things in = RecipeUtils.toThings(input.get(0));
             Things out = new Things().add(output.getOrEmpty(0));
-            TankMachineRecipe recipe = new TankMachineRecipe(name.toString(), isFilling, in, isFilling ? fluidOutput.get(0)
-                                                                                                       : fluidInput.get(0), out, TankMachineRecipe.Logic.NONE, RecipeLevel.IGNORE);
+            TankMachineRecipe recipe = new TankMachineRecipe(super.name.toString(), isFilling, in, isFilling ? fluidOutput.get(0)
+                                                                                                             : fluidInput.get(0), out, TankMachineRecipe.Logic.NONE, RecipeLevel.IGNORE);
 
             ModSupport.ENDER_IO.get().tank.add(recipe);
             return recipe;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/Tank.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/Tank.java
@@ -177,6 +177,7 @@ public class Tank extends VirtualizedRegistry<TankMachineRecipe> {
         }
     }
 
+    @Override
     @GroovyBlacklist
     public void onReload() {
         removeScripted().forEach(MachineRecipeRegistry.instance::removeRecipe);
@@ -225,6 +226,7 @@ public class Tank extends VirtualizedRegistry<TankMachineRecipe> {
             return "Error adding EnderIO Tank recipe";
         }
 
+        @Override
         public String getRecipeNamePrefix() {
             return "groovyscript_enderio_tank_";
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/Vat.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/Vat.java
@@ -104,7 +104,7 @@ public class Vat extends VirtualizedRegistry<VatRecipe> {
         @Property(defaultValue = "1", valid = @Comp(type = Comp.Type.GT, value = "0"))
         private float baseMultiplier = 1;
         @Property(valid = @Comp(type = Comp.Type.GT, value = "0"))
-        private int energy = 0;
+        private int energy;
 
         @RecipeBuilderMethodDescription
         public RecipeBuilder input(FluidStack input) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/Vat.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/Vat.java
@@ -66,6 +66,7 @@ public class Vat extends VirtualizedRegistry<VatRecipe> {
         }
     }
 
+    @Override
     @GroovyBlacklist
     public void onReload() {
         NNList<IRecipe> recipes = VatRecipeManager.getInstance().getRecipes();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/recipe/CustomEnchanterRecipe.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/recipe/CustomEnchanterRecipe.java
@@ -36,6 +36,7 @@ public class CustomEnchanterRecipe extends EnchanterRecipe {
         return book;
     }
 
+    @Override
     public boolean isRecipe(@Nonnull RecipeLevel machineLevel, @Nonnull NNList<MachineRecipeInput> inputs) {
         ItemStack slot0 = MachineRecipeInput.getInputForSlot(0, inputs);
         ItemStack slot1 = MachineRecipeInput.getInputForSlot(1, inputs);
@@ -57,6 +58,7 @@ public class CustomEnchanterRecipe extends EnchanterRecipe {
         return Math.min(size / this.getItemsPerLevel(), this.getEnchantment().getMaxLevel());
     }
 
+    @Override
     public boolean isValidInput(@Nonnull RecipeLevel machineLevel, @Nonnull MachineRecipeInput inputs) {
         ItemStack slot0 = MachineRecipeInput.getInputForSlot(0, inputs);
         ItemStack slot1 = MachineRecipeInput.getInputForSlot(1, inputs);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/evilcraft/BloodInfuser.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/evilcraft/BloodInfuser.java
@@ -100,11 +100,11 @@ public class BloodInfuser extends VirtualizedRegistry<IRecipe<IngredientFluidSta
         private static final Fluid bloodFluid = FluidRegistry.getFluid("evilcraftblood");
 
         @Property(valid = {@Comp(value = "0", type = Comp.Type.GTE), @Comp(value = "3", type = Comp.Type.LTE)})
-        private int tier = 0;
+        private int tier;
         @Property(valid = @Comp(value = "0", type = Comp.Type.GTE))
-        private int duration = 0;
+        private int duration;
         @Property(valid = @Comp(value = "0", type = Comp.Type.GTE))
-        private float xp = 0;
+        private float xp;
 
         @RecipeBuilderMethodDescription
         public RecipeBuilder tier(int tier) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/extendedcrafting/CombinationCrafting.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/extendedcrafting/CombinationCrafting.java
@@ -141,6 +141,7 @@ public class CombinationCrafting extends VirtualizedRegistry<CombinationRecipe> 
             return perTick(costPerTick);
         }
 
+        @Override
         @RecipeBuilderMethodDescription
         public RecipeBuilder input(IIngredient ingredient) {
             this.input.add(ingredient.withAmount(1));

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/extendedcrafting/CompressionCrafting.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/extendedcrafting/CompressionCrafting.java
@@ -122,6 +122,7 @@ public class CompressionCrafting extends VirtualizedRegistry<CompressorRecipe> {
         @Property(defaultValue = "ModConfig.confCompressorRFRate", valid = @Comp(type = Comp.Type.GTE, value = "0"))
         private int powerRate = ModConfig.confCompressorRFRate;
 
+        @Override
         @RecipeBuilderMethodDescription
         public RecipeBuilder input(IIngredient input) {
             if (input == null) return this;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/extendedcrafting/CompressionCrafting.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/extendedcrafting/CompressionCrafting.java
@@ -116,7 +116,7 @@ public class CompressionCrafting extends VirtualizedRegistry<CompressorRecipe> {
         @Property(defaultValue = "IngredientHelper.toIIngredient(ItemSingularity.getCatalystStack())", valid = @Comp(type = Comp.Type.NOT, value = "null"))
         private IIngredient catalyst = IngredientHelper.toIIngredient(ItemSingularity.getCatalystStack());
         @Property
-        private boolean consumeCatalyst = false;
+        private boolean consumeCatalyst;
         @Property(valid = @Comp(type = Comp.Type.GTE, value = "0"))
         private int powerCost;
         @Property(defaultValue = "ModConfig.confCompressorRFRate", valid = @Comp(type = Comp.Type.GTE, value = "0"))

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/extendedcrafting/EnderCrafting.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/extendedcrafting/EnderCrafting.java
@@ -54,8 +54,8 @@ public class EnderCrafting extends VirtualizedRegistry<IRecipe> {
     }
 
     @MethodDescription(description = "groovyscript.wiki.extendedcrafting.ender_crafting.addShapeless0", type = MethodDescription.Type.ADDITION)
-    public IRecipe addShapeless(ItemStack output, List<List<IIngredient>> input) {
-        return addShaped(ModConfig.confEnderTimeRequired, output, input);
+    public IRecipe addShapeless(ItemStack output, List<IIngredient> input) {
+        return addShapeless(ModConfig.confEnderTimeRequired, output, input);
     }
 
     @MethodDescription(description = "groovyscript.wiki.extendedcrafting.ender_crafting.addShapeless1", type = MethodDescription.Type.ADDITION)

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/extendedcrafting/TableCrafting.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/extendedcrafting/TableCrafting.java
@@ -53,8 +53,8 @@ public class TableCrafting extends VirtualizedRegistry<ITieredRecipe> {
     }
 
     @MethodDescription(description = "groovyscript.wiki.extendedcrafting.table_crafting.addShapeless0", type = MethodDescription.Type.ADDITION)
-    public ITieredRecipe addShapeless(ItemStack output, List<List<IIngredient>> input) {
-        return addShaped(0, output, input);
+    public ITieredRecipe addShapeless(ItemStack output, List<IIngredient> input) {
+        return addShapeless(0, output, input);
     }
 
     @MethodDescription(description = "groovyscript.wiki.extendedcrafting.table_crafting.addShapeless1", type = MethodDescription.Type.ADDITION)

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/extrautils2/GridPowerPassiveGenerator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/extrautils2/GridPowerPassiveGenerator.java
@@ -35,6 +35,7 @@ public class GridPowerPassiveGenerator extends VirtualizedRegistry<Pair<BlockPas
         removeScripted().forEach(x -> ((GeneratorTypeAccessor) x.getKey()).setPowerMultiplier(x.getValue()));
     }
 
+    @Override
     public void afterScriptLoad() {
         for (BlockPassiveGenerator.GeneratorType value : BlockPassiveGenerator.GeneratorType.values()) {
             GeneratorTypeAccessor accessor = (GeneratorTypeAccessor) value;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/extrautils2/Resonator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/extrautils2/Resonator.java
@@ -103,11 +103,11 @@ public class Resonator extends VirtualizedRegistry<IResonatorRecipe> {
         @Property(valid = @Comp(value = "100", type = Comp.Type.GTE))
         private int energy;
         @Property
-        private boolean ownerTag = false;
+        private boolean ownerTag;
         @Property
         private String requirementText = "";
         @Property
-        private Closure<Boolean> shouldProgress = null;
+        private Closure<Boolean> shouldProgress;
 
         @RecipeBuilderMethodDescription
         public RecipeBuilder energy(int energy) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/extrautils2/Resonator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/extrautils2/Resonator.java
@@ -200,10 +200,12 @@ public class Resonator extends VirtualizedRegistry<IResonatorRecipe> {
         public IResonatorRecipe register() {
             if (!validate()) return null;
             IResonatorRecipe recipe = new ResonatorRecipe(input.get(0).getMatchingStacks()[0], output.get(0), energy, ownerTag) {
+                @Override
                 public String getRequirementText() {
                     return requirementText == null ? "" : requirementText;
                 }
 
+                @Override
                 public boolean shouldProgress(TileEntity resonator, int frequency, ItemStack input) {
                     return shouldProgress == null || ClosureHelper.call(true, shouldProgress, resonator, frequency, input);
                 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/forestry/Centrifuge.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/forestry/Centrifuge.java
@@ -88,7 +88,7 @@ public class Centrifuge extends ForestryRegistry<ICentrifugeRecipe> {
     public class RecipeBuilder extends AbstractRecipeBuilder<ICentrifugeRecipe> {
 
         protected int time = 20;
-        protected Map<ItemStack, Float> outputs = new Object2FloatOpenHashMap<>();
+        protected final Map<ItemStack, Float> outputs = new Object2FloatOpenHashMap<>();
 
         public RecipeBuilder time(int time) {
             this.time = Math.max(time, 1);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/forestry/ForestryRegistry.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/forestry/ForestryRegistry.java
@@ -18,6 +18,7 @@ public abstract class ForestryRegistry<T> extends VirtualizedRegistry<T> {
         super(aliases);
     }
 
+    @Override
     @GroovyBlacklist
     @ApiStatus.Internal
     public boolean isEnabled() {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/forestry/ThermionicFabricator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/forestry/ThermionicFabricator.java
@@ -134,7 +134,7 @@ public class ThermionicFabricator extends ForestryRegistry<IFabricatorRecipe> {
 
         protected String[] pattern;
         protected IIngredient catalyst = IIngredient.EMPTY;
-        protected Char2ObjectOpenHashMap<IIngredient> keys = new Char2ObjectOpenHashMap<>();
+        protected final Char2ObjectOpenHashMap<IIngredient> keys = new Char2ObjectOpenHashMap<>();
 
         public RecipeBuilder catalyst(IIngredient item) {
             this.catalyst = item;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/IC2.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/IC2.java
@@ -29,16 +29,16 @@ public class IC2 extends GroovyPropertyContainer {
     public RareEarthExtractor rareEarthExtractor;
 
     // Experimental
-    public FluidGenerator semiFluidGenerator = null;
-    public Electrolyzer electrolyzer = null;
-    public Fermenter fermenter = null;
-    public BlastFurnace blastFurnace = null;
-    public BlockCutter blockCutter = null;
-    public FluidCanner fluidCanner = null;
-    public SolidCanner solidCanner = null;
-    public Recycler recycler = null;
-    public LiquidHeatExchanger liquidHeatExchanger = null;
-    public FluidHeater liquidFueledFirebox = null;
+    public FluidGenerator semiFluidGenerator;
+    public Electrolyzer electrolyzer;
+    public Fermenter fermenter;
+    public BlastFurnace blastFurnace;
+    public BlockCutter blockCutter;
+    public FluidCanner fluidCanner;
+    public SolidCanner solidCanner;
+    public Recycler recycler;
+    public LiquidHeatExchanger liquidHeatExchanger;
+    public FluidHeater liquidFueledFirebox;
 
     public IC2() {
         isExp = isExp();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/MetalFormer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/MetalFormer.java
@@ -122,14 +122,11 @@ public class MetalFormer extends VirtualizedRegistry<MetalFormer.MetalFormerReci
     }
 
     public IBasicMachineRecipeManager getManager(int type) {
-        switch (type) {
-            default:
-                return Recipes.metalformerCutting;
-            case 1:
-                return Recipes.metalformerExtruding;
-            case 2:
-                return Recipes.metalformerRolling;
-        }
+        return switch (type) {
+            default -> Recipes.metalformerCutting;
+            case 1 -> Recipes.metalformerExtruding;
+            case 2 -> Recipes.metalformerRolling;
+        };
     }
 
     public static class MetalFormerRecipe {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/classic/Canner.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/classic/Canner.java
@@ -255,41 +255,30 @@ public class Canner extends VirtualizedRegistry<Canner.CanningRecipe> {
 
     private void add(CanningRecipe recipe) {
         switch (recipe.type) {
-            case CANNING_RECIPE:
-                ClassicRecipes.canningMachine.registerCannerItem(recipe.container, new RecipeInput(recipe.input), recipe.output);
-                break;
-            case ITEM_EFFECT:
-                ClassicRecipes.canningMachine.registerItemsForEffect(recipe.intValue, recipe.input.getMatchingStacks());
-                break;
-            case FUEL_VALUE:
+            case CANNING_RECIPE -> ClassicRecipes.canningMachine.registerCannerItem(recipe.container, new RecipeInput(recipe.input), recipe.output);
+            case ITEM_EFFECT -> ClassicRecipes.canningMachine.registerItemsForEffect(recipe.intValue, recipe.input.getMatchingStacks());
+            case FUEL_VALUE -> {
                 for (ItemStack stack : recipe.input.getMatchingStacks()) {
                     ClassicRecipes.canningMachine.registerFuelValue(stack, recipe.intValue);
-                    if (recipe.floatValue > 0)
+                    if (recipe.floatValue > 0) {
                         ClassicRecipes.canningMachine.registerFuelMultiplier(stack, recipe.floatValue);
+                    }
                 }
-                break;
-            case REPAIR:
-                ClassicRecipes.canningMachine.addRepairRecipe(recipe.damageItem, recipe.meta, new RecipeInput(recipe.input), recipe.intValue);
-                break;
+            }
+            case REPAIR -> ClassicRecipes.canningMachine.addRepairRecipe(recipe.damageItem, recipe.meta, new RecipeInput(recipe.input), recipe.intValue);
         }
     }
 
     private void remove(CanningRecipe recipe) {
         switch (recipe.type) {
-            case CANNING_RECIPE:
-                ClassicRecipes.canningMachine.removeCanningRecipe(recipe.container, recipe.input.getMatchingStacks()[0]);
-                break;
-            case ITEM_EFFECT:
-                ClassicRecipes.canningMachine.deleteEffectID(recipe.intValue, true);
-                break;
-            case FUEL_VALUE:
+            case CANNING_RECIPE -> ClassicRecipes.canningMachine.removeCanningRecipe(recipe.container, recipe.input.getMatchingStacks()[0]);
+            case ITEM_EFFECT -> ClassicRecipes.canningMachine.deleteEffectID(recipe.intValue, true);
+            case FUEL_VALUE -> {
                 for (ItemStack stack : recipe.input.getMatchingStacks()) {
                     ClassicRecipes.canningMachine.deleteItemFuel(stack);
                 }
-                break;
-            case REPAIR:
-                ClassicRecipes.canningMachine.removeRepairItem(recipe.damageItem, recipe.meta);
-                break;
+            }
+            case REPAIR -> ClassicRecipes.canningMachine.removeRepairItem(recipe.damageItem, recipe.meta);
         }
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/classic/ClassicCompressor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/classic/ClassicCompressor.java
@@ -57,7 +57,7 @@ public class ClassicCompressor extends Compressor {
                     .add("xp must not be negative, defaulting to zero")
                     .warn()
                     .post();
-            xp = 0F;
+            xp = 0.0F;
         }
         MachineRecipe<IRecipeInput, Collection<ItemStack>> recipe = new MachineRecipe<>(new RecipeInput(input), Collections.singleton(output));
         ClassicRecipes.compressor.addRecipe(recipe.getInput(), output, xp, String.valueOf(recipe.hashCode()));

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/classic/ClassicElectrolyzer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/classic/ClassicElectrolyzer.java
@@ -127,44 +127,44 @@ public class ClassicElectrolyzer extends VirtualizedRegistry<ClassicElectrolyzer
 
     private void add(ElectrolyzerRecipe recipe) {
         switch (recipe.type) {
-            case CHARGE:
+            case CHARGE -> {
                 for (ItemStack stack : recipe.input.getMatchingStacks()) {
                     ClassicRecipes.electrolyzer.addChargeRecipe(stack, recipe.output, recipe.energy, String.valueOf(recipe.hashCode()));
                 }
-                break;
-            case DISCHARGE:
+            }
+            case DISCHARGE -> {
                 for (ItemStack stack : recipe.input.getMatchingStacks()) {
                     ClassicRecipes.electrolyzer.addDischargeRecipe(stack, recipe.output, recipe.energy, String.valueOf(recipe.hashCode()));
                 }
-                break;
-            case BOTH:
+            }
+            case BOTH -> {
                 for (ItemStack stack : recipe.input.getMatchingStacks()) {
                     ClassicRecipes.electrolyzer.addBothRecipe(stack, recipe.output, recipe.energy, String.valueOf(recipe.hashCode()));
                 }
-                break;
+            }
         }
     }
 
     private void remove(ElectrolyzerRecipe recipe) {
         switch (recipe.type) {
-            case CHARGE:
+            case CHARGE -> {
                 for (ItemStack stack : recipe.input.getMatchingStacks()) {
                     ClassicRecipes.electrolyzer.removeRecipe(stack, true, false);
                     removeFromMap(stack);
                 }
-                break;
-            case DISCHARGE:
+            }
+            case DISCHARGE -> {
                 for (ItemStack stack : recipe.input.getMatchingStacks()) {
                     ClassicRecipes.electrolyzer.removeRecipe(stack, false, false);
                     removeFromMap(stack);
                 }
-                break;
-            case BOTH:
+            }
+            case BOTH -> {
                 for (ItemStack stack : recipe.input.getMatchingStacks()) {
                     ClassicRecipes.electrolyzer.removeRecipe(stack, true, true);
                     removeFromMap(stack);
                 }
-                break;
+            }
         }
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/classic/ClassicExtractor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/classic/ClassicExtractor.java
@@ -58,7 +58,7 @@ public class ClassicExtractor extends Extractor {
                     .add("xp must not be negative, defaulting to zero")
                     .warn()
                     .post();
-            xp = 0F;
+            xp = 0.0F;
         }
         MachineRecipe<IRecipeInput, Collection<ItemStack>> recipe = new MachineRecipe<>(new RecipeInput(input), Collections.singleton(output));
         ClassicRecipes.extractor.addRecipe(recipe.getInput(), output, xp, String.valueOf(recipe.hashCode()));

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/classic/ClassicMacerator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/classic/ClassicMacerator.java
@@ -52,7 +52,7 @@ public class ClassicMacerator extends Macerator {
                     .add("xp must not be negative, defaulting to zero")
                     .warn()
                     .post();
-            xp = 0F;
+            xp = 0.0F;
         }
         MachineRecipe<IRecipeInput, Collection<ItemStack>> recipe = new MachineRecipe<>(new RecipeInput(input), Collections.singleton(output));
         ClassicRecipes.macerator.addRecipe(recipe.getInput(), output, xp, String.valueOf(recipe.hashCode()));

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/classic/ClassicScrapbox.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/classic/ClassicScrapbox.java
@@ -21,6 +21,7 @@ public class ClassicScrapbox extends Scrapbox {
         addScripted(new Drop(drop.getDrop(), drop.getChance()));
     }
 
+    @Override
     public void add(ItemStack stack, float chance) {
         if (GroovyLog.msg("Error adding Industrialcraft 2 Scrapbox recipe")
                 .add(IngredientHelper.isEmpty(stack), () -> "stack must not be emtpy")
@@ -63,6 +64,7 @@ public class ClassicScrapbox extends Scrapbox {
         return false;
     }
 
+    @Override
     public void removeAll() {
         for (IClassicScrapBoxManager.IDrop drop : ClassicRecipes.scrapboxDrops.getEntries()) {
             remove(drop);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/classic/Sawmill.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/classic/Sawmill.java
@@ -47,7 +47,7 @@ public class Sawmill extends VirtualizedRegistry<IMachineRecipeList.RecipeEntry>
                     .add("xp must not be negative, defaulting to zero")
                     .warn()
                     .post();
-            xp = 0F;
+            xp = 0.0F;
         }
         IMachineRecipeList.RecipeEntry entry = new IMachineRecipeList.RecipeEntry(new RecipeInput(input), new MachineExpOutput(null, xp, output), String.valueOf(output.hashCode()));
         ClassicRecipes.sawMill.addRecipe(entry.getInput(), entry.getOutput(), entry.getRecipeID());

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/exp/Electrolyzer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/exp/Electrolyzer.java
@@ -60,7 +60,7 @@ public class Electrolyzer extends VirtualizedRegistry<Pair<String, IElectrolyzer
                 list.add(new IElectrolyzerRecipeManager.ElectrolyzerOutput(fs.getFluid().getName(), fs.amount, EnumFacing.values()[i]));
         }
 
-        return add(input.getFluid().getName(), new IElectrolyzerRecipeManager.ElectrolyzerRecipe(input.amount, euATick, ticksNeeded, list.toArray(new IElectrolyzerRecipeManager.ElectrolyzerOutput[list.size()])));
+        return add(input.getFluid().getName(), new IElectrolyzerRecipeManager.ElectrolyzerRecipe(input.amount, euATick, ticksNeeded, list.toArray(new IElectrolyzerRecipeManager.ElectrolyzerOutput[0])));
     }
 
     public void removeByOutput(FluidStack... outputs) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/exp/LiquidHeatExchanger.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/exp/LiquidHeatExchanger.java
@@ -143,7 +143,8 @@ public class LiquidHeatExchanger extends VirtualizedRegistry<LiquidHeatExchanger
     public static class HeatExchangerRecipe {
 
         public int type; // 0 = heatup | 1 = cooldown
-        public Fluid hot, cold;
+        public Fluid hot;
+        public Fluid cold;
         public int huPerMB;
 
         public HeatExchangerRecipe(int type, FluidStack in, FluidStack out, int huPerMB) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/exp/Recycler.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/exp/Recycler.java
@@ -13,7 +13,7 @@ import java.util.Iterator;
 
 public class Recycler extends VirtualizedRegistry<IRecipeInput> {
 
-    private int type = 0; // 0 = Whitelist | 1 = Blacklist
+    private int type; // 0 = Whitelist | 1 = Blacklist
 
     private static final Object dummy = new Object();
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/Excavator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/Excavator.java
@@ -154,6 +154,7 @@ public class Excavator extends VirtualizedRegistry<Pair<ExcavatorHandler.Mineral
         @Property
         private boolean blacklist = true;
 
+        @Override
         @RecipeBuilderMethodDescription
         public RecipeBuilder name(String name) {
             this.name = name;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/inspirations/Cauldron.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/inspirations/Cauldron.java
@@ -355,44 +355,44 @@ public class Cauldron extends VirtualizedRegistry<ICauldronRecipe> {
             }
 
             switch (type) {
-                case STANDARD:
+                case STANDARD -> {
                     validateItems(msg, 1, 1, 1, 1);
                     validateFluids(msg, 1, 1, 0, 0);
                     msg.add(levels <= 0 || levels > InspirationsRegistry.getCauldronMax(), "levels must be greater than 0 and less than {}, yet it was {}", InspirationsRegistry.getCauldronMax(), levels);
                     msg.add(sound == null, "sound must be defined");
-                    break;
-                case TRANSFORM:
+                }
+                case TRANSFORM -> {
                     validateItems(msg, 1, 1, 0, 0);
                     validateFluids(msg, 1, 1, 1, 1);
                     msg.add(levels <= 0 || levels > InspirationsRegistry.getCauldronMax(), "levels must be greater than 0 and less than {}, yet it was {}", InspirationsRegistry.getCauldronMax(), levels);
-                    break;
-                case MIX:
+                }
+                case MIX -> {
                     validateItems(msg, 0, 0, 1, 1);
                     validateFluids(msg, 2, 2, 0, 0);
-                    break;
-                case FILL:
+                }
+                case FILL -> {
                     validateItems(msg, 1, 1, 1, 1);
                     validateFluids(msg, 1, 1, 0, 0);
                     msg.add(sound == null, "sound must be defined");
-                    break;
-                case BREWING:
+                }
+                case BREWING -> {
                     validateItems(msg, 1, 1, 0, 0);
                     validateFluids(msg);
                     msg.add(inputPotion == null, "inputPotion must be defined");
                     msg.add(outputPotion == null, "outputPotion must be defined");
-                    break;
-                case POTION:
+                }
+                case POTION -> {
                     validateItems(msg, 1, 1, 1, 1);
                     validateFluids(msg);
                     msg.add(inputPotion == null, "inputPotion must be defined");
                     msg.add(levels <= 0 || levels > InspirationsRegistry.getCauldronMax(), "levels must be greater than 0 and less than {}, yet it was {}", InspirationsRegistry.getCauldronMax(), levels);
-                    break;
-                case DYE:
+                }
+                case DYE -> {
                     validateItems(msg, 1, 1, 1, 1);
                     validateFluids(msg);
                     msg.add(dye == null, "dye must be defined");
                     msg.add(levels <= 0 || levels > InspirationsRegistry.getCauldronMax(), "levels must be greater than 0 and less than {}, yet it was {}", InspirationsRegistry.getCauldronMax(), levels);
-                    break;
+                }
             }
             msg.add(msg.hasSubMessages(), "Note that validation changes based on the type requested");
         }
@@ -402,34 +402,15 @@ public class Cauldron extends VirtualizedRegistry<ICauldronRecipe> {
         public @Nullable ICauldronRecipe register() {
             if (!validate()) return null;
 
-            ICauldronRecipe recipe;
-
-            switch (type) {
-                case STANDARD:
-                    recipe = new CauldronFluidRecipe(recipeMatchFromIngredient(input.get(0)), fluidInput.get(0).getFluid(), output.get(0), boiling, levels, sound);
-                    break;
-                case TRANSFORM:
-                    recipe = new CauldronFluidTransformRecipe(recipeMatchFromIngredient(input.get(0)), fluidInput.get(0).getFluid(), fluidOutput.get(0).getFluid(), boiling, levels);
-                    break;
-                case MIX:
-                    recipe = new CauldronMixRecipe(fluidInput.get(0).getFluid(), fluidInput.get(1).getFluid(), output.get(0));
-                    break;
-                case FILL:
-                    recipe = new FillCauldronRecipe(recipeMatchFromIngredient(input.get(0)), fluidInput.get(0).getFluid(), fluidInput.get(0).amount, output.get(0), boiling, sound);
-                    break;
-                case BREWING:
-                    recipe = new CauldronBrewingRecipe(inputPotion, input.get(0).toMcIngredient(), outputPotion);
-                    break;
-                case POTION:
-                    recipe = new CauldronPotionRecipe(recipeMatchFromIngredient(input.get(0)), inputPotion, output.get(0), levels, boiling);
-                    break;
-                case DYE:
-                    recipe = new CauldronDyeRecipe(recipeMatchFromIngredient(input.get(0)), dye, output.get(0), levels);
-                    break;
-                default:
-                    // Since we validate that type must be defined and return early if it isn't, this is impossible, but Intellij likes that it exists
-                    return null;
-            }
+            ICauldronRecipe recipe = switch (type) {
+                case STANDARD -> new CauldronFluidRecipe(recipeMatchFromIngredient(input.get(0)), fluidInput.get(0).getFluid(), output.get(0), boiling, levels, sound);
+                case TRANSFORM -> new CauldronFluidTransformRecipe(recipeMatchFromIngredient(input.get(0)), fluidInput.get(0).getFluid(), fluidOutput.get(0).getFluid(), boiling, levels);
+                case MIX -> new CauldronMixRecipe(fluidInput.get(0).getFluid(), fluidInput.get(1).getFluid(), output.get(0));
+                case FILL -> new FillCauldronRecipe(recipeMatchFromIngredient(input.get(0)), fluidInput.get(0).getFluid(), fluidInput.get(0).amount, output.get(0), boiling, sound);
+                case BREWING -> new CauldronBrewingRecipe(inputPotion, input.get(0).toMcIngredient(), outputPotion);
+                case POTION -> new CauldronPotionRecipe(recipeMatchFromIngredient(input.get(0)), inputPotion, output.get(0), levels, boiling);
+                case DYE -> new CauldronDyeRecipe(recipeMatchFromIngredient(input.get(0)), dye, output.get(0), levels);
+            };
 
             ModSupport.INSPIRATIONS.get().cauldron.add(recipe);
             return recipe;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/inspirations/Cauldron.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/inspirations/Cauldron.java
@@ -229,7 +229,7 @@ public class Cauldron extends VirtualizedRegistry<ICauldronRecipe> {
         @Property(valid = @Comp(value = "null", type = Comp.Type.NOT), needsOverride = true)
         private EnumDyeColor dye;
         @Property(needsOverride = true)
-        private Boolean boiling = null;
+        private Boolean boiling;
         @Property(valid = {@Comp(value = "0", type = Comp.Type.GTE),
                            @Comp(value = "`InspirationsRegistry.getCauldronMax()`", type = Comp.Type.LTE)}, needsOverride = true)
         private int levels;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/integrateddynamics/Squeezer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/integrateddynamics/Squeezer.java
@@ -130,6 +130,7 @@ public class Squeezer extends VirtualizedRegistry<IRecipe<IngredientRecipeCompon
             return this;
         }
 
+        @Override
         @RecipeBuilderMethodDescription
         public RecipeBuilder output(ItemStack output) {
             this.output.add(new IngredientRecipeComponent(output));

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/ChemicalInfuser.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/ChemicalInfuser.java
@@ -31,7 +31,7 @@ public class ChemicalInfuser extends VirtualizedMekanismRegistry<ChemicalInfuser
         msg.add(Mekanism.isEmpty(output), () -> "gas output must not be empty");
         if (msg.postIfNotEmpty()) return null;
 
-        ChemicalInfuserRecipe recipe = new ChemicalInfuserRecipe(leftInput.copy(), rightInput.copy(), output.copy());
+        ChemicalInfuserRecipe recipe = new ChemicalInfuserRecipe(leftInput, rightInput, output);
         addScripted(recipe);
         recipeRegistry.put(recipe);
         return recipe;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/ChemicalOxidizer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/ChemicalOxidizer.java
@@ -34,10 +34,9 @@ public class ChemicalOxidizer extends VirtualizedMekanismRegistry<OxidationRecip
         msg.add(Mekanism.isEmpty(output), () -> "output must not be empty");
         if (msg.postIfNotEmpty()) return null;
 
-        output = output.copy();
         OxidationRecipe recipe1 = null;
         for (ItemStack itemStack : ingredient.getMatchingStacks()) {
-            OxidationRecipe recipe = new OxidationRecipe(itemStack.copy(), output);
+            OxidationRecipe recipe = new OxidationRecipe(itemStack.copy(), output.copy());
             if (recipe1 == null) recipe1 = recipe;
             recipeRegistry.put(recipe);
             addScripted(recipe);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/ChemicalOxidizer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/ChemicalOxidizer.java
@@ -36,7 +36,7 @@ public class ChemicalOxidizer extends VirtualizedMekanismRegistry<OxidationRecip
 
         OxidationRecipe recipe1 = null;
         for (ItemStack itemStack : ingredient.getMatchingStacks()) {
-            OxidationRecipe recipe = new OxidationRecipe(itemStack.copy(), output.copy());
+            OxidationRecipe recipe = new OxidationRecipe(itemStack, output);
             if (recipe1 == null) recipe1 = recipe;
             recipeRegistry.put(recipe);
             addScripted(recipe);
@@ -86,7 +86,7 @@ public class ChemicalOxidizer extends VirtualizedMekanismRegistry<OxidationRecip
             if (!validate()) return null;
             OxidationRecipe recipe = null;
             for (ItemStack itemStack : input.get(0).getMatchingStacks()) {
-                OxidationRecipe r = new OxidationRecipe(itemStack.copy(), gasOutput.get(0));
+                OxidationRecipe r = new OxidationRecipe(itemStack, gasOutput.get(0));
                 if (recipe == null) recipe = r;
                 ModSupport.MEKANISM.get().chemicalOxidizer.add(r);
             }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Combiner.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Combiner.java
@@ -35,7 +35,7 @@ public class Combiner extends VirtualizedMekanismRegistry<CombinerRecipe> {
 
         CombinerRecipe recipe1 = null;
         for (ItemStack itemStack : ingredient.getMatchingStacks()) {
-            CombinerRecipe recipe = new CombinerRecipe(itemStack.copy(), extra.copy(), output.copy());
+            CombinerRecipe recipe = new CombinerRecipe(itemStack, extra, output);
             if (recipe1 == null) recipe1 = recipe;
             recipeRegistry.put(recipe);
             addScripted(recipe);
@@ -93,7 +93,7 @@ public class Combiner extends VirtualizedMekanismRegistry<CombinerRecipe> {
             if (!validate()) return null;
             CombinerRecipe recipe = null;
             for (ItemStack itemStack : input.get(0).getMatchingStacks()) {
-                CombinerRecipe r = new CombinerRecipe(itemStack.copy(), extra, output.get(0));
+                CombinerRecipe r = new CombinerRecipe(itemStack, extra, output.get(0));
                 if (recipe == null) recipe = r;
                 ModSupport.MEKANISM.get().combiner.add(r);
             }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Combiner.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Combiner.java
@@ -33,11 +33,9 @@ public class Combiner extends VirtualizedMekanismRegistry<CombinerRecipe> {
         msg.add(IngredientHelper.isEmpty(output), () -> "output must not be empty");
         if (msg.postIfNotEmpty()) return null;
 
-        extra = extra.copy();
-        output = output.copy();
         CombinerRecipe recipe1 = null;
         for (ItemStack itemStack : ingredient.getMatchingStacks()) {
-            CombinerRecipe recipe = new CombinerRecipe(itemStack.copy(), extra, output);
+            CombinerRecipe recipe = new CombinerRecipe(itemStack.copy(), extra.copy(), output.copy());
             if (recipe1 == null) recipe1 = recipe;
             recipeRegistry.put(recipe);
             addScripted(recipe);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Crusher.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Crusher.java
@@ -34,7 +34,7 @@ public class Crusher extends VirtualizedMekanismRegistry<CrusherRecipe> {
 
         CrusherRecipe recipe1 = null;
         for (ItemStack itemStack : ingredient.getMatchingStacks()) {
-            CrusherRecipe recipe = new CrusherRecipe(itemStack.copy(), output.copy());
+            CrusherRecipe recipe = new CrusherRecipe(itemStack, output);
             if (recipe1 == null) recipe1 = recipe;
             recipeRegistry.put(recipe);
             addScripted(recipe);
@@ -83,7 +83,7 @@ public class Crusher extends VirtualizedMekanismRegistry<CrusherRecipe> {
             if (!validate()) return null;
             CrusherRecipe recipe = null;
             for (ItemStack itemStack : input.get(0).getMatchingStacks()) {
-                CrusherRecipe r = new CrusherRecipe(itemStack.copy(), output.get(0));
+                CrusherRecipe r = new CrusherRecipe(itemStack, output.get(0));
                 if (recipe == null) recipe = r;
                 ModSupport.MEKANISM.get().crusher.add(r);
             }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Crusher.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Crusher.java
@@ -32,10 +32,9 @@ public class Crusher extends VirtualizedMekanismRegistry<CrusherRecipe> {
         msg.add(IngredientHelper.isEmpty(output), () -> "output must not be empty");
         if (msg.postIfNotEmpty()) return null;
 
-        output = output.copy();
         CrusherRecipe recipe1 = null;
         for (ItemStack itemStack : ingredient.getMatchingStacks()) {
-            CrusherRecipe recipe = new CrusherRecipe(itemStack.copy(), output);
+            CrusherRecipe recipe = new CrusherRecipe(itemStack.copy(), output.copy());
             if (recipe1 == null) recipe1 = recipe;
             recipeRegistry.put(recipe);
             addScripted(recipe);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Crystallizer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Crystallizer.java
@@ -32,7 +32,7 @@ public class Crystallizer extends VirtualizedMekanismRegistry<CrystallizerRecipe
         msg.add(IngredientHelper.isEmpty(output), () -> "output must not be empty");
         if (msg.postIfNotEmpty()) return null;
 
-        CrystallizerRecipe recipe = new CrystallizerRecipe(input.copy(), output.copy());
+        CrystallizerRecipe recipe = new CrystallizerRecipe(input, output);
         recipeRegistry.put(recipe);
         addScripted(recipe);
         return recipe;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/DissolutionChamber.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/DissolutionChamber.java
@@ -34,10 +34,9 @@ public class DissolutionChamber extends VirtualizedMekanismRegistry<DissolutionR
         msg.add(Mekanism.isEmpty(output), () -> "output must not be empty");
         if (msg.postIfNotEmpty()) return null;
 
-        output = output.copy();
         DissolutionRecipe recipe1 = null;
         for (ItemStack itemStack : ingredient.getMatchingStacks()) {
-            DissolutionRecipe recipe = new DissolutionRecipe(itemStack.copy(), output);
+            DissolutionRecipe recipe = new DissolutionRecipe(itemStack.copy(), output.copy());
             if (recipe1 == null) recipe1 = recipe;
             recipeRegistry.put(recipe);
             addScripted(recipe);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/DissolutionChamber.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/DissolutionChamber.java
@@ -36,7 +36,7 @@ public class DissolutionChamber extends VirtualizedMekanismRegistry<DissolutionR
 
         DissolutionRecipe recipe1 = null;
         for (ItemStack itemStack : ingredient.getMatchingStacks()) {
-            DissolutionRecipe recipe = new DissolutionRecipe(itemStack.copy(), output.copy());
+            DissolutionRecipe recipe = new DissolutionRecipe(itemStack, output);
             if (recipe1 == null) recipe1 = recipe;
             recipeRegistry.put(recipe);
             addScripted(recipe);
@@ -86,7 +86,7 @@ public class DissolutionChamber extends VirtualizedMekanismRegistry<DissolutionR
             if (!validate()) return null;
             DissolutionRecipe recipe = null;
             for (ItemStack itemStack : input.get(0).getMatchingStacks()) {
-                DissolutionRecipe r = new DissolutionRecipe(itemStack.copy(), gasOutput.get(0));
+                DissolutionRecipe r = new DissolutionRecipe(itemStack, gasOutput.get(0));
                 if (recipe == null) recipe = r;
                 ModSupport.MEKANISM.get().dissolutionChamber.add(r);
             }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/ElectrolyticSeparator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/ElectrolyticSeparator.java
@@ -34,7 +34,7 @@ public class ElectrolyticSeparator extends VirtualizedMekanismRegistry<Separator
         msg.add(Mekanism.isEmpty(rightOutput), () -> "right gas output must not be empty");
         if (msg.postIfNotEmpty()) return null;
 
-        SeparatorRecipe recipe = new SeparatorRecipe(input.copy(), energy, leftOutput.copy(), rightOutput.copy());
+        SeparatorRecipe recipe = new SeparatorRecipe(input, energy, leftOutput, rightOutput);
         addScripted(recipe);
         recipeRegistry.put(recipe);
         return recipe;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/EnrichmentChamber.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/EnrichmentChamber.java
@@ -33,10 +33,9 @@ public class EnrichmentChamber extends VirtualizedMekanismRegistry<EnrichmentRec
         msg.add(IngredientHelper.isEmpty(output), () -> "output must not be empty");
         if (msg.postIfNotEmpty()) return null;
 
-        output = output.copy();
         EnrichmentRecipe recipe1 = null;
         for (ItemStack itemStack : ingredient.getMatchingStacks()) {
-            EnrichmentRecipe recipe = new EnrichmentRecipe(itemStack.copy(), output);
+            EnrichmentRecipe recipe = new EnrichmentRecipe(itemStack.copy(), output.copy());
             if (recipe1 == null) recipe1 = recipe;
             recipeRegistry.put(recipe);
             addScripted(recipe);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/EnrichmentChamber.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/EnrichmentChamber.java
@@ -35,7 +35,7 @@ public class EnrichmentChamber extends VirtualizedMekanismRegistry<EnrichmentRec
 
         EnrichmentRecipe recipe1 = null;
         for (ItemStack itemStack : ingredient.getMatchingStacks()) {
-            EnrichmentRecipe recipe = new EnrichmentRecipe(itemStack.copy(), output.copy());
+            EnrichmentRecipe recipe = new EnrichmentRecipe(itemStack, output);
             if (recipe1 == null) recipe1 = recipe;
             recipeRegistry.put(recipe);
             addScripted(recipe);
@@ -84,7 +84,7 @@ public class EnrichmentChamber extends VirtualizedMekanismRegistry<EnrichmentRec
             if (!validate()) return null;
             EnrichmentRecipe recipe = null;
             for (ItemStack itemStack : input.get(0).getMatchingStacks()) {
-                EnrichmentRecipe r = new EnrichmentRecipe(itemStack.copy(), output.get(0));
+                EnrichmentRecipe r = new EnrichmentRecipe(itemStack, output.get(0));
                 if (recipe == null) recipe = r;
                 ModSupport.MEKANISM.get().enrichmentChamber.add(r);
             }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Infusion.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Infusion.java
@@ -34,7 +34,7 @@ import java.util.stream.Collectors;
 )
 public class Infusion extends VirtualizedRegistry<Pair<String, InfuseType>> {
 
-    private AbstractReloadableStorage<Pair<ItemStack, InfuseObject>> objectStorage = new AbstractReloadableStorage<>();
+    private final AbstractReloadableStorage<Pair<ItemStack, InfuseObject>> objectStorage = new AbstractReloadableStorage<>();
 
     public static InfusionItems infusion(InfuseType type) {
         return new InfusionItems(type);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Infusion.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Infusion.java
@@ -84,8 +84,8 @@ public class Infusion extends VirtualizedRegistry<Pair<String, InfuseType>> {
     }
 
     @MethodDescription(example = {
-            @Example("infusion('diamond'), 100, item('minecraft:clay')"),
-            @Example("infusion('carbon'), 100, item('minecraft:gold_ingot')")
+            @Example("infusionType('diamond'), 100, item('minecraft:clay')"),
+            @Example("infusionType('carbon'), 100, item('minecraft:gold_ingot')")
     }, type = MethodDescription.Type.ADDITION)
     public void add(InfuseType type, int amount, ItemStack item) {
         InfuseObject object = new InfuseObject(type, amount);
@@ -143,8 +143,8 @@ public class Infusion extends VirtualizedRegistry<Pair<String, InfuseType>> {
     }
 
     @MethodDescription(example = {
-            @Example("infusion('carbon')"),
-            @Example(value = "infusion('diamond')", commented = true)
+            @Example("infusionType('carbon')"),
+            @Example(value = "infusionType('diamond')", commented = true)
     })
     public void removeByType(InfuseType type) {
         for (Map.Entry<ItemStack, InfuseObject> entry : InfuseRegistry.getObjectMap().entrySet().stream().filter(x -> x.getValue().type == type).collect(Collectors.toList())) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/InjectionChamber.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/InjectionChamber.java
@@ -35,10 +35,9 @@ public class InjectionChamber extends VirtualizedMekanismRegistry<InjectionRecip
         msg.add(IngredientHelper.isEmpty(output), () -> "output must not be empty");
         if (msg.postIfNotEmpty()) return null;
 
-        output = output.copy();
         InjectionRecipe recipe1 = null;
         for (ItemStack itemStack : ingredient.getMatchingStacks()) {
-            InjectionRecipe recipe = new InjectionRecipe(itemStack.copy(), gasInput.getGas(), output);
+            InjectionRecipe recipe = new InjectionRecipe(itemStack, gasInput.getGas(), output);
             if (recipe1 == null) recipe1 = recipe;
             recipeRegistry.put(recipe);
             addScripted(recipe);
@@ -90,7 +89,7 @@ public class InjectionChamber extends VirtualizedMekanismRegistry<InjectionRecip
             if (!validate()) return null;
             InjectionRecipe recipe = null;
             for (ItemStack itemStack : input.get(0).getMatchingStacks()) {
-                InjectionRecipe r = new InjectionRecipe(itemStack.copy(), gasInput.get(0).getGas(), output.get(0));
+                InjectionRecipe r = new InjectionRecipe(itemStack, gasInput.get(0).getGas(), output.get(0));
                 if (recipe == null) recipe = r;
                 ModSupport.MEKANISM.get().injectionChamber.add(r);
             }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Mekanism.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Mekanism.java
@@ -48,7 +48,7 @@ public class Mekanism extends GroovyPropertyContainer {
                 .completerOfNamed(GasRegistry::getRegisteredGasses, Gas::getName)
                 .docOfType("gas stack")
                 .register();
-        container.objectMapperBuilder("infusionType", InfuseType.class) // infusion clashes with infusion field
+        container.objectMapperBuilder("infusionType", InfuseType.class)
                 .parser(IObjectParser.wrapStringGetter(InfuseRegistry::get, true))
                 .completerOfNames(InfuseRegistry.getInfuseMap()::keySet)
                 .docOfType("infusion type")

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/MetallurgicInfuser.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/MetallurgicInfuser.java
@@ -36,10 +36,9 @@ public class MetallurgicInfuser extends VirtualizedMekanismRegistry<MetallurgicI
         if (infuseAmount <= 0) infuseAmount = 40;
         if (msg.postIfNotEmpty()) return null;
 
-        output = output.copy();
         MetallurgicInfuserRecipe recipe1 = null;
         for (ItemStack itemStack : ingredient.getMatchingStacks()) {
-            MetallurgicInfuserRecipe recipe = new MetallurgicInfuserRecipe(new InfusionInput(infuseType, infuseAmount, itemStack.copy()), output);
+            MetallurgicInfuserRecipe recipe = new MetallurgicInfuserRecipe(new InfusionInput(infuseType, infuseAmount, itemStack.copy()), output.copy());
             if (recipe1 == null) recipe1 = recipe;
             recipeRegistry.put(recipe);
             addScripted(recipe);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/MetallurgicInfuser.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/MetallurgicInfuser.java
@@ -22,12 +22,12 @@ public class MetallurgicInfuser extends VirtualizedMekanismRegistry<MetallurgicI
         super(RecipeHandler.Recipe.METALLURGIC_INFUSER);
     }
 
-    @RecipeBuilderDescription(example = @Example(".input(item('minecraft:nether_star')).infuse(infusion('groovy_example')).amount(50).output(item('minecraft:clay'))"))
+    @RecipeBuilderDescription(example = @Example(".input(item('minecraft:nether_star')).infuse(infusionType('groovy_example')).amount(50).output(item('minecraft:clay'))"))
     public RecipeBuilder recipeBuilder() {
         return new RecipeBuilder();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.mekanism.metallurgic_infuser.add0", type = MethodDescription.Type.ADDITION, example = @Example(value = "item('minecraft:nether_star'), infusion('groovy_example'), 50, item('minecraft:clay')", commented = true))
+    @MethodDescription(description = "groovyscript.wiki.mekanism.metallurgic_infuser.add0", type = MethodDescription.Type.ADDITION, example = @Example(value = "item('minecraft:nether_star'), infusionType('groovy_example'), 50, item('minecraft:clay')", commented = true))
     public MetallurgicInfuserRecipe add(IIngredient ingredient, InfuseType infuseType, int infuseAmount, ItemStack output) {
         GroovyLog.Msg msg = GroovyLog.msg("Error adding Mekanism Metallurgic Infuser recipe").error();
         msg.add(IngredientHelper.isEmpty(ingredient), () -> "input must not be empty");

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/MetallurgicInfuser.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/MetallurgicInfuser.java
@@ -38,7 +38,7 @@ public class MetallurgicInfuser extends VirtualizedMekanismRegistry<MetallurgicI
 
         MetallurgicInfuserRecipe recipe1 = null;
         for (ItemStack itemStack : ingredient.getMatchingStacks()) {
-            MetallurgicInfuserRecipe recipe = new MetallurgicInfuserRecipe(new InfusionInput(infuseType, infuseAmount, itemStack.copy()), output.copy());
+            MetallurgicInfuserRecipe recipe = new MetallurgicInfuserRecipe(new InfusionInput(infuseType, infuseAmount, itemStack), output);
             if (recipe1 == null) recipe1 = recipe;
             recipeRegistry.put(recipe);
             addScripted(recipe);
@@ -120,7 +120,7 @@ public class MetallurgicInfuser extends VirtualizedMekanismRegistry<MetallurgicI
             if (!validate()) return null;
             MetallurgicInfuserRecipe recipe = null;
             for (ItemStack itemStack : input.get(0).getMatchingStacks()) {
-                MetallurgicInfuserRecipe r = new MetallurgicInfuserRecipe(new InfusionInput(infuse, amount, itemStack.copy()), output.get(0));
+                MetallurgicInfuserRecipe r = new MetallurgicInfuserRecipe(new InfusionInput(infuse, amount, itemStack), output.get(0));
                 if (recipe == null) recipe = r;
                 ModSupport.MEKANISM.get().metallurgicInfuser.add(r);
             }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/OsmiumCompressor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/OsmiumCompressor.java
@@ -36,10 +36,9 @@ public class OsmiumCompressor extends VirtualizedMekanismRegistry<OsmiumCompress
         msg.add(IngredientHelper.isEmpty(output), () -> "output must not be empty");
         if (msg.postIfNotEmpty()) return null;
 
-        output = output.copy();
         OsmiumCompressorRecipe recipe1 = null;
         for (ItemStack itemStack : ingredient.getMatchingStacks()) {
-            OsmiumCompressorRecipe recipe = new OsmiumCompressorRecipe(new AdvancedMachineInput(itemStack.copy(), gasInput.getGas()), new ItemStackOutput(output));
+            OsmiumCompressorRecipe recipe = new OsmiumCompressorRecipe(new AdvancedMachineInput(itemStack.copy(), gasInput.getGas()), new ItemStackOutput(output.copy()));
             if (recipe1 == null) recipe1 = recipe;
             recipeRegistry.put(recipe);
             addScripted(recipe);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/OsmiumCompressor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/OsmiumCompressor.java
@@ -38,7 +38,7 @@ public class OsmiumCompressor extends VirtualizedMekanismRegistry<OsmiumCompress
 
         OsmiumCompressorRecipe recipe1 = null;
         for (ItemStack itemStack : ingredient.getMatchingStacks()) {
-            OsmiumCompressorRecipe recipe = new OsmiumCompressorRecipe(new AdvancedMachineInput(itemStack.copy(), gasInput.getGas()), new ItemStackOutput(output.copy()));
+            OsmiumCompressorRecipe recipe = new OsmiumCompressorRecipe(new AdvancedMachineInput(itemStack, gasInput.getGas()), new ItemStackOutput(output));
             if (recipe1 == null) recipe1 = recipe;
             recipeRegistry.put(recipe);
             addScripted(recipe);
@@ -91,7 +91,7 @@ public class OsmiumCompressor extends VirtualizedMekanismRegistry<OsmiumCompress
             Gas gas = gasInput.isEmpty() ? MekanismFluids.LiquidOsmium : gasInput.get(0).getGas();
             OsmiumCompressorRecipe recipe = null;
             for (ItemStack itemStack : input.get(0).getMatchingStacks()) {
-                OsmiumCompressorRecipe r = new OsmiumCompressorRecipe(new AdvancedMachineInput(itemStack.copy(), gas), new ItemStackOutput(output.get(0)));
+                OsmiumCompressorRecipe r = new OsmiumCompressorRecipe(new AdvancedMachineInput(itemStack, gas), new ItemStackOutput(output.get(0)));
                 if (recipe == null) recipe = r;
                 ModSupport.MEKANISM.get().osmiumCompressor.add(r);
             }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/PressurizedReactionChamber.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/PressurizedReactionChamber.java
@@ -33,7 +33,7 @@ public class PressurizedReactionChamber extends VirtualizedMekanismRegistry<Pres
     public PressurizedRecipe add(IIngredient inputSolid, FluidStack inputFluid, GasStack inputGas, ItemStack outputSolid, GasStack outputGas, double energy, int duration) {
         PressurizedRecipe r = null;
         for (ItemStack item : inputSolid.getMatchingStacks()) {
-            PressurizedRecipe recipe = new PressurizedRecipe(item, inputFluid.copy(), inputGas.copy(), outputSolid.copy(), outputGas.copy(), energy, duration);
+            PressurizedRecipe recipe = new PressurizedRecipe(item, inputFluid, inputGas, outputSolid, outputGas, energy, duration);
             if (r == null) r = recipe;
             recipeRegistry.put(recipe);
             addScripted(recipe);
@@ -112,7 +112,7 @@ public class PressurizedReactionChamber extends VirtualizedMekanismRegistry<Pres
                 ModSupport.MEKANISM.get().pressurizedReactionChamber.add(recipe);
             } else {
                 for (ItemStack itemStack : input.get(0).getMatchingStacks()) {
-                    PressurizedRecipe r = new PressurizedRecipe(new PressurizedInput(itemStack.copy(), fluidInput.get(0), gasInput.get(0)), pressurizedOutput, energy, duration);
+                    PressurizedRecipe r = new PressurizedRecipe(new PressurizedInput(itemStack, fluidInput.get(0), gasInput.get(0)), pressurizedOutput, energy, duration);
                     if (recipe == null) recipe = r;
                     ModSupport.MEKANISM.get().pressurizedReactionChamber.add(r);
                 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/PurificationChamber.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/PurificationChamber.java
@@ -35,10 +35,9 @@ public class PurificationChamber extends VirtualizedMekanismRegistry<Purificatio
         msg.add(IngredientHelper.isEmpty(output), () -> "output must not be empty");
         if (msg.postIfNotEmpty()) return null;
 
-        output = output.copy();
         PurificationRecipe recipe1 = null;
         for (ItemStack itemStack : ingredient.getMatchingStacks()) {
-            PurificationRecipe recipe = new PurificationRecipe(new AdvancedMachineInput(itemStack.copy(), gasInput.getGas()), new ItemStackOutput(output));
+            PurificationRecipe recipe = new PurificationRecipe(new AdvancedMachineInput(itemStack.copy(), gasInput.getGas()), new ItemStackOutput(output.copy()));
             if (recipe1 == null) recipe1 = recipe;
             recipeRegistry.put(recipe);
             addScripted(recipe);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/PurificationChamber.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/PurificationChamber.java
@@ -37,7 +37,7 @@ public class PurificationChamber extends VirtualizedMekanismRegistry<Purificatio
 
         PurificationRecipe recipe1 = null;
         for (ItemStack itemStack : ingredient.getMatchingStacks()) {
-            PurificationRecipe recipe = new PurificationRecipe(new AdvancedMachineInput(itemStack.copy(), gasInput.getGas()), new ItemStackOutput(output.copy()));
+            PurificationRecipe recipe = new PurificationRecipe(new AdvancedMachineInput(itemStack, gasInput.getGas()), new ItemStackOutput(output));
             if (recipe1 == null) recipe1 = recipe;
             recipeRegistry.put(recipe);
             addScripted(recipe);
@@ -89,7 +89,7 @@ public class PurificationChamber extends VirtualizedMekanismRegistry<Purificatio
             if (!validate()) return null;
             PurificationRecipe recipe = null;
             for (ItemStack itemStack : input.get(0).getMatchingStacks()) {
-                PurificationRecipe r = new PurificationRecipe(new AdvancedMachineInput(itemStack.copy(), gasInput.get(0).getGas()), new ItemStackOutput(output.get(0)));
+                PurificationRecipe r = new PurificationRecipe(new AdvancedMachineInput(itemStack, gasInput.get(0).getGas()), new ItemStackOutput(output.get(0)));
                 if (recipe == null) recipe = r;
                 ModSupport.MEKANISM.get().purificationChamber.add(r);
             }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Sawmill.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Sawmill.java
@@ -46,14 +46,12 @@ public class Sawmill extends VirtualizedMekanismRegistry<SawmillRecipe> {
         boolean withSecondary = !IngredientHelper.isEmpty(secondary);
         if (withSecondary) {
             if (chance <= 0) chance = 1;
-            secondary = secondary.copy();
         }
 
-        output = output.copy();
         SawmillRecipe recipe1 = null;
         for (ItemStack itemStack : ingredient.getMatchingStacks()) {
             SawmillRecipe recipe;
-            ChanceOutput chanceOutput = withSecondary ? new ChanceOutput(output, secondary, chance) : new ChanceOutput(output);
+            ChanceOutput chanceOutput = withSecondary ? new ChanceOutput(output.copy(), secondary.copy(), chance) : new ChanceOutput(output.copy());
             recipe = new SawmillRecipe(new ItemStackInput(itemStack.copy()), chanceOutput);
             if (recipe1 == null) recipe1 = recipe;
             recipeRegistry.put(recipe);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Sawmill.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Sawmill.java
@@ -51,8 +51,8 @@ public class Sawmill extends VirtualizedMekanismRegistry<SawmillRecipe> {
         SawmillRecipe recipe1 = null;
         for (ItemStack itemStack : ingredient.getMatchingStacks()) {
             SawmillRecipe recipe;
-            ChanceOutput chanceOutput = withSecondary ? new ChanceOutput(output.copy(), secondary.copy(), chance) : new ChanceOutput(output.copy());
-            recipe = new SawmillRecipe(new ItemStackInput(itemStack.copy()), chanceOutput);
+            ChanceOutput chanceOutput = withSecondary ? new ChanceOutput(output, secondary, chance) : new ChanceOutput(output);
+            recipe = new SawmillRecipe(new ItemStackInput(itemStack), chanceOutput);
             if (recipe1 == null) recipe1 = recipe;
             recipeRegistry.put(recipe);
             addScripted(recipe);
@@ -120,7 +120,7 @@ public class Sawmill extends VirtualizedMekanismRegistry<SawmillRecipe> {
                                         : new ChanceOutput(output.get(0), extra, chance);
             SawmillRecipe recipe = null;
             for (ItemStack itemStack : input.get(0).getMatchingStacks()) {
-                SawmillRecipe r = new SawmillRecipe(new ItemStackInput(itemStack.copy()), chanceOutput);
+                SawmillRecipe r = new SawmillRecipe(new ItemStackInput(itemStack), chanceOutput);
                 if (recipe == null) recipe = r;
                 ModSupport.MEKANISM.get().sawmill.add(r);
             }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Smelting.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Smelting.java
@@ -40,7 +40,7 @@ public class Smelting extends VirtualizedMekanismRegistry<SmeltingRecipe> {
 
         SmeltingRecipe recipe1 = null;
         for (ItemStack itemStack : ingredient.getMatchingStacks()) {
-            SmeltingRecipe recipe = new SmeltingRecipe(new ItemStackInput(itemStack.copy()), new ItemStackOutput(output.copy()));
+            SmeltingRecipe recipe = new SmeltingRecipe(new ItemStackInput(itemStack), new ItemStackOutput(output));
             if (recipe1 == null) recipe1 = recipe;
             recipeRegistry.put(recipe);
             addScripted(recipe);
@@ -89,7 +89,7 @@ public class Smelting extends VirtualizedMekanismRegistry<SmeltingRecipe> {
             if (!validate()) return null;
             SmeltingRecipe recipe = null;
             for (ItemStack itemStack : input.get(0).getMatchingStacks()) {
-                SmeltingRecipe r = new SmeltingRecipe(itemStack.copy(), output.get(0));
+                SmeltingRecipe r = new SmeltingRecipe(itemStack, output.get(0));
                 if (recipe == null) recipe = r;
                 ModSupport.MEKANISM.get().smelting.add(r);
             }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Smelting.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Smelting.java
@@ -38,10 +38,9 @@ public class Smelting extends VirtualizedMekanismRegistry<SmeltingRecipe> {
         msg.add(IngredientHelper.isEmpty(output), () -> "output must not be empty");
         if (msg.postIfNotEmpty()) return null;
 
-        output = output.copy();
         SmeltingRecipe recipe1 = null;
         for (ItemStack itemStack : ingredient.getMatchingStacks()) {
-            SmeltingRecipe recipe = new SmeltingRecipe(new ItemStackInput(itemStack.copy()), new ItemStackOutput(output));
+            SmeltingRecipe recipe = new SmeltingRecipe(new ItemStackInput(itemStack.copy()), new ItemStackOutput(output.copy()));
             if (recipe1 == null) recipe1 = recipe;
             recipeRegistry.put(recipe);
             addScripted(recipe);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/SolarNeutronActivator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/SolarNeutronActivator.java
@@ -31,7 +31,7 @@ public class SolarNeutronActivator extends VirtualizedMekanismRegistry<SolarNeut
         msg.add(Mekanism.isEmpty(output), () -> "output must not be empty");
         if (msg.postIfNotEmpty()) return null;
 
-        SolarNeutronRecipe recipe = new SolarNeutronRecipe(input.copy(), output.copy());
+        SolarNeutronRecipe recipe = new SolarNeutronRecipe(input, output);
         recipeRegistry.put(recipe);
         addScripted(recipe);
         return recipe;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/ThermalEvaporationPlant.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/ThermalEvaporationPlant.java
@@ -32,7 +32,7 @@ public class ThermalEvaporationPlant extends VirtualizedMekanismRegistry<Thermal
         msg.add(IngredientHelper.isEmpty(output), () -> "output must not be empty");
         if (msg.postIfNotEmpty()) return null;
 
-        ThermalEvaporationRecipe recipe = new ThermalEvaporationRecipe(input.copy(), output.copy());
+        ThermalEvaporationRecipe recipe = new ThermalEvaporationRecipe(input, output);
         recipeRegistry.put(recipe);
         addScripted(recipe);
         return recipe;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Washer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Washer.java
@@ -31,7 +31,7 @@ public class Washer extends VirtualizedMekanismRegistry<WasherRecipe> {
         msg.add(Mekanism.isEmpty(output), () -> "output must not be empty");
         if (msg.postIfNotEmpty()) return null;
 
-        WasherRecipe recipe = new WasherRecipe(input.copy(), output.copy());
+        WasherRecipe recipe = new WasherRecipe(input, output);
         recipeRegistry.put(recipe);
         addScripted(recipe);
         return recipe;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/naturesaura/Altar.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/naturesaura/Altar.java
@@ -140,6 +140,7 @@ public class Altar extends VirtualizedRegistry<AltarRecipe> {
             return "Error adding Nature's Aura Altar Recipe";
         }
 
+        @Override
         public String getRecipeNamePrefix() {
             return "groovyscript_altar_";
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/naturesaura/Altar.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/naturesaura/Altar.java
@@ -58,7 +58,7 @@ public class Altar extends VirtualizedRegistry<AltarRecipe> {
         return true;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:rotten_flesh')"))
+    @MethodDescription(example = @Example("item('minecraft:rotten_flesh')"))
     public boolean removeByInput(IIngredient input) {
         return NaturesAuraAPI.ALTAR_RECIPES.entrySet().removeIf(r -> {
             for (var item : r.getValue().input.getMatchingStacks()) {
@@ -71,7 +71,7 @@ public class Altar extends VirtualizedRegistry<AltarRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByCatalyst", example = @Example("item('naturesaura:crushing_catalyst')"))
+    @MethodDescription(example = @Example("item('naturesaura:crushing_catalyst')"))
     public boolean removeByCatalyst(IIngredient catalyst) {
         return NaturesAuraAPI.ALTAR_RECIPES.entrySet().removeIf(r -> {
             for (var item : r.getValue().catalyst.getMatchingStacks()) {
@@ -84,7 +84,7 @@ public class Altar extends VirtualizedRegistry<AltarRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('minecraft:soul_sand')"))
+    @MethodDescription(example = @Example("item('minecraft:soul_sand')"))
     public boolean removeByOutput(IIngredient output) {
         return NaturesAuraAPI.ALTAR_RECIPES.entrySet().removeIf(r -> {
             if (output.test(r.getValue().output)) {
@@ -95,13 +95,13 @@ public class Altar extends VirtualizedRegistry<AltarRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         NaturesAuraAPI.ALTAR_RECIPES.values().forEach(this::addBackup);
         NaturesAuraAPI.ALTAR_RECIPES.entrySet().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<Map.Entry<ResourceLocation, AltarRecipe>> streamRecipes() {
         return new SimpleObjectStream<>(NaturesAuraAPI.ALTAR_RECIPES.entrySet()).setRemover(x -> remove(x.getValue()));
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/naturesaura/Altar.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/naturesaura/Altar.java
@@ -159,7 +159,7 @@ public class Altar extends VirtualizedRegistry<AltarRecipe> {
         @RecipeBuilderRegistrationMethod
         public @Nullable AltarRecipe register() {
             if (!validate()) return null;
-            AltarRecipe recipe = new AltarRecipe(name, input.get(0).toMcIngredient(), output.get(0), catalyst.toMcIngredient(), aura, time);
+            AltarRecipe recipe = new AltarRecipe(super.name, input.get(0).toMcIngredient(), output.get(0), catalyst.toMcIngredient(), aura, time);
             ModSupport.NATURES_AURA.get().altar.add(recipe);
             return recipe;
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/naturesaura/Offering.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/naturesaura/Offering.java
@@ -137,7 +137,7 @@ public class Offering extends VirtualizedRegistry<OfferingRecipe> {
         @RecipeBuilderRegistrationMethod
         public @Nullable OfferingRecipe register() {
             if (!validate()) return null;
-            OfferingRecipe recipe = new OfferingRecipe(name, input.get(0).toMcIngredient(), catalyst.toMcIngredient(), output.get(0));
+            OfferingRecipe recipe = new OfferingRecipe(super.name, input.get(0).toMcIngredient(), catalyst.toMcIngredient(), output.get(0));
             ModSupport.NATURES_AURA.get().offering.add(recipe);
             return recipe;
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/naturesaura/Offering.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/naturesaura/Offering.java
@@ -54,7 +54,7 @@ public class Offering extends VirtualizedRegistry<OfferingRecipe> {
         return true;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:nether_star')"))
+    @MethodDescription(example = @Example("item('minecraft:nether_star')"))
     public boolean removeByInput(IIngredient input) {
         return NaturesAuraAPI.OFFERING_RECIPES.entrySet().removeIf(r -> {
             for (var item : r.getValue().input.getMatchingStacks()) {
@@ -67,7 +67,7 @@ public class Offering extends VirtualizedRegistry<OfferingRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByCatalyst", example = @Example(value = "item('naturesaura:calling_spirit')", commented = true))
+    @MethodDescription(example = @Example(value = "item('naturesaura:calling_spirit')", commented = true))
     public boolean removeByCatalyst(IIngredient catalyst) {
         return NaturesAuraAPI.OFFERING_RECIPES.entrySet().removeIf(r -> {
             for (var x : r.getValue().startItem.getMatchingStacks()) {
@@ -80,7 +80,7 @@ public class Offering extends VirtualizedRegistry<OfferingRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('naturesaura:sky_ingot')"))
+    @MethodDescription(example = @Example("item('naturesaura:sky_ingot')"))
     public boolean removeByOutput(IIngredient output) {
         return NaturesAuraAPI.OFFERING_RECIPES.entrySet().removeIf(r -> {
             if (output.test(r.getValue().output)) {
@@ -91,13 +91,13 @@ public class Offering extends VirtualizedRegistry<OfferingRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         NaturesAuraAPI.OFFERING_RECIPES.values().forEach(this::addBackup);
         NaturesAuraAPI.OFFERING_RECIPES.entrySet().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<Map.Entry<ResourceLocation, OfferingRecipe>> streamRecipes() {
         return new SimpleObjectStream<>(NaturesAuraAPI.OFFERING_RECIPES.entrySet()).setRemover(x -> remove(x.getValue()));
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/naturesaura/Offering.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/naturesaura/Offering.java
@@ -120,6 +120,7 @@ public class Offering extends VirtualizedRegistry<OfferingRecipe> {
             return "Error adding Nature's Aura Offering Recipe";
         }
 
+        @Override
         public String getRecipeNamePrefix() {
             return "groovyscript_offering_";
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/naturesaura/Ritual.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/naturesaura/Ritual.java
@@ -55,7 +55,7 @@ public class Ritual extends VirtualizedRegistry<TreeRitualRecipe> {
         return true;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('naturesaura:infused_stone')"))
+    @MethodDescription( example = @Example("item('naturesaura:infused_stone')"))
     public boolean removeByInput(IIngredient input) {
         return NaturesAuraAPI.TREE_RITUAL_RECIPES.entrySet().removeIf(r -> {
             for (var ingredient : r.getValue().ingredients) {
@@ -83,7 +83,7 @@ public class Ritual extends VirtualizedRegistry<TreeRitualRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('naturesaura:eye')"))
+    @MethodDescription( example = @Example("item('naturesaura:eye')"))
     public boolean removeByOutput(IIngredient output) {
         return NaturesAuraAPI.TREE_RITUAL_RECIPES.entrySet().removeIf(r -> {
             if (output.test(r.getValue().result)) {
@@ -94,13 +94,13 @@ public class Ritual extends VirtualizedRegistry<TreeRitualRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         NaturesAuraAPI.TREE_RITUAL_RECIPES.values().forEach(this::addBackup);
         NaturesAuraAPI.TREE_RITUAL_RECIPES.entrySet().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<Map.Entry<ResourceLocation, TreeRitualRecipe>> streamRecipes() {
         return new SimpleObjectStream<>(NaturesAuraAPI.TREE_RITUAL_RECIPES.entrySet()).setRemover(x -> remove(x.getValue()));
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/naturesaura/Ritual.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/naturesaura/Ritual.java
@@ -131,6 +131,7 @@ public class Ritual extends VirtualizedRegistry<TreeRitualRecipe> {
             return "Error adding Nature's Aura Ritual Recipe";
         }
 
+        @Override
         public String getRecipeNamePrefix() {
             return "groovyscript_ritual_";
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/naturesaura/Ritual.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/naturesaura/Ritual.java
@@ -149,7 +149,7 @@ public class Ritual extends VirtualizedRegistry<TreeRitualRecipe> {
         @RecipeBuilderRegistrationMethod
         public @Nullable TreeRitualRecipe register() {
             if (!validate()) return null;
-            TreeRitualRecipe recipe = new TreeRitualRecipe(name, sapling.toMcIngredient(), output.get(0), time, input.stream().map(IIngredient::toMcIngredient).toArray(Ingredient[]::new));
+            TreeRitualRecipe recipe = new TreeRitualRecipe(super.name, sapling.toMcIngredient(), output.get(0), time, input.stream().map(IIngredient::toMcIngredient).toArray(Ingredient[]::new));
             ModSupport.NATURES_AURA.get().ritual.add(recipe);
             return recipe;
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/naturesaura/Spawning.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/naturesaura/Spawning.java
@@ -143,6 +143,7 @@ public class Spawning extends VirtualizedRegistry<AnimalSpawnerRecipe> {
             return "Error adding Nature's Aura Spawning Recipe";
         }
 
+        @Override
         public String getRecipeNamePrefix() {
             return "groovyscript_spawning_";
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/naturesaura/Spawning.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/naturesaura/Spawning.java
@@ -55,7 +55,7 @@ public class Spawning extends VirtualizedRegistry<AnimalSpawnerRecipe> {
         return true;
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:bone')"))
+    @MethodDescription(example = @Example("item('minecraft:bone')"))
     public boolean removeByInput(IIngredient input) {
         return NaturesAuraAPI.ANIMAL_SPAWNER_RECIPES.entrySet().removeIf(r -> {
             for (var ingredient : r.getValue().ingredients) {
@@ -92,13 +92,13 @@ public class Spawning extends VirtualizedRegistry<AnimalSpawnerRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         NaturesAuraAPI.ANIMAL_SPAWNER_RECIPES.values().forEach(this::addBackup);
         NaturesAuraAPI.ANIMAL_SPAWNER_RECIPES.entrySet().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<Map.Entry<ResourceLocation, AnimalSpawnerRecipe>> streamRecipes() {
         return new SimpleObjectStream<>(NaturesAuraAPI.ANIMAL_SPAWNER_RECIPES.entrySet()).setRemover(x -> remove(x.getValue()));
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/naturesaura/Spawning.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/naturesaura/Spawning.java
@@ -160,7 +160,7 @@ public class Spawning extends VirtualizedRegistry<AnimalSpawnerRecipe> {
         @RecipeBuilderRegistrationMethod
         public @Nullable AnimalSpawnerRecipe register() {
             if (!validate()) return null;
-            AnimalSpawnerRecipe recipe = new AnimalSpawnerRecipe(name, entity, aura, time, input.stream().map(IIngredient::toMcIngredient).toArray(Ingredient[]::new));
+            AnimalSpawnerRecipe recipe = new AnimalSpawnerRecipe(super.name, entity, aura, time, input.stream().map(IIngredient::toMcIngredient).toArray(Ingredient[]::new));
             ModSupport.NATURES_AURA.get().spawning.add(recipe);
             return recipe;
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/pyrotech/Anvil.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/pyrotech/Anvil.java
@@ -136,8 +136,8 @@ public class Anvil extends ForgeRegistryWrapper<AnvilRecipe> {
             msg.add(hits < 0, "duration must be a non negative integer, yet it was {}", hits);
             msg.add(type == null, "type cannot be null. ");
             msg.add(tier == null, "tier cannot be null.");
-            msg.add(name == null, "name cannot be null.");
-            msg.add(ModuleTechBasic.Registries.ANVIL_RECIPE.getValue(name) != null, "tried to register {}, but it already exists.", name);
+            msg.add(super.name == null, "name cannot be null.");
+            msg.add(ModuleTechBasic.Registries.ANVIL_RECIPE.getValue(super.name) != null, "tried to register {}, but it already exists.", super.name);
         }
 
         @Override
@@ -145,7 +145,7 @@ public class Anvil extends ForgeRegistryWrapper<AnvilRecipe> {
         public @Nullable AnvilRecipe register() {
             if (!validate()) return null;
 
-            AnvilRecipe recipe = new AnvilRecipe(output.get(0), input.get(0).toMcIngredient(), hits, type, tier).setRegistryName(name);
+            AnvilRecipe recipe = new AnvilRecipe(output.get(0), input.get(0).toMcIngredient(), hits, type, tier).setRegistryName(super.name);
             PyroTech.anvil.add(recipe);
             return recipe;
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/pyrotech/Barrel.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/pyrotech/Barrel.java
@@ -77,8 +77,8 @@ public class Barrel extends ForgeRegistryWrapper<BarrelRecipe> {
             validateItems(msg, 4, 4, 0, 0);
             validateFluids(msg, 1, 1, 1, 1);
             msg.add(duration < 0, "duration must be a non negative integer, yet it was {}", duration);
-            msg.add(name == null, "name cannot be null.");
-            msg.add(ModuleTechBasic.Registries.BARREL_RECIPE.getValue(name) != null, "tried to register {}, but it already exists.", name);
+            msg.add(super.name == null, "name cannot be null.");
+            msg.add(ModuleTechBasic.Registries.BARREL_RECIPE.getValue(super.name) != null, "tried to register {}, but it already exists.", super.name);
         }
 
         @RecipeBuilderRegistrationMethod
@@ -89,7 +89,7 @@ public class Barrel extends ForgeRegistryWrapper<BarrelRecipe> {
             // Because you need Ingredient[] to register a recipe
             Ingredient[] inputIngredient = input.stream().map(IIngredient::toMcIngredient).toArray(Ingredient[]::new);
 
-            BarrelRecipe recipe = new BarrelRecipe(fluidOutput.get(0), inputIngredient, fluidInput.get(0), duration).setRegistryName(name);
+            BarrelRecipe recipe = new BarrelRecipe(fluidOutput.get(0), inputIngredient, fluidInput.get(0), duration).setRegistryName(super.name);
             PyroTech.barrel.add(recipe);
 
             return recipe;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/pyrotech/Campfire.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/pyrotech/Campfire.java
@@ -86,15 +86,15 @@ public class Campfire extends ForgeRegistryWrapper<CampfireRecipe> {
         public void validate(GroovyLog.Msg msg) {
             validateItems(msg, 1, 1, 1, 1);
             msg.add(duration < 0, "duration must be a non negative integer, yet it was {}", duration);
-            msg.add(name == null, "name cannot be null.");
-            msg.add(ModuleTechBasic.Registries.CAMPFIRE_RECIPE.getValue(name) != null, "tried to register {}, but it already exists.", name);
+            msg.add(super.name == null, "name cannot be null.");
+            msg.add(ModuleTechBasic.Registries.CAMPFIRE_RECIPE.getValue(super.name) != null, "tried to register {}, but it already exists.", super.name);
         }
 
         @RecipeBuilderRegistrationMethod
         @Override
         public @Nullable CampfireRecipe register() {
             if (!validate()) return null;
-            CampfireRecipe recipe = new CampfireRecipe(output.get(0), input.get(0).toMcIngredient(), duration).setRegistryName(name);
+            CampfireRecipe recipe = new CampfireRecipe(output.get(0), input.get(0).toMcIngredient(), duration).setRegistryName(super.name);
             PyroTech.campfire.add(recipe);
             return recipe;
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/pyrotech/ChoppingBlock.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/pyrotech/ChoppingBlock.java
@@ -81,15 +81,15 @@ public class ChoppingBlock extends ForgeRegistryWrapper<ChoppingBlockRecipe> {
         public void validate(GroovyLog.Msg msg) {
             validateItems(msg, 1, 1, 1, 1);
             msg.add(quantities.isEmpty(), "cops and quantities must be a non negative integer, yet it was {}", quantities.size());
-            msg.add(name == null, "name cannot be null.");
-            msg.add(ModuleTechBasic.Registries.CHOPPING_BLOCK_RECIPE.getValue(name) != null, "tried to register {}, but it already exists.", name);
+            msg.add(super.name == null, "name cannot be null.");
+            msg.add(ModuleTechBasic.Registries.CHOPPING_BLOCK_RECIPE.getValue(super.name) != null, "tried to register {}, but it already exists.", super.name);
         }
 
         @RecipeBuilderRegistrationMethod
         @Override
         public @Nullable ChoppingBlockRecipe register() {
             if (!validate()) return null;
-            ChoppingBlockRecipe recipe = new ChoppingBlockRecipe(output.get(0), input.get(0).toMcIngredient(), chops.toIntArray(), quantities.toIntArray()).setRegistryName(name);
+            ChoppingBlockRecipe recipe = new ChoppingBlockRecipe(output.get(0), input.get(0).toMcIngredient(), chops.toIntArray(), quantities.toIntArray()).setRegistryName(super.name);
             PyroTech.choppingBlock.add(recipe);
             return recipe;
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/pyrotech/CompactingBin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/pyrotech/CompactingBin.java
@@ -87,15 +87,15 @@ public class CompactingBin extends ForgeRegistryWrapper<CompactingBinRecipe> {
         public void validate(GroovyLog.Msg msg) {
             validateItems(msg, 1, 1, 1, 1);
             msg.add(toolUses < 0, "toolUses must be a non negative integer, yet it was {}", toolUses);
-            msg.add(name == null, "name cannot be null.");
-            msg.add(ModuleTechBasic.Registries.COMPACTING_BIN_RECIPE.getValue(name) != null, "tried to register {}, but it already exists.", name);
+            msg.add(super.name == null, "name cannot be null.");
+            msg.add(ModuleTechBasic.Registries.COMPACTING_BIN_RECIPE.getValue(super.name) != null, "tried to register {}, but it already exists.", super.name);
         }
 
         @RecipeBuilderRegistrationMethod
         @Override
         public @Nullable CompactingBinRecipe register() {
             if (!validate()) return null;
-            CompactingBinRecipe recipe = new CompactingBinRecipe(output.get(0), input.get(0).toMcIngredient(), toolUses).setRegistryName(name);
+            CompactingBinRecipe recipe = new CompactingBinRecipe(output.get(0), input.get(0).toMcIngredient(), toolUses).setRegistryName(super.name);
             PyroTech.compactingBin.add(recipe);
             return recipe;
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/pyrotech/CompostBin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/pyrotech/CompostBin.java
@@ -88,8 +88,8 @@ public class CompostBin extends ForgeRegistryWrapper<CompostBinRecipe> {
         public void validate(GroovyLog.Msg msg) {
             validateItems(msg, 1, 1, 1, 1);
             msg.add(compostValue < 0, "compostValue must be a non negative integer, yet it was {}", compostValue);
-            msg.add(name == null, "name cannot be null.");
-            msg.add(ModuleTechBasic.Registries.COMPACTING_BIN_RECIPE.getValue(name) != null, "tried to register {}, but it already exists.", name);
+            msg.add(super.name == null, "name cannot be null.");
+            msg.add(ModuleTechBasic.Registries.COMPACTING_BIN_RECIPE.getValue(super.name) != null, "tried to register {}, but it already exists.", super.name);
         }
 
         @RecipeBuilderRegistrationMethod
@@ -100,13 +100,13 @@ public class CompostBin extends ForgeRegistryWrapper<CompostBinRecipe> {
             if (in.length > 1) {
                 int j = 1;
                 for (ItemStack i : in) {
-                    ResourceLocation rl = new ResourceLocation(name.getNamespace(), name.getPath() + "_" + (j++));
+                    ResourceLocation rl = new ResourceLocation(super.name.getNamespace(), super.name.getPath() + "_" + (j++));
                     CompostBinRecipe recipe = new CompostBinRecipe(output.get(0), i, compostValue).setRegistryName(rl);
                     PyroTech.compostBin.add(recipe);
                 }
                 return null;
             }
-            CompostBinRecipe recipe = new CompostBinRecipe(output.get(0), in[0], compostValue).setRegistryName(name);
+            CompostBinRecipe recipe = new CompostBinRecipe(output.get(0), in[0], compostValue).setRegistryName(super.name);
             PyroTech.compostBin.add(recipe);
             return recipe;
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/pyrotech/CrudeDryingRack.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/pyrotech/CrudeDryingRack.java
@@ -87,15 +87,15 @@ public class CrudeDryingRack extends ForgeRegistryWrapper<CrudeDryingRackRecipe>
         public void validate(GroovyLog.Msg msg) {
             validateItems(msg, 1, 1, 1, 1);
             msg.add(dryTime < 0, "dryTime must be a non negative integer, yet it was {}", dryTime);
-            msg.add(name == null, "name cannot be null.");
-            msg.add(ModuleTechBasic.Registries.CRUDE_DRYING_RACK_RECIPE.getValue(name) != null, "tried to register {}, but it already exists.", name);
+            msg.add(super.name == null, "name cannot be null.");
+            msg.add(ModuleTechBasic.Registries.CRUDE_DRYING_RACK_RECIPE.getValue(super.name) != null, "tried to register {}, but it already exists.", super.name);
         }
 
         @RecipeBuilderRegistrationMethod
         @Override
         public @Nullable CrudeDryingRackRecipe register() {
             if (!validate()) return null;
-            CrudeDryingRackRecipe recipe = new CrudeDryingRackRecipe(output.get(0), input.get(0).toMcIngredient(), dryTime).setRegistryName(name);
+            CrudeDryingRackRecipe recipe = new CrudeDryingRackRecipe(output.get(0), input.get(0).toMcIngredient(), dryTime).setRegistryName(super.name);
             PyroTech.crudeDryingRack.add(recipe);
             return recipe;
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/pyrotech/DryingRack.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/pyrotech/DryingRack.java
@@ -87,15 +87,15 @@ public class DryingRack extends ForgeRegistryWrapper<DryingRackRecipe> {
         public void validate(GroovyLog.Msg msg) {
             validateItems(msg, 1, 1, 1, 1);
             msg.add(dryTime < 0, "dryTime must be a non negative integer, yet it was {}", dryTime);
-            msg.add(name == null, "name cannot be null.");
-            msg.add(ModuleTechBasic.Registries.DRYING_RACK_RECIPE.getValue(name) != null, "tried to register {}, but it already exists.", name);
+            msg.add(super.name == null, "name cannot be null.");
+            msg.add(ModuleTechBasic.Registries.DRYING_RACK_RECIPE.getValue(super.name) != null, "tried to register {}, but it already exists.", super.name);
         }
 
         @RecipeBuilderRegistrationMethod
         @Override
         public @Nullable DryingRackRecipe register() {
             if (!validate()) return null;
-            DryingRackRecipe recipe = new DryingRackRecipe(output.get(0), input.get(0).toMcIngredient(), dryTime).setRegistryName(name);
+            DryingRackRecipe recipe = new DryingRackRecipe(output.get(0), input.get(0).toMcIngredient(), dryTime).setRegistryName(super.name);
             PyroTech.dryingRack.add(recipe);
             return recipe;
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/pyrotech/Kiln.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/pyrotech/Kiln.java
@@ -122,15 +122,15 @@ public class Kiln extends ForgeRegistryWrapper<KilnPitRecipe> {
             validateCustom(msg, failureOutput, 1, 100, "failure output");
             msg.add(burnTime < 0, "burnTime must be a non negative integer, yet it was {}", burnTime);
             msg.add(failureChance < 0, "failureChance must be a non negative float, yet it was {}", failureChance);
-            msg.add(name == null, "name cannot be null.");
-            msg.add(ModuleTechBasic.Registries.KILN_PIT_RECIPE.getValue(name) != null, "tried to register {}, but it already exists.", name);
+            msg.add(super.name == null, "name cannot be null.");
+            msg.add(ModuleTechBasic.Registries.KILN_PIT_RECIPE.getValue(super.name) != null, "tried to register {}, but it already exists.", super.name);
         }
 
         @RecipeBuilderRegistrationMethod
         @Override
         public @Nullable KilnPitRecipe register() {
             if (!validate()) return null;
-            KilnPitRecipe recipe = new KilnPitRecipe(output.get(0), input.get(0).toMcIngredient(), burnTime, failureChance, failureOutput.toArray(new ItemStack[0])).setRegistryName(name);
+            KilnPitRecipe recipe = new KilnPitRecipe(output.get(0), input.get(0).toMcIngredient(), burnTime, failureChance, failureOutput.toArray(new ItemStack[0])).setRegistryName(super.name);
             PyroTech.kiln.add(recipe);
             return recipe;
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/pyrotech/SoakingPot.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/pyrotech/SoakingPot.java
@@ -98,14 +98,14 @@ public class SoakingPot extends ForgeRegistryWrapper<SoakingPotRecipe> {
         public void validate(GroovyLog.Msg msg) {
             validateItems(msg, 1, 1, 1, 1);
             validateFluids(msg, 1, 1, 0, 0);
-            msg.add(name == null, "name cannot be null.");
-            msg.add(ModuleTechBasic.Registries.SOAKING_POT_RECIPE.getValue(name) != null, "tried to register {}, but it already exists.", name);
+            msg.add(super.name == null, "name cannot be null.");
+            msg.add(ModuleTechBasic.Registries.SOAKING_POT_RECIPE.getValue(super.name) != null, "tried to register {}, but it already exists.", super.name);
         }
 
         @Override
         public @Nullable SoakingPotRecipe register() {
             if (!validate()) return null;
-            SoakingPotRecipe recipe = new SoakingPotRecipe(output.get(0), input.get(0).toMcIngredient(), fluidInput.get(0), campfireRequired, time).setRegistryName(name);
+            SoakingPotRecipe recipe = new SoakingPotRecipe(output.get(0), input.get(0).toMcIngredient(), fluidInput.get(0), campfireRequired, time).setRegistryName(super.name);
             PyroTech.soakingPot.add(recipe);
             return recipe;
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/pyrotech/TanningRack.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/pyrotech/TanningRack.java
@@ -96,8 +96,8 @@ public class TanningRack extends ForgeRegistryWrapper<TanningRackRecipe> {
         public void validate(GroovyLog.Msg msg) {
             validateItems(msg, 1, 1, 1, 1);
             msg.add(dryTime < 0, "dryTime must be a non negative integer, yet it was {}", dryTime);
-            msg.add(name == null, "name cannot be null.");
-            msg.add(ModuleTechBasic.Registries.TANNING_RACK_RECIPE.getValue(name) != null, "tried to register {}, but it already exists.", name);
+            msg.add(super.name == null, "name cannot be null.");
+            msg.add(ModuleTechBasic.Registries.TANNING_RACK_RECIPE.getValue(super.name) != null, "tried to register {}, but it already exists.", super.name);
         }
 
         @RecipeBuilderRegistrationMethod
@@ -105,7 +105,7 @@ public class TanningRack extends ForgeRegistryWrapper<TanningRackRecipe> {
         @Override
         public @Nullable TanningRackRecipe register() {
             if (!validate()) return null;
-            TanningRackRecipe recipe = new TanningRackRecipe(output.get(0), input.get(0).toMcIngredient(), failureItem, dryTime).setRegistryName(name);
+            TanningRackRecipe recipe = new TanningRackRecipe(output.get(0), input.get(0).toMcIngredient(), failureItem, dryTime).setRegistryName(super.name);
             PyroTech.tanningRack.add(recipe);
             return recipe;
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/AnimalHarvest.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/AnimalHarvest.java
@@ -118,8 +118,8 @@ public class AnimalHarvest extends VirtualizedRegistry<Pair<ResourceLocation, An
         @RecipeBuilderRegistrationMethod
         public @Nullable AnimalHarvestRecipe register() {
             if (!validate()) return null;
-            AnimalHarvestRecipe recipe = new AnimalHarvestRecipe(name, entity);
-            ModSupport.ROOTS.get().animalHarvest.add(name, recipe);
+            AnimalHarvestRecipe recipe = new AnimalHarvestRecipe(super.name, entity);
+            ModSupport.ROOTS.get().animalHarvest.add(super.name, recipe);
             return recipe;
         }
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/AnimalHarvest.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/AnimalHarvest.java
@@ -101,6 +101,7 @@ public class AnimalHarvest extends VirtualizedRegistry<Pair<ResourceLocation, An
             return "Error adding Roots Animal Harvest recipe";
         }
 
+        @Override
         public String getRecipeNamePrefix() {
             return "groovyscript_animal_harvest_";
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/AnimalHarvest.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/AnimalHarvest.java
@@ -11,13 +11,12 @@ import epicsquid.roots.recipe.AnimalHarvestRecipe;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.common.registry.EntityEntry;
-import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
 
 @RegistryDescription
-public class AnimalHarvest extends VirtualizedRegistry<Pair<ResourceLocation, AnimalHarvestRecipe>> {
+public class AnimalHarvest extends VirtualizedRegistry<AnimalHarvestRecipe> {
 
     @RecipeBuilderDescription(example = {
             @Example(".name('wither_skeleton_harvest').entity(entity('minecraft:wither_skeleton'))"),
@@ -29,8 +28,8 @@ public class AnimalHarvest extends VirtualizedRegistry<Pair<ResourceLocation, An
 
     @Override
     public void onReload() {
-        removeScripted().forEach(pair -> ModRecipes.removeAnimalHarvestRecipe(pair.getKey()));
-        restoreFromBackup().forEach(pair -> ModRecipes.getAnimalHarvestRecipes().put(pair.getKey(), pair.getValue()));
+        removeScripted().forEach(recipe -> ModRecipes.removeAnimalHarvestRecipe(recipe.getRegistryName()));
+        restoreFromBackup().forEach(recipe -> ModRecipes.getAnimalHarvestRecipes().put(recipe.getRegistryName(), recipe));
     }
 
     public void add(AnimalHarvestRecipe recipe) {
@@ -39,7 +38,7 @@ public class AnimalHarvest extends VirtualizedRegistry<Pair<ResourceLocation, An
 
     public void add(ResourceLocation name, AnimalHarvestRecipe recipe) {
         ModRecipes.getAnimalHarvestRecipes().put(name, recipe);
-        addScripted(Pair.of(name, recipe));
+        addScripted(recipe);
     }
 
     public ResourceLocation findRecipe(AnimalHarvestRecipe recipe) {
@@ -54,7 +53,7 @@ public class AnimalHarvest extends VirtualizedRegistry<Pair<ResourceLocation, An
         AnimalHarvestRecipe recipe = ModRecipes.getAnimalHarvestRecipes().get(name);
         if (recipe == null) return false;
         ModRecipes.removeAnimalHarvestRecipe(name);
-        addBackup(Pair.of(name, recipe));
+        addBackup(recipe);
         return true;
     }
 
@@ -63,7 +62,7 @@ public class AnimalHarvest extends VirtualizedRegistry<Pair<ResourceLocation, An
         for (Map.Entry<ResourceLocation, AnimalHarvestRecipe> x : ModRecipes.getAnimalHarvestRecipes().entrySet()) {
             if (x.getValue().matches(entity.getEntityClass())) {
                 ModRecipes.getAnimalHarvestRecipes().remove(x.getKey());
-                addBackup(Pair.of(x.getKey(), x.getValue()));
+                addBackup(x.getValue());
                 return true;
             }
         }
@@ -72,7 +71,7 @@ public class AnimalHarvest extends VirtualizedRegistry<Pair<ResourceLocation, An
 
     @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
-        ModRecipes.getAnimalHarvestRecipes().forEach((key, value) -> addBackup(Pair.of(key, value)));
+        ModRecipes.getAnimalHarvestRecipes().values().forEach(this::addBackup);
         ModRecipes.getAnimalHarvestRecipes().clear();
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/AnimalHarvest.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/AnimalHarvest.java
@@ -6,6 +6,7 @@ import com.cleanroommc.groovyscript.compat.mods.ModSupport;
 import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
 import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import epicsquid.roots.init.ModRecipes;
 import epicsquid.roots.recipe.AnimalHarvestRecipe;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.util.ResourceLocation;
@@ -14,9 +15,6 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
-
-import static epicsquid.roots.init.ModRecipes.getAnimalHarvestRecipes;
-import static epicsquid.roots.init.ModRecipes.removeAnimalHarvestRecipe;
 
 @RegistryDescription
 public class AnimalHarvest extends VirtualizedRegistry<Pair<ResourceLocation, AnimalHarvestRecipe>> {
@@ -31,8 +29,8 @@ public class AnimalHarvest extends VirtualizedRegistry<Pair<ResourceLocation, An
 
     @Override
     public void onReload() {
-        removeScripted().forEach(pair -> removeAnimalHarvestRecipe(pair.getKey()));
-        restoreFromBackup().forEach(pair -> getAnimalHarvestRecipes().put(pair.getKey(), pair.getValue()));
+        removeScripted().forEach(pair -> ModRecipes.removeAnimalHarvestRecipe(pair.getKey()));
+        restoreFromBackup().forEach(pair -> ModRecipes.getAnimalHarvestRecipes().put(pair.getKey(), pair.getValue()));
     }
 
     public void add(AnimalHarvestRecipe recipe) {
@@ -40,12 +38,12 @@ public class AnimalHarvest extends VirtualizedRegistry<Pair<ResourceLocation, An
     }
 
     public void add(ResourceLocation name, AnimalHarvestRecipe recipe) {
-        getAnimalHarvestRecipes().put(name, recipe);
+        ModRecipes.getAnimalHarvestRecipes().put(name, recipe);
         addScripted(Pair.of(name, recipe));
     }
 
     public ResourceLocation findRecipe(AnimalHarvestRecipe recipe) {
-        for (Map.Entry<ResourceLocation, AnimalHarvestRecipe> entry : getAnimalHarvestRecipes().entrySet()) {
+        for (Map.Entry<ResourceLocation, AnimalHarvestRecipe> entry : ModRecipes.getAnimalHarvestRecipes().entrySet()) {
             if (entry.getValue().matches(recipe.getHarvestClass())) return entry.getKey();
         }
         return null;
@@ -53,18 +51,18 @@ public class AnimalHarvest extends VirtualizedRegistry<Pair<ResourceLocation, An
 
     @MethodDescription(example = @Example("resource('roots:chicken')"))
     public boolean removeByName(ResourceLocation name) {
-        AnimalHarvestRecipe recipe = getAnimalHarvestRecipes().get(name);
+        AnimalHarvestRecipe recipe = ModRecipes.getAnimalHarvestRecipes().get(name);
         if (recipe == null) return false;
-        removeAnimalHarvestRecipe(name);
+        ModRecipes.removeAnimalHarvestRecipe(name);
         addBackup(Pair.of(name, recipe));
         return true;
     }
 
     @MethodDescription(example = @Example("entity('minecraft:pig')"))
     public boolean removeByEntity(EntityEntry entity) {
-        for (Map.Entry<ResourceLocation, AnimalHarvestRecipe> x : getAnimalHarvestRecipes().entrySet()) {
+        for (Map.Entry<ResourceLocation, AnimalHarvestRecipe> x : ModRecipes.getAnimalHarvestRecipes().entrySet()) {
             if (x.getValue().matches(entity.getEntityClass())) {
-                getAnimalHarvestRecipes().remove(x.getKey());
+                ModRecipes.getAnimalHarvestRecipes().remove(x.getKey());
                 addBackup(Pair.of(x.getKey(), x.getValue()));
                 return true;
             }
@@ -74,13 +72,13 @@ public class AnimalHarvest extends VirtualizedRegistry<Pair<ResourceLocation, An
 
     @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
-        getAnimalHarvestRecipes().forEach((key, value) -> addBackup(Pair.of(key, value)));
-        getAnimalHarvestRecipes().clear();
+        ModRecipes.getAnimalHarvestRecipes().forEach((key, value) -> addBackup(Pair.of(key, value)));
+        ModRecipes.getAnimalHarvestRecipes().clear();
     }
 
     @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<Map.Entry<ResourceLocation, AnimalHarvestRecipe>> streamRecipes() {
-        return new SimpleObjectStream<>(getAnimalHarvestRecipes().entrySet())
+        return new SimpleObjectStream<>(ModRecipes.getAnimalHarvestRecipes().entrySet())
                 .setRemover(r -> this.removeByName(r.getKey()));
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/AnimalHarvestFish.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/AnimalHarvestFish.java
@@ -6,6 +6,7 @@ import com.cleanroommc.groovyscript.compat.mods.ModSupport;
 import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
 import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import epicsquid.roots.init.ModRecipes;
 import epicsquid.roots.recipe.AnimalHarvestFishRecipe;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
@@ -13,9 +14,6 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
-
-import static epicsquid.roots.init.ModRecipes.getAnimalHarvestFishRecipes;
-import static epicsquid.roots.init.ModRecipes.removeAnimalHarvestFishRecipe;
 
 @RegistryDescription
 public class AnimalHarvestFish extends VirtualizedRegistry<Pair<ResourceLocation, AnimalHarvestFishRecipe>> {
@@ -30,8 +28,8 @@ public class AnimalHarvestFish extends VirtualizedRegistry<Pair<ResourceLocation
 
     @Override
     public void onReload() {
-        removeScripted().forEach(pair -> removeAnimalHarvestFishRecipe(pair.getKey()));
-        restoreFromBackup().forEach(pair -> getAnimalHarvestFishRecipes().put(pair.getKey(), pair.getValue()));
+        removeScripted().forEach(pair -> ModRecipes.removeAnimalHarvestFishRecipe(pair.getKey()));
+        restoreFromBackup().forEach(pair -> ModRecipes.getAnimalHarvestFishRecipes().put(pair.getKey(), pair.getValue()));
     }
 
     public void add(AnimalHarvestFishRecipe recipe) {
@@ -39,12 +37,12 @@ public class AnimalHarvestFish extends VirtualizedRegistry<Pair<ResourceLocation
     }
 
     public void add(ResourceLocation name, AnimalHarvestFishRecipe recipe) {
-        getAnimalHarvestFishRecipes().put(name, recipe);
+        ModRecipes.getAnimalHarvestFishRecipes().put(name, recipe);
         addScripted(Pair.of(name, recipe));
     }
 
     public ResourceLocation findRecipeByOutput(ItemStack output) {
-        for (Map.Entry<ResourceLocation, AnimalHarvestFishRecipe> entry : getAnimalHarvestFishRecipes().entrySet()) {
+        for (Map.Entry<ResourceLocation, AnimalHarvestFishRecipe> entry : ModRecipes.getAnimalHarvestFishRecipes().entrySet()) {
             if (ItemStack.areItemsEqual(entry.getValue().getItemStack(), output)) return entry.getKey();
         }
         return null;
@@ -52,18 +50,18 @@ public class AnimalHarvestFish extends VirtualizedRegistry<Pair<ResourceLocation
 
     @MethodDescription(example = @Example("resource('roots:cod')"))
     public boolean removeByName(ResourceLocation name) {
-        AnimalHarvestFishRecipe recipe = getAnimalHarvestFishRecipes().get(name);
+        AnimalHarvestFishRecipe recipe = ModRecipes.getAnimalHarvestFishRecipes().get(name);
         if (recipe == null) return false;
-        removeAnimalHarvestFishRecipe(name);
+        ModRecipes.removeAnimalHarvestFishRecipe(name);
         addBackup(Pair.of(name, recipe));
         return true;
     }
 
     @MethodDescription(example = @Example("item('minecraft:fish:1')"))
     public boolean removeByOutput(ItemStack output) {
-        for (Map.Entry<ResourceLocation, AnimalHarvestFishRecipe> x : getAnimalHarvestFishRecipes().entrySet()) {
+        for (Map.Entry<ResourceLocation, AnimalHarvestFishRecipe> x : ModRecipes.getAnimalHarvestFishRecipes().entrySet()) {
             if (ItemStack.areItemsEqual(x.getValue().getItemStack(), output)) {
-                getAnimalHarvestFishRecipes().remove(x.getKey());
+                ModRecipes.getAnimalHarvestFishRecipes().remove(x.getKey());
                 addBackup(Pair.of(x.getKey(), x.getValue()));
                 return true;
             }
@@ -78,13 +76,13 @@ public class AnimalHarvestFish extends VirtualizedRegistry<Pair<ResourceLocation
 
     @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
-        getAnimalHarvestFishRecipes().forEach((key, value) -> addBackup(Pair.of(key, value)));
-        getAnimalHarvestFishRecipes().clear();
+        ModRecipes.getAnimalHarvestFishRecipes().forEach((key, value) -> addBackup(Pair.of(key, value)));
+        ModRecipes.getAnimalHarvestFishRecipes().clear();
     }
 
     @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<Map.Entry<ResourceLocation, AnimalHarvestFishRecipe>> streamRecipes() {
-        return new SimpleObjectStream<>(getAnimalHarvestFishRecipes().entrySet())
+        return new SimpleObjectStream<>(ModRecipes.getAnimalHarvestFishRecipes().entrySet())
                 .setRemover(r -> this.removeByName(r.getKey()));
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/AnimalHarvestFish.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/AnimalHarvestFish.java
@@ -129,8 +129,8 @@ public class AnimalHarvestFish extends VirtualizedRegistry<Pair<ResourceLocation
         @RecipeBuilderRegistrationMethod
         public @Nullable AnimalHarvestFishRecipe register() {
             if (!validate()) return null;
-            AnimalHarvestFishRecipe recipe = new AnimalHarvestFishRecipe(name, output.get(0), weight);
-            ModSupport.ROOTS.get().animalHarvestFish.add(name, recipe);
+            AnimalHarvestFishRecipe recipe = new AnimalHarvestFishRecipe(super.name, output.get(0), weight);
+            ModSupport.ROOTS.get().animalHarvestFish.add(super.name, recipe);
             return recipe;
         }
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/AnimalHarvestFish.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/AnimalHarvestFish.java
@@ -112,6 +112,7 @@ public class AnimalHarvestFish extends VirtualizedRegistry<Pair<ResourceLocation
             return "Error adding Roots Animal Harvest Fish recipe";
         }
 
+        @Override
         public String getRecipeNamePrefix() {
             return "groovyscript_animal_harvest_fish_";
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/AnimalHarvestFish.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/AnimalHarvestFish.java
@@ -10,13 +10,12 @@ import epicsquid.roots.init.ModRecipes;
 import epicsquid.roots.recipe.AnimalHarvestFishRecipe;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
-import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
 
 @RegistryDescription
-public class AnimalHarvestFish extends VirtualizedRegistry<Pair<ResourceLocation, AnimalHarvestFishRecipe>> {
+public class AnimalHarvestFish extends VirtualizedRegistry<AnimalHarvestFishRecipe> {
 
     @RecipeBuilderDescription(example = {
             @Example(".name('clay_fish').weight(50).output(item('minecraft:clay'))"),
@@ -28,8 +27,8 @@ public class AnimalHarvestFish extends VirtualizedRegistry<Pair<ResourceLocation
 
     @Override
     public void onReload() {
-        removeScripted().forEach(pair -> ModRecipes.removeAnimalHarvestFishRecipe(pair.getKey()));
-        restoreFromBackup().forEach(pair -> ModRecipes.getAnimalHarvestFishRecipes().put(pair.getKey(), pair.getValue()));
+        removeScripted().forEach(recipe -> ModRecipes.removeAnimalHarvestFishRecipe(recipe.getRegistryName()));
+        restoreFromBackup().forEach(recipe -> ModRecipes.getAnimalHarvestFishRecipes().put(recipe.getRegistryName(), recipe));
     }
 
     public void add(AnimalHarvestFishRecipe recipe) {
@@ -38,7 +37,7 @@ public class AnimalHarvestFish extends VirtualizedRegistry<Pair<ResourceLocation
 
     public void add(ResourceLocation name, AnimalHarvestFishRecipe recipe) {
         ModRecipes.getAnimalHarvestFishRecipes().put(name, recipe);
-        addScripted(Pair.of(name, recipe));
+        addScripted(recipe);
     }
 
     public ResourceLocation findRecipeByOutput(ItemStack output) {
@@ -53,7 +52,7 @@ public class AnimalHarvestFish extends VirtualizedRegistry<Pair<ResourceLocation
         AnimalHarvestFishRecipe recipe = ModRecipes.getAnimalHarvestFishRecipes().get(name);
         if (recipe == null) return false;
         ModRecipes.removeAnimalHarvestFishRecipe(name);
-        addBackup(Pair.of(name, recipe));
+        addBackup(recipe);
         return true;
     }
 
@@ -62,7 +61,7 @@ public class AnimalHarvestFish extends VirtualizedRegistry<Pair<ResourceLocation
         for (Map.Entry<ResourceLocation, AnimalHarvestFishRecipe> x : ModRecipes.getAnimalHarvestFishRecipes().entrySet()) {
             if (ItemStack.areItemsEqual(x.getValue().getItemStack(), output)) {
                 ModRecipes.getAnimalHarvestFishRecipes().remove(x.getKey());
-                addBackup(Pair.of(x.getKey(), x.getValue()));
+                addBackup(x.getValue());
                 return true;
             }
         }
@@ -76,7 +75,7 @@ public class AnimalHarvestFish extends VirtualizedRegistry<Pair<ResourceLocation
 
     @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
-        ModRecipes.getAnimalHarvestFishRecipes().forEach((key, value) -> addBackup(Pair.of(key, value)));
+        ModRecipes.getAnimalHarvestFishRecipes().values().forEach(this::addBackup);
         ModRecipes.getAnimalHarvestFishRecipes().clear();
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/BarkCarving.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/BarkCarving.java
@@ -14,13 +14,12 @@ import net.minecraft.block.BlockPlanks;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
-import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
 
 @RegistryDescription
-public class BarkCarving extends VirtualizedRegistry<Pair<ResourceLocation, BarkRecipe>> {
+public class BarkCarving extends VirtualizedRegistry<BarkRecipe> {
 
     public BarkCarving() {
         super(Alias.generateOfClassAnd(BarkCarving.class, "Bark"));
@@ -37,8 +36,8 @@ public class BarkCarving extends VirtualizedRegistry<Pair<ResourceLocation, Bark
 
     @Override
     public void onReload() {
-        removeScripted().forEach(pair -> ModRecipes.getBarkRecipeMap().remove(pair.getKey()));
-        restoreFromBackup().forEach(pair -> ModRecipes.getBarkRecipeMap().put(pair.getKey(), pair.getValue()));
+        removeScripted().forEach(recipe -> ModRecipes.getBarkRecipeMap().remove(recipe.getName()));
+        restoreFromBackup().forEach(recipe -> ModRecipes.getBarkRecipeMap().put(recipe.getName(), recipe));
     }
 
     public void add(BarkRecipe recipe) {
@@ -47,7 +46,7 @@ public class BarkCarving extends VirtualizedRegistry<Pair<ResourceLocation, Bark
 
     public void add(ResourceLocation name, BarkRecipe recipe) {
         ModRecipes.getBarkRecipeMap().put(name, recipe);
-        addScripted(Pair.of(name, recipe));
+        addScripted(recipe);
     }
 
     public ResourceLocation findRecipe(BarkRecipe recipe) {
@@ -80,7 +79,7 @@ public class BarkCarving extends VirtualizedRegistry<Pair<ResourceLocation, Bark
         BarkRecipe recipe = ModRecipes.getBarkRecipeByName(name);
         if (recipe == null) return false;
         ModRecipes.removeBarkRecipe(recipe.getBlockStack());
-        addBackup(Pair.of(name, recipe));
+        addBackup(recipe);
         return true;
     }
 
@@ -89,7 +88,7 @@ public class BarkCarving extends VirtualizedRegistry<Pair<ResourceLocation, Bark
         for (Map.Entry<ResourceLocation, BarkRecipe> x : ModRecipes.getBarkRecipeMap().entrySet()) {
             if (ItemStack.areItemsEqual(x.getValue().getBlockStack(), input)) {
                 ModRecipes.getBarkRecipeMap().remove(x.getKey());
-                addBackup(Pair.of(x.getKey(), x.getValue()));
+                addBackup(x.getValue());
                 return true;
             }
         }
@@ -106,7 +105,7 @@ public class BarkCarving extends VirtualizedRegistry<Pair<ResourceLocation, Bark
         for (Map.Entry<ResourceLocation, BarkRecipe> x : ModRecipes.getBarkRecipeMap().entrySet()) {
             if (ItemStack.areItemsEqual(x.getValue().getItem(), output)) {
                 ModRecipes.getBarkRecipeMap().remove(x.getKey());
-                addBackup(Pair.of(x.getKey(), x.getValue()));
+                addBackup(x.getValue());
                 return true;
             }
         }
@@ -115,7 +114,7 @@ public class BarkCarving extends VirtualizedRegistry<Pair<ResourceLocation, Bark
 
     @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
-        ModRecipes.getBarkRecipeMap().forEach((key, value) -> addBackup(Pair.of(key, value)));
+        ModRecipes.getBarkRecipeMap().values().forEach(this::addBackup);
         ModRecipes.getBarkRecipeMap().clear();
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/BarkCarving.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/BarkCarving.java
@@ -8,6 +8,7 @@ import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
 import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
 import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import epicsquid.roots.init.ModRecipes;
 import epicsquid.roots.recipe.BarkRecipe;
 import net.minecraft.block.BlockPlanks;
 import net.minecraft.block.state.IBlockState;
@@ -17,8 +18,6 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
-
-import static epicsquid.roots.init.ModRecipes.*;
 
 @RegistryDescription
 public class BarkCarving extends VirtualizedRegistry<Pair<ResourceLocation, BarkRecipe>> {
@@ -38,8 +37,8 @@ public class BarkCarving extends VirtualizedRegistry<Pair<ResourceLocation, Bark
 
     @Override
     public void onReload() {
-        removeScripted().forEach(pair -> getBarkRecipeMap().remove(pair.getKey()));
-        restoreFromBackup().forEach(pair -> getBarkRecipeMap().put(pair.getKey(), pair.getValue()));
+        removeScripted().forEach(pair -> ModRecipes.getBarkRecipeMap().remove(pair.getKey()));
+        restoreFromBackup().forEach(pair -> ModRecipes.getBarkRecipeMap().put(pair.getKey(), pair.getValue()));
     }
 
     public void add(BarkRecipe recipe) {
@@ -47,30 +46,30 @@ public class BarkCarving extends VirtualizedRegistry<Pair<ResourceLocation, Bark
     }
 
     public void add(ResourceLocation name, BarkRecipe recipe) {
-        getBarkRecipeMap().put(name, recipe);
+        ModRecipes.getBarkRecipeMap().put(name, recipe);
         addScripted(Pair.of(name, recipe));
     }
 
     public ResourceLocation findRecipe(BarkRecipe recipe) {
-        return getBarkRecipeByName(recipe.getName()) == null ? null : recipe.getName();
+        return ModRecipes.getBarkRecipeByName(recipe.getName()) == null ? null : recipe.getName();
     }
 
     public ResourceLocation findRecipeByInput(BlockPlanks.EnumType input) {
-        for (BarkRecipe entry : getBarkRecipes()) {
+        for (BarkRecipe entry : ModRecipes.getBarkRecipes()) {
             if (entry.getType() == input) return entry.getName();
         }
         return null;
     }
 
     public ResourceLocation findRecipeByInput(ItemStack input) {
-        for (BarkRecipe entry : getBarkRecipes()) {
+        for (BarkRecipe entry : ModRecipes.getBarkRecipes()) {
             if (ItemStack.areItemsEqual(entry.getBlockStack(), input)) return entry.getName();
         }
         return null;
     }
 
     public ResourceLocation findRecipeByOutput(ItemStack output) {
-        for (BarkRecipe entry : getBarkRecipes()) {
+        for (BarkRecipe entry : ModRecipes.getBarkRecipes()) {
             if (ItemStack.areItemsEqual(entry.getItem(), output)) return entry.getName();
         }
         return null;
@@ -78,18 +77,18 @@ public class BarkCarving extends VirtualizedRegistry<Pair<ResourceLocation, Bark
 
     @MethodDescription(example = @Example("resource('roots:wildwood')"))
     public boolean removeByName(ResourceLocation name) {
-        BarkRecipe recipe = getBarkRecipeByName(name);
+        BarkRecipe recipe = ModRecipes.getBarkRecipeByName(name);
         if (recipe == null) return false;
-        removeBarkRecipe(recipe.getBlockStack());
+        ModRecipes.removeBarkRecipe(recipe.getBlockStack());
         addBackup(Pair.of(name, recipe));
         return true;
     }
 
     @MethodDescription(example = @Example("item('minecraft:log')"))
     public boolean removeByInput(ItemStack input) {
-        for (Map.Entry<ResourceLocation, BarkRecipe> x : getBarkRecipeMap().entrySet()) {
+        for (Map.Entry<ResourceLocation, BarkRecipe> x : ModRecipes.getBarkRecipeMap().entrySet()) {
             if (ItemStack.areItemsEqual(x.getValue().getBlockStack(), input)) {
-                getBarkRecipeMap().remove(x.getKey());
+                ModRecipes.getBarkRecipeMap().remove(x.getKey());
                 addBackup(Pair.of(x.getKey(), x.getValue()));
                 return true;
             }
@@ -104,9 +103,9 @@ public class BarkCarving extends VirtualizedRegistry<Pair<ResourceLocation, Bark
 
     @MethodDescription(example = @Example("item('roots:bark_dark_oak')"))
     public boolean removeByOutput(ItemStack output) {
-        for (Map.Entry<ResourceLocation, BarkRecipe> x : getBarkRecipeMap().entrySet()) {
+        for (Map.Entry<ResourceLocation, BarkRecipe> x : ModRecipes.getBarkRecipeMap().entrySet()) {
             if (ItemStack.areItemsEqual(x.getValue().getItem(), output)) {
-                getBarkRecipeMap().remove(x.getKey());
+                ModRecipes.getBarkRecipeMap().remove(x.getKey());
                 addBackup(Pair.of(x.getKey(), x.getValue()));
                 return true;
             }
@@ -116,13 +115,13 @@ public class BarkCarving extends VirtualizedRegistry<Pair<ResourceLocation, Bark
 
     @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
-        getBarkRecipeMap().forEach((key, value) -> addBackup(Pair.of(key, value)));
-        getBarkRecipeMap().clear();
+        ModRecipes.getBarkRecipeMap().forEach((key, value) -> addBackup(Pair.of(key, value)));
+        ModRecipes.getBarkRecipeMap().clear();
     }
 
     @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<BarkRecipe> streamRecipes() {
-        return new SimpleObjectStream<>(getBarkRecipes())
+        return new SimpleObjectStream<>(ModRecipes.getBarkRecipes())
                 .setRemover(r -> this.removeByName(r.getName()));
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/BarkCarving.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/BarkCarving.java
@@ -164,8 +164,8 @@ public class BarkCarving extends VirtualizedRegistry<Pair<ResourceLocation, Bark
         public @Nullable BarkRecipe register() {
             if (!validate()) return null;
             BarkRecipe recipe;
-            recipe = new BarkRecipe(name, output.get(0), input.get(0).toMcIngredient().getMatchingStacks()[0]);
-            ModSupport.ROOTS.get().barkCarving.add(name, recipe);
+            recipe = new BarkRecipe(super.name, output.get(0), input.get(0).toMcIngredient().getMatchingStacks()[0]);
+            ModSupport.ROOTS.get().barkCarving.add(super.name, recipe);
             return recipe;
         }
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/BarkCarving.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/BarkCarving.java
@@ -147,6 +147,7 @@ public class BarkCarving extends VirtualizedRegistry<Pair<ResourceLocation, Bark
             return "Error adding Roots Bark Carving recipe";
         }
 
+        @Override
         public String getRecipeNamePrefix() {
             return "groovyscript_bark_carving_";
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Chrysopoeia.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Chrysopoeia.java
@@ -132,6 +132,7 @@ public class Chrysopoeia extends VirtualizedRegistry<Pair<ResourceLocation, Chry
             return "Error adding Roots Chrysopoeia conversion recipe";
         }
 
+        @Override
         public String getRecipeNamePrefix() {
             return "groovyscript_chrysopoeia_";
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Chrysopoeia.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Chrysopoeia.java
@@ -12,7 +12,6 @@ import epicsquid.roots.recipe.ChrysopoeiaRecipe;
 import epicsquid.roots.util.IngredientWithStack;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
-import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Chrysopoeia.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Chrysopoeia.java
@@ -18,7 +18,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Map;
 
 @RegistryDescription
-public class Chrysopoeia extends VirtualizedRegistry<Pair<ResourceLocation, ChrysopoeiaRecipe>> {
+public class Chrysopoeia extends VirtualizedRegistry<ChrysopoeiaRecipe> {
 
     @RecipeBuilderDescription(example = {
             @Example(".name('clay_transmute').input(item('minecraft:gold_ingot')).output(item('minecraft:clay'))"),
@@ -30,8 +30,8 @@ public class Chrysopoeia extends VirtualizedRegistry<Pair<ResourceLocation, Chry
 
     @Override
     public void onReload() {
-        removeScripted().forEach(pair -> ModRecipesAccessor.getChrysopoeiaRecipes().remove(pair.getKey()));
-        restoreFromBackup().forEach(pair -> ModRecipesAccessor.getChrysopoeiaRecipes().put(pair.getKey(), pair.getValue()));
+        removeScripted().forEach(recipe -> ModRecipesAccessor.getChrysopoeiaRecipes().remove(recipe.getRegistryName()));
+        restoreFromBackup().forEach(recipe -> ModRecipesAccessor.getChrysopoeiaRecipes().put(recipe.getRegistryName(), recipe));
     }
 
     public void add(ChrysopoeiaRecipe recipe) {
@@ -40,7 +40,7 @@ public class Chrysopoeia extends VirtualizedRegistry<Pair<ResourceLocation, Chry
 
     public void add(ResourceLocation name, ChrysopoeiaRecipe recipe) {
         ModRecipesAccessor.getChrysopoeiaRecipes().put(name, recipe);
-        addScripted(Pair.of(name, recipe));
+        addScripted(recipe);
     }
 
     public ResourceLocation findRecipe(ChrysopoeiaRecipe recipe) {
@@ -62,7 +62,7 @@ public class Chrysopoeia extends VirtualizedRegistry<Pair<ResourceLocation, Chry
         ChrysopoeiaRecipe recipe = ModRecipesAccessor.getChrysopoeiaRecipes().get(name);
         if (recipe == null) return false;
         ModRecipesAccessor.getChrysopoeiaRecipes().remove(name);
-        addBackup(Pair.of(name, recipe));
+        addBackup(recipe);
         return true;
     }
 
@@ -71,7 +71,7 @@ public class Chrysopoeia extends VirtualizedRegistry<Pair<ResourceLocation, Chry
         for (Map.Entry<ResourceLocation, ChrysopoeiaRecipe> entry : ModRecipesAccessor.getChrysopoeiaRecipes().entrySet()) {
             if (ItemStack.areItemsEqual(entry.getValue().getOutput(), output)) {
                 ModRecipesAccessor.getChrysopoeiaRecipes().remove(entry.getKey());
-                addBackup(Pair.of(entry.getKey(), entry.getValue()));
+                addBackup(entry.getValue());
                 return true;
             }
         }
@@ -83,7 +83,7 @@ public class Chrysopoeia extends VirtualizedRegistry<Pair<ResourceLocation, Chry
         for (Map.Entry<ResourceLocation, ChrysopoeiaRecipe> entry : ModRecipesAccessor.getChrysopoeiaRecipes().entrySet()) {
             if (entry.getValue().getIngredient().getIngredient().test(output)) {
                 ModRecipesAccessor.getChrysopoeiaRecipes().remove(entry.getKey());
-                addBackup(Pair.of(entry.getKey(), entry.getValue()));
+                addBackup(entry.getValue());
                 return true;
             }
         }
@@ -92,7 +92,7 @@ public class Chrysopoeia extends VirtualizedRegistry<Pair<ResourceLocation, Chry
 
     @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
-        ModRecipesAccessor.getChrysopoeiaRecipes().forEach((key, value) -> addBackup(Pair.of(key, value)));
+        ModRecipesAccessor.getChrysopoeiaRecipes().values().forEach(this::addBackup);
         ModRecipesAccessor.getChrysopoeiaRecipes().clear();
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Chrysopoeia.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Chrysopoeia.java
@@ -151,8 +151,8 @@ public class Chrysopoeia extends VirtualizedRegistry<Pair<ResourceLocation, Chry
         public @Nullable ChrysopoeiaRecipe register() {
             if (!validate()) return null;
             ChrysopoeiaRecipe recipe = new ChrysopoeiaRecipe(new IngredientWithStack(IngredientHelper.toItemStack(input.get(0))), output.get(0)/*, byproduct, overload, byproductChance*/);
-            recipe.setRegistryName(name);
-            ModSupport.ROOTS.get().chrysopoeia.add(name, recipe);
+            recipe.setRegistryName(super.name);
+            ModSupport.ROOTS.get().chrysopoeia.add(super.name, recipe);
             return recipe;
         }
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/FeyCrafter.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/FeyCrafter.java
@@ -126,7 +126,7 @@ public class FeyCrafter extends VirtualizedRegistry<Pair<ResourceLocation, FeyCr
             if (!validate()) return null;
             FeyCraftingRecipe recipe = new FeyCraftingRecipe(output.get(0), xp);
             input.forEach(i -> recipe.addIngredient(i.toMcIngredient()));
-            ModSupport.ROOTS.get().feyCrafter.add(name, recipe);
+            ModSupport.ROOTS.get().feyCrafter.add(super.name, recipe);
             return recipe;
         }
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/FeyCrafter.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/FeyCrafter.java
@@ -107,6 +107,7 @@ public class FeyCrafter extends VirtualizedRegistry<Pair<ResourceLocation, FeyCr
             return "Error adding Roots Fey Crafter recipe";
         }
 
+        @Override
         public String getRecipeNamePrefix() {
             return "groovyscript_fey_crafter_";
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/FeyCrafter.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/FeyCrafter.java
@@ -6,6 +6,7 @@ import com.cleanroommc.groovyscript.compat.mods.ModSupport;
 import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
 import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import epicsquid.roots.init.ModRecipes;
 import epicsquid.roots.recipe.FeyCraftingRecipe;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
@@ -13,8 +14,6 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
-
-import static epicsquid.roots.init.ModRecipes.*;
 
 @RegistryDescription(
         admonition = @Admonition(value = "groovyscript.wiki.roots.fey_crafter.note", type = Admonition.Type.DANGER, format = Admonition.Format.STANDARD)
@@ -28,8 +27,8 @@ public class FeyCrafter extends VirtualizedRegistry<Pair<ResourceLocation, FeyCr
 
     @Override
     public void onReload() {
-        removeScripted().forEach(pair -> removeFeyCraftingRecipe(pair.getKey()));
-        restoreFromBackup().forEach(pair -> addFeyCraftingRecipe(pair.getKey(), pair.getValue()));
+        removeScripted().forEach(pair -> ModRecipes.removeFeyCraftingRecipe(pair.getKey()));
+        restoreFromBackup().forEach(pair -> ModRecipes.addFeyCraftingRecipe(pair.getKey(), pair.getValue()));
     }
 
     public void add(FeyCraftingRecipe recipe) {
@@ -37,19 +36,19 @@ public class FeyCrafter extends VirtualizedRegistry<Pair<ResourceLocation, FeyCr
     }
 
     public void add(ResourceLocation name, FeyCraftingRecipe recipe) {
-        addFeyCraftingRecipe(name, recipe);
+        ModRecipes.addFeyCraftingRecipe(name, recipe);
         addScripted(Pair.of(name, recipe));
     }
 
     public ResourceLocation findRecipe(FeyCraftingRecipe recipe) {
-        for (Map.Entry<ResourceLocation, FeyCraftingRecipe> entry : getFeyCraftingRecipes().entrySet()) {
+        for (Map.Entry<ResourceLocation, FeyCraftingRecipe> entry : ModRecipes.getFeyCraftingRecipes().entrySet()) {
             if (entry.getValue().matches(recipe.getRecipe())) return entry.getKey();
         }
         return null;
     }
 
     public ResourceLocation findRecipeByOutput(ItemStack output) {
-        for (Map.Entry<ResourceLocation, FeyCraftingRecipe> entry : getFeyCraftingRecipes().entrySet()) {
+        for (Map.Entry<ResourceLocation, FeyCraftingRecipe> entry : ModRecipes.getFeyCraftingRecipes().entrySet()) {
             if (ItemStack.areItemsEqual(entry.getValue().getResult(), output)) return entry.getKey();
         }
         return null;
@@ -57,18 +56,18 @@ public class FeyCrafter extends VirtualizedRegistry<Pair<ResourceLocation, FeyCr
 
     @MethodDescription(example = @Example("resource('roots:unending_bowl')"))
     public boolean removeByName(ResourceLocation name) {
-        FeyCraftingRecipe recipe = getFeyCraftingRecipe(name);
+        FeyCraftingRecipe recipe = ModRecipes.getFeyCraftingRecipe(name);
         if (recipe == null) return false;
-        removeFeyCraftingRecipe(name);
+        ModRecipes.removeFeyCraftingRecipe(name);
         addBackup(Pair.of(name, recipe));
         return true;
     }
 
     @MethodDescription(example = @Example("item('minecraft:gravel')"))
     public boolean removeByOutput(ItemStack output) {
-        for (Map.Entry<ResourceLocation, FeyCraftingRecipe> x : getFeyCraftingRecipes().entrySet()) {
+        for (Map.Entry<ResourceLocation, FeyCraftingRecipe> x : ModRecipes.getFeyCraftingRecipes().entrySet()) {
             if (ItemStack.areItemsEqual(x.getValue().getResult(), output)) {
-                getFeyCraftingRecipes().remove(x.getKey());
+                ModRecipes.getFeyCraftingRecipes().remove(x.getKey());
                 addBackup(Pair.of(x.getKey(), x.getValue()));
                 return true;
             }
@@ -78,13 +77,13 @@ public class FeyCrafter extends VirtualizedRegistry<Pair<ResourceLocation, FeyCr
 
     @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
-        getFeyCraftingRecipes().forEach((key, value) -> addBackup(Pair.of(key, value)));
-        getFeyCraftingRecipes().clear();
+        ModRecipes.getFeyCraftingRecipes().forEach((key, value) -> addBackup(Pair.of(key, value)));
+        ModRecipes.getFeyCraftingRecipes().clear();
     }
 
     @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<Map.Entry<ResourceLocation, FeyCraftingRecipe>> streamRecipes() {
-        return new SimpleObjectStream<>(getFeyCraftingRecipes().entrySet())
+        return new SimpleObjectStream<>(ModRecipes.getFeyCraftingRecipes().entrySet())
                 .setRemover(r -> this.removeByName(r.getKey()));
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/FeyCrafter.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/FeyCrafter.java
@@ -94,7 +94,7 @@ public class FeyCrafter extends VirtualizedRegistry<Pair<ResourceLocation, FeyCr
     public static class RecipeBuilder extends AbstractRecipeBuilder<FeyCraftingRecipe> {
 
         @Property(valid = @Comp(value = "0", type = Comp.Type.GTE))
-        private int xp = 0;
+        private int xp;
 
         @RecipeBuilderMethodDescription
         public RecipeBuilder xp(int xp) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/FlowerGeneration.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/FlowerGeneration.java
@@ -14,7 +14,6 @@ import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.Ingredient;
 import net.minecraft.util.ResourceLocation;
-import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
@@ -24,7 +23,7 @@ import java.util.Map;
 @RegistryDescription(
         category = RegistryDescription.Category.ENTRIES
 )
-public class FlowerGeneration extends VirtualizedRegistry<Pair<ResourceLocation, FlowerRecipe>> {
+public class FlowerGeneration extends VirtualizedRegistry<FlowerRecipe> {
 
     @RecipeBuilderDescription(example = @Example(".name('clay_flower').flower(blockstate('minecraft:clay'))"))
     public static RecipeBuilder recipeBuilder() {
@@ -33,8 +32,8 @@ public class FlowerGeneration extends VirtualizedRegistry<Pair<ResourceLocation,
 
     @Override
     public void onReload() {
-        removeScripted().forEach(pair -> ModRecipes.getFlowerRecipes().remove(pair.getKey()));
-        restoreFromBackup().forEach(pair -> ModRecipes.getFlowerRecipes().put(pair.getKey(), pair.getValue()));
+        removeScripted().forEach(recipe -> ModRecipes.getFlowerRecipes().remove(recipe.getRegistryName()));
+        restoreFromBackup().forEach(recipe -> ModRecipes.getFlowerRecipes().put(recipe.getRegistryName(), recipe));
     }
 
     public void add(FlowerRecipe recipe) {
@@ -43,7 +42,7 @@ public class FlowerGeneration extends VirtualizedRegistry<Pair<ResourceLocation,
 
     public void add(ResourceLocation name, FlowerRecipe recipe) {
         ModRecipes.getFlowerRecipes().put(name, recipe);
-        addScripted(Pair.of(name, recipe));
+        addScripted(recipe);
     }
 
     public ResourceLocation findRecipe(FlowerRecipe recipe) {
@@ -58,7 +57,7 @@ public class FlowerGeneration extends VirtualizedRegistry<Pair<ResourceLocation,
         FlowerRecipe recipe = ModRecipes.getFlowerRecipes().get(name);
         if (recipe == null) return false;
         ModRecipes.getFlowerRecipes().remove(name);
-        addBackup(Pair.of(name, recipe));
+        addBackup(recipe);
         return true;
     }
 
@@ -67,7 +66,7 @@ public class FlowerGeneration extends VirtualizedRegistry<Pair<ResourceLocation,
         for (Map.Entry<ResourceLocation, FlowerRecipe> x : ModRecipes.getFlowerRecipes().entrySet()) {
             if (x.getValue().getFlower() == flower) {
                 ModRecipes.getFlowerRecipes().remove(x.getKey());
-                addBackup(Pair.of(x.getKey(), x.getValue()));
+                addBackup(x.getValue());
                 return true;
             }
         }
@@ -95,7 +94,7 @@ public class FlowerGeneration extends VirtualizedRegistry<Pair<ResourceLocation,
 
     @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
-        ModRecipes.getFlowerRecipes().forEach((key, value) -> addBackup(Pair.of(key, value)));
+        ModRecipes.getFlowerRecipes().values().forEach(this::addBackup);
         ModRecipes.getFlowerRecipes().clear();
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/FlowerGeneration.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/FlowerGeneration.java
@@ -151,6 +151,7 @@ public class FlowerGeneration extends VirtualizedRegistry<Pair<ResourceLocation,
             return "Error adding Roots Flower Generation recipe";
         }
 
+        @Override
         public String getRecipeNamePrefix() {
             return "groovyscript_flower_generation_recipe_";
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/FlowerGeneration.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/FlowerGeneration.java
@@ -6,6 +6,7 @@ import com.cleanroommc.groovyscript.compat.mods.ModSupport;
 import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
 import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import epicsquid.roots.init.ModRecipes;
 import epicsquid.roots.recipe.FlowerRecipe;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
@@ -20,8 +21,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import static epicsquid.roots.init.ModRecipes.getFlowerRecipes;
-
 @RegistryDescription(
         category = RegistryDescription.Category.ENTRIES
 )
@@ -34,8 +33,8 @@ public class FlowerGeneration extends VirtualizedRegistry<Pair<ResourceLocation,
 
     @Override
     public void onReload() {
-        removeScripted().forEach(pair -> getFlowerRecipes().remove(pair.getKey()));
-        restoreFromBackup().forEach(pair -> getFlowerRecipes().put(pair.getKey(), pair.getValue()));
+        removeScripted().forEach(pair -> ModRecipes.getFlowerRecipes().remove(pair.getKey()));
+        restoreFromBackup().forEach(pair -> ModRecipes.getFlowerRecipes().put(pair.getKey(), pair.getValue()));
     }
 
     public void add(FlowerRecipe recipe) {
@@ -43,12 +42,12 @@ public class FlowerGeneration extends VirtualizedRegistry<Pair<ResourceLocation,
     }
 
     public void add(ResourceLocation name, FlowerRecipe recipe) {
-        getFlowerRecipes().put(name, recipe);
+        ModRecipes.getFlowerRecipes().put(name, recipe);
         addScripted(Pair.of(name, recipe));
     }
 
     public ResourceLocation findRecipe(FlowerRecipe recipe) {
-        for (Map.Entry<ResourceLocation, FlowerRecipe> entry : getFlowerRecipes().entrySet()) {
+        for (Map.Entry<ResourceLocation, FlowerRecipe> entry : ModRecipes.getFlowerRecipes().entrySet()) {
             if (entry.getValue().equals(recipe)) return entry.getKey();
         }
         return null;
@@ -56,18 +55,18 @@ public class FlowerGeneration extends VirtualizedRegistry<Pair<ResourceLocation,
 
     @MethodDescription(example = @Example("resource('roots:dandelion')"))
     public boolean removeByName(ResourceLocation name) {
-        FlowerRecipe recipe = getFlowerRecipes().get(name);
+        FlowerRecipe recipe = ModRecipes.getFlowerRecipes().get(name);
         if (recipe == null) return false;
-        getFlowerRecipes().remove(name);
+        ModRecipes.getFlowerRecipes().remove(name);
         addBackup(Pair.of(name, recipe));
         return true;
     }
 
     @MethodDescription(description = "groovyscript.wiki.roots.flower_generation.removeByFlower0", example = @Example("blockstate('minecraft:red_flower:2')"))
     public boolean removeByFlower(IBlockState flower) {
-        for (Map.Entry<ResourceLocation, FlowerRecipe> x : getFlowerRecipes().entrySet()) {
+        for (Map.Entry<ResourceLocation, FlowerRecipe> x : ModRecipes.getFlowerRecipes().entrySet()) {
             if (x.getValue().getFlower() == flower) {
-                getFlowerRecipes().remove(x.getKey());
+                ModRecipes.getFlowerRecipes().remove(x.getKey());
                 addBackup(Pair.of(x.getKey(), x.getValue()));
                 return true;
             }
@@ -96,13 +95,13 @@ public class FlowerGeneration extends VirtualizedRegistry<Pair<ResourceLocation,
 
     @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
-        getFlowerRecipes().forEach((key, value) -> addBackup(Pair.of(key, value)));
-        getFlowerRecipes().clear();
+        ModRecipes.getFlowerRecipes().forEach((key, value) -> addBackup(Pair.of(key, value)));
+        ModRecipes.getFlowerRecipes().clear();
     }
 
     @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<Map.Entry<ResourceLocation, FlowerRecipe>> streamRecipes() {
-        return new SimpleObjectStream<>(getFlowerRecipes().entrySet())
+        return new SimpleObjectStream<>(ModRecipes.getFlowerRecipes().entrySet())
                 .setRemover(r -> this.removeByName(r.getKey()));
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/FlowerGeneration.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/FlowerGeneration.java
@@ -168,8 +168,8 @@ public class FlowerGeneration extends VirtualizedRegistry<Pair<ResourceLocation,
         @RecipeBuilderRegistrationMethod
         public @Nullable FlowerRecipe register() {
             if (!validate()) return null;
-            FlowerRecipe recipe = new FlowerRecipe(name, flower, allowedSoils);
-            ModSupport.ROOTS.get().flowerGeneration.add(name, recipe);
+            FlowerRecipe recipe = new FlowerRecipe(super.name, flower, allowedSoils);
+            ModSupport.ROOTS.get().flowerGeneration.add(super.name, recipe);
             return recipe;
         }
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/LifeEssence.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/LifeEssence.java
@@ -5,10 +5,9 @@ import com.cleanroommc.groovyscript.api.documentation.annotations.MethodDescript
 import com.cleanroommc.groovyscript.api.documentation.annotations.RegistryDescription;
 import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import epicsquid.roots.init.ModRecipes;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraftforge.fml.common.registry.EntityEntry;
-
-import static epicsquid.roots.init.ModRecipes.getLifeEssenceList;
 
 @RegistryDescription(
         category = RegistryDescription.Category.ENTRIES
@@ -17,13 +16,13 @@ public class LifeEssence extends VirtualizedRegistry<Class<? extends EntityLivin
 
     @Override
     public void onReload() {
-        removeScripted().forEach(getLifeEssenceList()::remove);
-        restoreFromBackup().forEach(getLifeEssenceList()::add);
+        removeScripted().forEach(ModRecipes.getLifeEssenceList()::remove);
+        restoreFromBackup().forEach(ModRecipes.getLifeEssenceList()::add);
     }
 
     @MethodDescription(type = MethodDescription.Type.ADDITION)
     public void add(Class<? extends EntityLivingBase> clazz) {
-        getLifeEssenceList().add(clazz);
+        ModRecipes.getLifeEssenceList().add(clazz);
         addScripted(clazz);
     }
 
@@ -39,7 +38,7 @@ public class LifeEssence extends VirtualizedRegistry<Class<? extends EntityLivin
 
     @MethodDescription(example = @Example("entity('minecraft:sheep')"))
     public boolean remove(Class<? extends EntityLivingBase> clazz) {
-        if (!getLifeEssenceList().remove(clazz)) return false;
+        if (!ModRecipes.getLifeEssenceList().remove(clazz)) return false;
         addBackup(clazz);
         return true;
     }
@@ -56,12 +55,12 @@ public class LifeEssence extends VirtualizedRegistry<Class<? extends EntityLivin
 
     @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
-        getLifeEssenceList().forEach(this::addBackup);
-        getLifeEssenceList().clear();
+        ModRecipes.getLifeEssenceList().forEach(this::addBackup);
+        ModRecipes.getLifeEssenceList().clear();
     }
 
     @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<Class<? extends EntityLivingBase>> streamRecipes() {
-        return new SimpleObjectStream<>(getLifeEssenceList()).setRemover(this::remove);
+        return new SimpleObjectStream<>(ModRecipes.getLifeEssenceList()).setRemover(this::remove);
     }
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Mortar.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Mortar.java
@@ -240,6 +240,7 @@ public class Mortar extends VirtualizedRegistry<Pair<ResourceLocation, MortarRec
             return "Error adding Roots Mortar recipe";
         }
 
+        @Override
         public String getRecipeNamePrefix() {
             return "groovyscript_mortar_recipe_";
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Mortar.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Mortar.java
@@ -14,14 +14,13 @@ import epicsquid.roots.recipe.MortarRecipe;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.Ingredient;
 import net.minecraft.util.ResourceLocation;
-import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @RegistryDescription
-public class Mortar extends VirtualizedRegistry<Pair<ResourceLocation, MortarRecipe>> {
+public class Mortar extends VirtualizedRegistry<MortarRecipe> {
 
     public Mortar() {
         super(Alias.generateOfClassAnd(Mortar.class, "MortarAndPestle"));
@@ -38,8 +37,8 @@ public class Mortar extends VirtualizedRegistry<Pair<ResourceLocation, MortarRec
 
     @Override
     public void onReload() {
-        removeScripted().forEach(pair -> ModRecipesAccessor.getMortarRecipes().remove(pair.getKey()));
-        restoreFromBackup().forEach(pair -> ModRecipes.addMortarRecipe(pair.getValue()));
+        removeScripted().forEach(recipe -> ModRecipesAccessor.getMortarRecipes().remove(recipe.getRegistryName()));
+        restoreFromBackup().forEach(ModRecipes::addMortarRecipe);
     }
 
     public void add(MortarRecipe recipe) {
@@ -48,7 +47,7 @@ public class Mortar extends VirtualizedRegistry<Pair<ResourceLocation, MortarRec
 
     public void add(ResourceLocation name, MortarRecipe recipe) {
         ModRecipes.addMortarRecipe(recipe);
-        addScripted(Pair.of(name, recipe));
+        addScripted(recipe);
     }
 
     public ResourceLocation findRecipe(MortarRecipe recipe) {
@@ -70,7 +69,7 @@ public class Mortar extends VirtualizedRegistry<Pair<ResourceLocation, MortarRec
         return ModRecipesAccessor.getMortarRecipes().entrySet().removeIf(x -> {
             // Some Mortar recipe names are generated via [base]_x. If we are removing eg "wheat_flour" we should detect and remove all 5 variants
             if (x.getKey().equals(name) || x.getKey().toString().startsWith(name.toString())) {
-                addBackup(Pair.of(x.getKey(), x.getValue()));
+                addBackup(x.getValue());
                 return true;
             }
             return false;
@@ -81,7 +80,7 @@ public class Mortar extends VirtualizedRegistry<Pair<ResourceLocation, MortarRec
     public boolean removeByOutput(ItemStack output) {
         return ModRecipesAccessor.getMortarRecipes().entrySet().removeIf(x -> {
             if (ItemStack.areItemsEqual(x.getValue().getResult(), output)) {
-                addBackup(Pair.of(x.getKey(), x.getValue()));
+                addBackup(x.getValue());
                 return true;
             }
             return false;
@@ -90,7 +89,7 @@ public class Mortar extends VirtualizedRegistry<Pair<ResourceLocation, MortarRec
 
     @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
-        ModRecipesAccessor.getMortarRecipes().forEach((key, value) -> addBackup(Pair.of(key, value)));
+        ModRecipesAccessor.getMortarRecipes().values().forEach(this::addBackup);
         ModRecipesAccessor.getMortarRecipes().clear();
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Mortar.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Mortar.java
@@ -272,15 +272,15 @@ public class Mortar extends VirtualizedRegistry<Pair<ResourceLocation, MortarRec
                     ItemStack copy = output.get(0).copy();
                     copy.setCount(i * count);
                     MortarRecipe recipe = new MortarRecipe(copy, ingredients.toArray(new Ingredient[0]), red1, green1, blue1, red2, green2, blue2);
-                    recipe.setRegistryName(new ResourceLocation(name.toString() + "_" + i));
+                    recipe.setRegistryName(new ResourceLocation(super.name.toString() + "_" + i));
                     ModSupport.ROOTS.get().mortar.add(recipe.getRegistryName(), recipe);
                 }
                 return null;
             }
 
             MortarRecipe recipe = new MortarRecipe(output.get(0), input.stream().map(IIngredient::toMcIngredient).toArray(Ingredient[]::new), red1, red2, green1, green2, blue1, blue2);
-            recipe.setRegistryName(name);
-            ModSupport.ROOTS.get().mortar.add(name, recipe);
+            recipe.setRegistryName(super.name);
+            ModSupport.ROOTS.get().mortar.add(super.name, recipe);
             return recipe;
 
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Mortar.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Mortar.java
@@ -9,6 +9,7 @@ import com.cleanroommc.groovyscript.helper.Alias;
 import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
 import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import epicsquid.roots.init.ModRecipes;
 import epicsquid.roots.recipe.MortarRecipe;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.Ingredient;
@@ -18,9 +19,6 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import static epicsquid.roots.init.ModRecipes.addMortarRecipe;
-import static epicsquid.roots.init.ModRecipes.getMortarRecipes;
 
 @RegistryDescription
 public class Mortar extends VirtualizedRegistry<Pair<ResourceLocation, MortarRecipe>> {
@@ -41,7 +39,7 @@ public class Mortar extends VirtualizedRegistry<Pair<ResourceLocation, MortarRec
     @Override
     public void onReload() {
         removeScripted().forEach(pair -> ModRecipesAccessor.getMortarRecipes().remove(pair.getKey()));
-        restoreFromBackup().forEach(pair -> addMortarRecipe(pair.getValue()));
+        restoreFromBackup().forEach(pair -> ModRecipes.addMortarRecipe(pair.getValue()));
     }
 
     public void add(MortarRecipe recipe) {
@@ -49,19 +47,19 @@ public class Mortar extends VirtualizedRegistry<Pair<ResourceLocation, MortarRec
     }
 
     public void add(ResourceLocation name, MortarRecipe recipe) {
-        addMortarRecipe(recipe);
+        ModRecipes.addMortarRecipe(recipe);
         addScripted(Pair.of(name, recipe));
     }
 
     public ResourceLocation findRecipe(MortarRecipe recipe) {
-        for (MortarRecipe entry : getMortarRecipes()) {
+        for (MortarRecipe entry : ModRecipes.getMortarRecipes()) {
             if (entry.matches(recipe.getRecipe())) return entry.getRegistryName();
         }
         return null;
     }
 
     public ResourceLocation findRecipeByOutput(ItemStack output) {
-        for (MortarRecipe entry : getMortarRecipes()) {
+        for (MortarRecipe entry : ModRecipes.getMortarRecipes()) {
             if (ItemStack.areItemsEqual(entry.getResult(), output)) return entry.getRegistryName();
         }
         return null;
@@ -99,7 +97,7 @@ public class Mortar extends VirtualizedRegistry<Pair<ResourceLocation, MortarRec
 
     @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<MortarRecipe> streamRecipes() {
-        return new SimpleObjectStream<>(getMortarRecipes())
+        return new SimpleObjectStream<>(ModRecipes.getMortarRecipes())
                 .setRemover(r -> this.removeByName(r.getRegistryName()));
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Pacifist.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Pacifist.java
@@ -121,8 +121,8 @@ public class Pacifist extends VirtualizedRegistry<Pair<ResourceLocation, Pacifis
         @RecipeBuilderRegistrationMethod
         public @Nullable PacifistEntry register() {
             if (!validate()) return null;
-            PacifistEntry recipe = new PacifistEntry(entity, name.toString());
-            ((PacifistEntryAccessor) recipe).setName(name);
+            PacifistEntry recipe = new PacifistEntry(entity, super.name.toString());
+            ((PacifistEntryAccessor) recipe).setName(super.name);
             ModSupport.ROOTS.get().pacifist.add(recipe.getRegistryName(), recipe);
             return recipe;
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Pacifist.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Pacifist.java
@@ -104,6 +104,7 @@ public class Pacifist extends VirtualizedRegistry<Pair<ResourceLocation, Pacifis
             return "Error adding Roots Runic Shear Entity recipe";
         }
 
+        @Override
         public String getRecipeNamePrefix() {
             return "groovyscript_pacifist_";
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Pacifist.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Pacifist.java
@@ -7,6 +7,7 @@ import com.cleanroommc.groovyscript.core.mixin.roots.PacifistEntryAccessor;
 import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
 import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import epicsquid.roots.init.ModRecipes;
 import epicsquid.roots.recipe.PacifistEntry;
 import net.minecraft.entity.Entity;
 import net.minecraft.util.ResourceLocation;
@@ -15,8 +16,6 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
-
-import static epicsquid.roots.init.ModRecipes.getPacifistEntities;
 
 @RegistryDescription(
         category = RegistryDescription.Category.ENTRIES
@@ -30,8 +29,8 @@ public class Pacifist extends VirtualizedRegistry<Pair<ResourceLocation, Pacifis
 
     @Override
     public void onReload() {
-        removeScripted().forEach(pair -> getPacifistEntities().remove(pair.getKey()));
-        restoreFromBackup().forEach(pair -> getPacifistEntities().put(pair.getKey(), pair.getValue()));
+        removeScripted().forEach(pair -> ModRecipes.getPacifistEntities().remove(pair.getKey()));
+        restoreFromBackup().forEach(pair -> ModRecipes.getPacifistEntities().put(pair.getKey(), pair.getValue()));
     }
 
     public void add(PacifistEntry recipe) {
@@ -39,12 +38,12 @@ public class Pacifist extends VirtualizedRegistry<Pair<ResourceLocation, Pacifis
     }
 
     public void add(ResourceLocation name, PacifistEntry recipe) {
-        getPacifistEntities().put(name, recipe);
+        ModRecipes.getPacifistEntities().put(name, recipe);
         addScripted(Pair.of(name, recipe));
     }
 
     public ResourceLocation findRecipe(PacifistEntry recipe) {
-        for (Map.Entry<ResourceLocation, PacifistEntry> entry : getPacifistEntities().entrySet()) {
+        for (Map.Entry<ResourceLocation, PacifistEntry> entry : ModRecipes.getPacifistEntities().entrySet()) {
             if (entry.getValue().equals(recipe)) return entry.getKey();
         }
         return null;
@@ -52,9 +51,9 @@ public class Pacifist extends VirtualizedRegistry<Pair<ResourceLocation, Pacifis
 
     @MethodDescription(example = @Example("resource('minecraft:chicken')"))
     public boolean removeByName(ResourceLocation name) {
-        PacifistEntry recipe = getPacifistEntities().get(name);
+        PacifistEntry recipe = ModRecipes.getPacifistEntities().get(name);
         if (recipe == null) return false;
-        getPacifistEntities().remove(name);
+        ModRecipes.getPacifistEntities().remove(name);
         addBackup(Pair.of(name, recipe));
         return true;
     }
@@ -66,7 +65,7 @@ public class Pacifist extends VirtualizedRegistry<Pair<ResourceLocation, Pacifis
 
     @MethodDescription
     public boolean removeByClass(Class<? extends Entity> clazz) {
-        return getPacifistEntities().entrySet().removeIf(x -> {
+        return ModRecipes.getPacifistEntities().entrySet().removeIf(x -> {
             if (x.getValue().getEntityClass().equals(clazz)) {
                 addBackup(Pair.of(x.getKey(), x.getValue()));
                 return true;
@@ -77,13 +76,13 @@ public class Pacifist extends VirtualizedRegistry<Pair<ResourceLocation, Pacifis
 
     @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
-        getPacifistEntities().forEach((key, value) -> addBackup(Pair.of(key, value)));
-        getPacifistEntities().clear();
+        ModRecipes.getPacifistEntities().forEach((key, value) -> addBackup(Pair.of(key, value)));
+        ModRecipes.getPacifistEntities().clear();
     }
 
     @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<Map.Entry<ResourceLocation, PacifistEntry>> streamRecipes() {
-        return new SimpleObjectStream<>(getPacifistEntities().entrySet())
+        return new SimpleObjectStream<>(ModRecipes.getPacifistEntities().entrySet())
                 .setRemover(r -> this.removeByName(r.getKey()));
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Pacifist.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Pacifist.java
@@ -12,7 +12,6 @@ import epicsquid.roots.recipe.PacifistEntry;
 import net.minecraft.entity.Entity;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.common.registry.EntityEntry;
-import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
@@ -20,7 +19,7 @@ import java.util.Map;
 @RegistryDescription(
         category = RegistryDescription.Category.ENTRIES
 )
-public class Pacifist extends VirtualizedRegistry<Pair<ResourceLocation, PacifistEntry>> {
+public class Pacifist extends VirtualizedRegistry<PacifistEntry> {
 
     @RecipeBuilderDescription(example = @Example(".name('wither_skeleton_pacifist').entity(entity('minecraft:wither_skeleton'))"))
     public static RecipeBuilder recipeBuilder() {
@@ -29,8 +28,8 @@ public class Pacifist extends VirtualizedRegistry<Pair<ResourceLocation, Pacifis
 
     @Override
     public void onReload() {
-        removeScripted().forEach(pair -> ModRecipes.getPacifistEntities().remove(pair.getKey()));
-        restoreFromBackup().forEach(pair -> ModRecipes.getPacifistEntities().put(pair.getKey(), pair.getValue()));
+        removeScripted().forEach(recipe -> ModRecipes.getPacifistEntities().remove(recipe.getRegistryName()));
+        restoreFromBackup().forEach(recipe -> ModRecipes.getPacifistEntities().put(recipe.getRegistryName(), recipe));
     }
 
     public void add(PacifistEntry recipe) {
@@ -39,7 +38,7 @@ public class Pacifist extends VirtualizedRegistry<Pair<ResourceLocation, Pacifis
 
     public void add(ResourceLocation name, PacifistEntry recipe) {
         ModRecipes.getPacifistEntities().put(name, recipe);
-        addScripted(Pair.of(name, recipe));
+        addScripted(recipe);
     }
 
     public ResourceLocation findRecipe(PacifistEntry recipe) {
@@ -54,7 +53,7 @@ public class Pacifist extends VirtualizedRegistry<Pair<ResourceLocation, Pacifis
         PacifistEntry recipe = ModRecipes.getPacifistEntities().get(name);
         if (recipe == null) return false;
         ModRecipes.getPacifistEntities().remove(name);
-        addBackup(Pair.of(name, recipe));
+        addBackup(recipe);
         return true;
     }
 
@@ -67,7 +66,7 @@ public class Pacifist extends VirtualizedRegistry<Pair<ResourceLocation, Pacifis
     public boolean removeByClass(Class<? extends Entity> clazz) {
         return ModRecipes.getPacifistEntities().entrySet().removeIf(x -> {
             if (x.getValue().getEntityClass().equals(clazz)) {
-                addBackup(Pair.of(x.getKey(), x.getValue()));
+                addBackup(x.getValue());
                 return true;
             }
             return false;
@@ -76,7 +75,7 @@ public class Pacifist extends VirtualizedRegistry<Pair<ResourceLocation, Pacifis
 
     @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
-        ModRecipes.getPacifistEntities().forEach((key, value) -> addBackup(Pair.of(key, value)));
+        ModRecipes.getPacifistEntities().values().forEach(this::addBackup);
         ModRecipes.getPacifistEntities().clear();
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Predicates.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Predicates.java
@@ -62,9 +62,9 @@ public class Predicates extends NamedRegistry {
         @Property(valid = @Comp(value = "null", type = Comp.Type.NOT))
         private IBlockState blockstate;
         @Property(requirement = "groovyscript.wiki.roots.predicates.above_or_below.required")
-        private boolean above = false;
+        private boolean above;
         @Property(requirement = "groovyscript.wiki.roots.predicates.above_or_below.required")
-        private boolean below = false;
+        private boolean below;
 
         @RecipeBuilderMethodDescription
         public StateBuilder blockstate(IBlockState blockstate) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Pyre.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Pyre.java
@@ -127,6 +127,7 @@ public class Pyre extends VirtualizedRegistry<Pair<ResourceLocation, PyreCraftin
             return "Error adding Roots Pyre recipe";
         }
 
+        @Override
         public String getRecipeNamePrefix() {
             return "groovyscript_pyre_recipe_";
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Pyre.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Pyre.java
@@ -147,8 +147,8 @@ public class Pyre extends VirtualizedRegistry<Pair<ResourceLocation, PyreCraftin
             PyreCraftingRecipe recipe = new PyreCraftingRecipe(output.get(0), xp);
             input.forEach(i -> recipe.addIngredient(i.toMcIngredient()));
             recipe.setBurnTime(this.burnTime);
-            recipe.setName(name.toString());
-            ModSupport.ROOTS.get().pyre.add(name, recipe);
+            recipe.setName(super.name.toString());
+            ModSupport.ROOTS.get().pyre.add(super.name, recipe);
             return recipe;
         }
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Pyre.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Pyre.java
@@ -10,13 +10,12 @@ import epicsquid.roots.init.ModRecipes;
 import epicsquid.roots.recipe.PyreCraftingRecipe;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
-import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
 
 @RegistryDescription
-public class Pyre extends VirtualizedRegistry<Pair<ResourceLocation, PyreCraftingRecipe>> {
+public class Pyre extends VirtualizedRegistry<PyreCraftingRecipe> {
 
     @RecipeBuilderDescription(example = {
             @Example(".name('clay_from_fire').input(item('minecraft:stone'),item('minecraft:stone'),item('minecraft:stone'),item('minecraft:stone'),item('minecraft:stone')).output(item('minecraft:clay')).xp(5).time(1)"),
@@ -28,8 +27,8 @@ public class Pyre extends VirtualizedRegistry<Pair<ResourceLocation, PyreCraftin
 
     @Override
     public void onReload() {
-        removeScripted().forEach(pair -> ModRecipes.removePyreCraftingRecipe(pair.getKey()));
-        restoreFromBackup().forEach(pair -> ModRecipes.addPyreCraftingRecipe(pair.getKey(), pair.getValue()));
+        removeScripted().forEach(recipe -> ModRecipes.removePyreCraftingRecipe(recipe.getRegistryName()));
+        restoreFromBackup().forEach(recipe -> ModRecipes.addPyreCraftingRecipe(recipe.getRegistryName(), recipe));
     }
 
     public void add(PyreCraftingRecipe recipe) {
@@ -38,7 +37,7 @@ public class Pyre extends VirtualizedRegistry<Pair<ResourceLocation, PyreCraftin
 
     public void add(ResourceLocation name, PyreCraftingRecipe recipe) {
         ModRecipes.addPyreCraftingRecipe(name, recipe);
-        addScripted(Pair.of(name, recipe));
+        addScripted(recipe);
     }
 
     public ResourceLocation findRecipe(PyreCraftingRecipe recipe) {
@@ -60,7 +59,7 @@ public class Pyre extends VirtualizedRegistry<Pair<ResourceLocation, PyreCraftin
         PyreCraftingRecipe recipe = ModRecipes.getCraftingRecipe(name);
         if (recipe == null) return false;
         ModRecipes.removePyreCraftingRecipe(name);
-        addBackup(Pair.of(name, recipe));
+        addBackup(recipe);
         return true;
     }
 
@@ -69,7 +68,7 @@ public class Pyre extends VirtualizedRegistry<Pair<ResourceLocation, PyreCraftin
         for (Map.Entry<ResourceLocation, PyreCraftingRecipe> x : ModRecipes.getPyreCraftingRecipes().entrySet()) {
             if (ItemStack.areItemsEqual(x.getValue().getResult(), output)) {
                 ModRecipes.getPyreCraftingRecipes().remove(x.getKey());
-                addBackup(Pair.of(x.getKey(), x.getValue()));
+                addBackup(x.getValue());
                 return true;
             }
         }
@@ -78,7 +77,7 @@ public class Pyre extends VirtualizedRegistry<Pair<ResourceLocation, PyreCraftin
 
     @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
-        ModRecipes.getPyreCraftingRecipes().forEach((key, value) -> addBackup(Pair.of(key, value)));
+        ModRecipes.getPyreCraftingRecipes().values().forEach(this::addBackup);
         ModRecipes.getPyreCraftingRecipes().clear();
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Pyre.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Pyre.java
@@ -6,6 +6,7 @@ import com.cleanroommc.groovyscript.compat.mods.ModSupport;
 import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
 import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import epicsquid.roots.init.ModRecipes;
 import epicsquid.roots.recipe.PyreCraftingRecipe;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
@@ -13,8 +14,6 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
-
-import static epicsquid.roots.init.ModRecipes.*;
 
 @RegistryDescription
 public class Pyre extends VirtualizedRegistry<Pair<ResourceLocation, PyreCraftingRecipe>> {
@@ -29,8 +28,8 @@ public class Pyre extends VirtualizedRegistry<Pair<ResourceLocation, PyreCraftin
 
     @Override
     public void onReload() {
-        removeScripted().forEach(pair -> removePyreCraftingRecipe(pair.getKey()));
-        restoreFromBackup().forEach(pair -> addPyreCraftingRecipe(pair.getKey(), pair.getValue()));
+        removeScripted().forEach(pair -> ModRecipes.removePyreCraftingRecipe(pair.getKey()));
+        restoreFromBackup().forEach(pair -> ModRecipes.addPyreCraftingRecipe(pair.getKey(), pair.getValue()));
     }
 
     public void add(PyreCraftingRecipe recipe) {
@@ -38,19 +37,19 @@ public class Pyre extends VirtualizedRegistry<Pair<ResourceLocation, PyreCraftin
     }
 
     public void add(ResourceLocation name, PyreCraftingRecipe recipe) {
-        addPyreCraftingRecipe(name, recipe);
+        ModRecipes.addPyreCraftingRecipe(name, recipe);
         addScripted(Pair.of(name, recipe));
     }
 
     public ResourceLocation findRecipe(PyreCraftingRecipe recipe) {
-        for (Map.Entry<ResourceLocation, PyreCraftingRecipe> entry : getPyreCraftingRecipes().entrySet()) {
+        for (Map.Entry<ResourceLocation, PyreCraftingRecipe> entry : ModRecipes.getPyreCraftingRecipes().entrySet()) {
             if (entry.getValue().matches(recipe.getRecipe())) return entry.getKey();
         }
         return null;
     }
 
     public ResourceLocation findRecipeByOutput(ItemStack output) {
-        for (Map.Entry<ResourceLocation, PyreCraftingRecipe> entry : getPyreCraftingRecipes().entrySet()) {
+        for (Map.Entry<ResourceLocation, PyreCraftingRecipe> entry : ModRecipes.getPyreCraftingRecipes().entrySet()) {
             if (ItemStack.areItemsEqual(entry.getValue().getResult(), output)) return entry.getKey();
         }
         return null;
@@ -58,18 +57,18 @@ public class Pyre extends VirtualizedRegistry<Pair<ResourceLocation, PyreCraftin
 
     @MethodDescription(example = @Example("resource('roots:infernal_bulb')"))
     public boolean removeByName(ResourceLocation name) {
-        PyreCraftingRecipe recipe = getCraftingRecipe(name);
+        PyreCraftingRecipe recipe = ModRecipes.getCraftingRecipe(name);
         if (recipe == null) return false;
-        removePyreCraftingRecipe(name);
+        ModRecipes.removePyreCraftingRecipe(name);
         addBackup(Pair.of(name, recipe));
         return true;
     }
 
     @MethodDescription(example = @Example("item('minecraft:gravel')"))
     public boolean removeByOutput(ItemStack output) {
-        for (Map.Entry<ResourceLocation, PyreCraftingRecipe> x : getPyreCraftingRecipes().entrySet()) {
+        for (Map.Entry<ResourceLocation, PyreCraftingRecipe> x : ModRecipes.getPyreCraftingRecipes().entrySet()) {
             if (ItemStack.areItemsEqual(x.getValue().getResult(), output)) {
-                getPyreCraftingRecipes().remove(x.getKey());
+                ModRecipes.getPyreCraftingRecipes().remove(x.getKey());
                 addBackup(Pair.of(x.getKey(), x.getValue()));
                 return true;
             }
@@ -79,13 +78,13 @@ public class Pyre extends VirtualizedRegistry<Pair<ResourceLocation, PyreCraftin
 
     @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
-        getPyreCraftingRecipes().forEach((key, value) -> addBackup(Pair.of(key, value)));
-        getPyreCraftingRecipes().clear();
+        ModRecipes.getPyreCraftingRecipes().forEach((key, value) -> addBackup(Pair.of(key, value)));
+        ModRecipes.getPyreCraftingRecipes().clear();
     }
 
     @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<Map.Entry<ResourceLocation, PyreCraftingRecipe>> streamRecipes() {
-        return new SimpleObjectStream<>(getPyreCraftingRecipes().entrySet())
+        return new SimpleObjectStream<>(ModRecipes.getPyreCraftingRecipes().entrySet())
                 .setRemover(r -> this.removeByName(r.getKey()));
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Pyre.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Pyre.java
@@ -95,7 +95,7 @@ public class Pyre extends VirtualizedRegistry<Pair<ResourceLocation, PyreCraftin
     public static class RecipeBuilder extends AbstractRecipeBuilder<PyreCraftingRecipe> {
 
         @Property(valid = @Comp(value = "0", type = Comp.Type.GTE))
-        private int xp = 0;
+        private int xp;
         @Property(defaultValue = "200")
         private int burnTime = 200;
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/RunicShearBlock.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/RunicShearBlock.java
@@ -13,13 +13,12 @@ import epicsquid.roots.recipe.transmutation.StatePredicate;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
-import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
 
 @RegistryDescription
-public class RunicShearBlock extends VirtualizedRegistry<Pair<ResourceLocation, RunicShearRecipe>> {
+public class RunicShearBlock extends VirtualizedRegistry<RunicShearRecipe> {
 
     @RecipeBuilderDescription(example = {
             @Example(".name('clay_from_runic_diamond').state(blockstate('minecraft:diamond_block')).replacementState(blockstate('minecraft:air')).output(item('minecraft:clay') * 64).displayItem(item('minecraft:diamond') * 9)"),
@@ -31,8 +30,8 @@ public class RunicShearBlock extends VirtualizedRegistry<Pair<ResourceLocation, 
 
     @Override
     public void onReload() {
-        removeScripted().forEach(pair -> ModRecipes.getRunicShearRecipes().remove(pair.getKey()));
-        restoreFromBackup().forEach(pair -> ModRecipes.getRunicShearRecipes().put(pair.getKey(), pair.getValue()));
+        removeScripted().forEach(recipe -> ModRecipes.getRunicShearRecipes().remove(recipe.getRegistryName()));
+        restoreFromBackup().forEach(recipe -> ModRecipes.getRunicShearRecipes().put(recipe.getRegistryName(), recipe));
     }
 
     public void add(RunicShearRecipe recipe) {
@@ -41,7 +40,7 @@ public class RunicShearBlock extends VirtualizedRegistry<Pair<ResourceLocation, 
 
     public void add(ResourceLocation name, RunicShearRecipe recipe) {
         ModRecipes.getRunicShearRecipes().put(name, recipe);
-        addScripted(Pair.of(name, recipe));
+        addScripted(recipe);
     }
 
     public ResourceLocation findRecipe(RunicShearRecipe recipe) {
@@ -56,7 +55,7 @@ public class RunicShearBlock extends VirtualizedRegistry<Pair<ResourceLocation, 
         RunicShearRecipe recipe = ModRecipes.getRunicShearRecipes().get(name);
         if (recipe == null) return false;
         ModRecipes.getRunicShearRecipes().remove(name);
-        addBackup(Pair.of(name, recipe));
+        addBackup(recipe);
         return true;
     }
 
@@ -65,7 +64,7 @@ public class RunicShearBlock extends VirtualizedRegistry<Pair<ResourceLocation, 
         for (Map.Entry<ResourceLocation, RunicShearRecipe> x : ModRecipes.getRunicShearRecipes().entrySet()) {
             if (x.getValue().matches(state)) {
                 ModRecipes.getRunicShearRecipes().remove(x.getKey());
-                addBackup(Pair.of(x.getKey(), x.getValue()));
+                addBackup(x.getValue());
                 return true;
             }
         }
@@ -77,7 +76,7 @@ public class RunicShearBlock extends VirtualizedRegistry<Pair<ResourceLocation, 
         for (Map.Entry<ResourceLocation, RunicShearRecipe> x : ModRecipes.getRunicShearRecipes().entrySet()) {
             if (ItemStack.areItemsEqual(x.getValue().getDrop(), output)) {
                 ModRecipes.getRunicShearRecipes().remove(x.getKey());
-                addBackup(Pair.of(x.getKey(), x.getValue()));
+                addBackup(x.getValue());
                 return true;
             }
         }
@@ -86,7 +85,7 @@ public class RunicShearBlock extends VirtualizedRegistry<Pair<ResourceLocation, 
 
     @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
-        ModRecipes.getRunicShearRecipes().forEach((key, value) -> addBackup(Pair.of(key, value)));
+        ModRecipes.getRunicShearRecipes().values().forEach(this::addBackup);
         ModRecipes.getRunicShearRecipes().clear();
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/RunicShearBlock.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/RunicShearBlock.java
@@ -158,8 +158,8 @@ public class RunicShearBlock extends VirtualizedRegistry<Pair<ResourceLocation, 
         @RecipeBuilderRegistrationMethod
         public @Nullable RunicShearRecipe register() {
             if (!validate()) return null;
-            RunicShearRecipe recipe = new RunicShearRecipe(name, state, replacementState, output.get(0), displayItem);
-            ModSupport.ROOTS.get().runicShearBlock.add(name, recipe);
+            RunicShearRecipe recipe = new RunicShearRecipe(super.name, state, replacementState, output.get(0), displayItem);
+            ModSupport.ROOTS.get().runicShearBlock.add(super.name, recipe);
             return recipe;
         }
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/RunicShearBlock.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/RunicShearBlock.java
@@ -137,6 +137,7 @@ public class RunicShearBlock extends VirtualizedRegistry<Pair<ResourceLocation, 
             return "Error adding Roots Runic Shear Block recipe";
         }
 
+        @Override
         public String getRecipeNamePrefix() {
             return "groovyscript_runic_shear_block_";
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/RunicShearBlock.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/RunicShearBlock.java
@@ -6,6 +6,7 @@ import com.cleanroommc.groovyscript.compat.mods.ModSupport;
 import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
 import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import epicsquid.roots.init.ModRecipes;
 import epicsquid.roots.recipe.RunicShearRecipe;
 import epicsquid.roots.recipe.transmutation.BlockStatePredicate;
 import epicsquid.roots.recipe.transmutation.StatePredicate;
@@ -16,8 +17,6 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
-
-import static epicsquid.roots.init.ModRecipes.getRunicShearRecipes;
 
 @RegistryDescription
 public class RunicShearBlock extends VirtualizedRegistry<Pair<ResourceLocation, RunicShearRecipe>> {
@@ -32,8 +31,8 @@ public class RunicShearBlock extends VirtualizedRegistry<Pair<ResourceLocation, 
 
     @Override
     public void onReload() {
-        removeScripted().forEach(pair -> getRunicShearRecipes().remove(pair.getKey()));
-        restoreFromBackup().forEach(pair -> getRunicShearRecipes().put(pair.getKey(), pair.getValue()));
+        removeScripted().forEach(pair -> ModRecipes.getRunicShearRecipes().remove(pair.getKey()));
+        restoreFromBackup().forEach(pair -> ModRecipes.getRunicShearRecipes().put(pair.getKey(), pair.getValue()));
     }
 
     public void add(RunicShearRecipe recipe) {
@@ -41,12 +40,12 @@ public class RunicShearBlock extends VirtualizedRegistry<Pair<ResourceLocation, 
     }
 
     public void add(ResourceLocation name, RunicShearRecipe recipe) {
-        getRunicShearRecipes().put(name, recipe);
+        ModRecipes.getRunicShearRecipes().put(name, recipe);
         addScripted(Pair.of(name, recipe));
     }
 
     public ResourceLocation findRecipe(RunicShearRecipe recipe) {
-        for (Map.Entry<ResourceLocation, RunicShearRecipe> entry : getRunicShearRecipes().entrySet()) {
+        for (Map.Entry<ResourceLocation, RunicShearRecipe> entry : ModRecipes.getRunicShearRecipes().entrySet()) {
             if (entry.getValue().equals(recipe)) return entry.getKey();
         }
         return null;
@@ -54,18 +53,18 @@ public class RunicShearBlock extends VirtualizedRegistry<Pair<ResourceLocation, 
 
     @MethodDescription(example = @Example("resource('roots:wildewheet')"))
     public boolean removeByName(ResourceLocation name) {
-        RunicShearRecipe recipe = getRunicShearRecipes().get(name);
+        RunicShearRecipe recipe = ModRecipes.getRunicShearRecipes().get(name);
         if (recipe == null) return false;
-        getRunicShearRecipes().remove(name);
+        ModRecipes.getRunicShearRecipes().remove(name);
         addBackup(Pair.of(name, recipe));
         return true;
     }
 
     @MethodDescription(example = @Example("blockstate('minecraft:beetroots:age=3')"))
     public boolean removeByState(IBlockState state) {
-        for (Map.Entry<ResourceLocation, RunicShearRecipe> x : getRunicShearRecipes().entrySet()) {
+        for (Map.Entry<ResourceLocation, RunicShearRecipe> x : ModRecipes.getRunicShearRecipes().entrySet()) {
             if (x.getValue().matches(state)) {
-                getRunicShearRecipes().remove(x.getKey());
+                ModRecipes.getRunicShearRecipes().remove(x.getKey());
                 addBackup(Pair.of(x.getKey(), x.getValue()));
                 return true;
             }
@@ -75,9 +74,9 @@ public class RunicShearBlock extends VirtualizedRegistry<Pair<ResourceLocation, 
 
     @MethodDescription(example = @Example("item('roots:spirit_herb')"))
     public boolean removeByOutput(ItemStack output) {
-        for (Map.Entry<ResourceLocation, RunicShearRecipe> x : getRunicShearRecipes().entrySet()) {
+        for (Map.Entry<ResourceLocation, RunicShearRecipe> x : ModRecipes.getRunicShearRecipes().entrySet()) {
             if (ItemStack.areItemsEqual(x.getValue().getDrop(), output)) {
-                getRunicShearRecipes().remove(x.getKey());
+                ModRecipes.getRunicShearRecipes().remove(x.getKey());
                 addBackup(Pair.of(x.getKey(), x.getValue()));
                 return true;
             }
@@ -87,13 +86,13 @@ public class RunicShearBlock extends VirtualizedRegistry<Pair<ResourceLocation, 
 
     @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
-        getRunicShearRecipes().forEach((key, value) -> addBackup(Pair.of(key, value)));
-        getRunicShearRecipes().clear();
+        ModRecipes.getRunicShearRecipes().forEach((key, value) -> addBackup(Pair.of(key, value)));
+        ModRecipes.getRunicShearRecipes().clear();
     }
 
     @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<Map.Entry<ResourceLocation, RunicShearRecipe>> streamRecipes() {
-        return new SimpleObjectStream<>(getRunicShearRecipes().entrySet())
+        return new SimpleObjectStream<>(ModRecipes.getRunicShearRecipes().entrySet())
                 .setRemover(r -> this.removeByName(r.getKey()));
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/RunicShearEntity.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/RunicShearEntity.java
@@ -6,6 +6,7 @@ import com.cleanroommc.groovyscript.compat.mods.ModSupport;
 import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
 import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import epicsquid.roots.init.ModRecipes;
 import epicsquid.roots.recipe.RunicShearConditionalEntityRecipe;
 import epicsquid.roots.recipe.RunicShearEntityRecipe;
 import net.minecraft.entity.EntityLivingBase;
@@ -18,8 +19,6 @@ import org.jetbrains.annotations.Nullable;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.function.Function;
-
-import static epicsquid.roots.init.ModRecipes.getRunicShearEntityRecipes;
 
 @RegistryDescription
 public class RunicShearEntity extends VirtualizedRegistry<Pair<ResourceLocation, RunicShearEntityRecipe>> {
@@ -36,8 +35,8 @@ public class RunicShearEntity extends VirtualizedRegistry<Pair<ResourceLocation,
     @Override
     public void onReload() {
         // FIXME Not currently reloadable due to being controlled by the Capability RunicShearsCapabilityProvider
-        removeScripted().forEach(pair -> getRunicShearEntityRecipes().remove(pair.getKey()));
-        restoreFromBackup().forEach(pair -> getRunicShearEntityRecipes().put(pair.getKey(), pair.getValue()));
+        removeScripted().forEach(pair -> ModRecipes.getRunicShearEntityRecipes().remove(pair.getKey()));
+        restoreFromBackup().forEach(pair -> ModRecipes.getRunicShearEntityRecipes().put(pair.getKey(), pair.getValue()));
     }
 
     public void add(RunicShearEntityRecipe recipe) {
@@ -45,12 +44,12 @@ public class RunicShearEntity extends VirtualizedRegistry<Pair<ResourceLocation,
     }
 
     public void add(ResourceLocation name, RunicShearEntityRecipe recipe) {
-        getRunicShearEntityRecipes().put(name, recipe);
+        ModRecipes.getRunicShearEntityRecipes().put(name, recipe);
         addScripted(Pair.of(name, recipe));
     }
 
     public ResourceLocation findRecipe(RunicShearEntityRecipe recipe) {
-        for (Map.Entry<ResourceLocation, RunicShearEntityRecipe> entry : getRunicShearEntityRecipes().entrySet()) {
+        for (Map.Entry<ResourceLocation, RunicShearEntityRecipe> entry : ModRecipes.getRunicShearEntityRecipes().entrySet()) {
             if (entry.getValue().equals(recipe)) return entry.getKey();
         }
         return null;
@@ -58,16 +57,16 @@ public class RunicShearEntity extends VirtualizedRegistry<Pair<ResourceLocation,
 
     @MethodDescription(example = @Example("resource('roots:slime_strange_ooze')"))
     public boolean removeByName(ResourceLocation name) {
-        RunicShearEntityRecipe recipe = getRunicShearEntityRecipes().get(name);
+        RunicShearEntityRecipe recipe = ModRecipes.getRunicShearEntityRecipes().get(name);
         if (recipe == null) return false;
-        getRunicShearEntityRecipes().remove(name);
+        ModRecipes.getRunicShearEntityRecipes().remove(name);
         addBackup(Pair.of(name, recipe));
         return true;
     }
 
     @MethodDescription(example = @Example("item('roots:fey_leather')"))
     public boolean removeByOutput(ItemStack output) {
-        return getRunicShearEntityRecipes().entrySet().removeIf(x -> {
+        return ModRecipes.getRunicShearEntityRecipes().entrySet().removeIf(x -> {
             if (ItemStack.areItemsEqual(x.getValue().getDrop(), output)) {
                 addBackup(Pair.of(x.getKey(), x.getValue()));
                 return true;
@@ -83,9 +82,9 @@ public class RunicShearEntity extends VirtualizedRegistry<Pair<ResourceLocation,
 
     @MethodDescription
     public boolean removeByEntity(Class<? extends EntityLivingBase> clazz) {
-        for (Map.Entry<ResourceLocation, RunicShearEntityRecipe> x : getRunicShearEntityRecipes().entrySet()) {
+        for (Map.Entry<ResourceLocation, RunicShearEntityRecipe> x : ModRecipes.getRunicShearEntityRecipes().entrySet()) {
             if (x.getValue().getClazz() == clazz) {
-                getRunicShearEntityRecipes().remove(x.getKey());
+                ModRecipes.getRunicShearEntityRecipes().remove(x.getKey());
                 addBackup(Pair.of(x.getKey(), x.getValue()));
                 return true;
             }
@@ -95,13 +94,13 @@ public class RunicShearEntity extends VirtualizedRegistry<Pair<ResourceLocation,
 
     @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
-        getRunicShearEntityRecipes().forEach((key, value) -> addBackup(Pair.of(key, value)));
-        getRunicShearEntityRecipes().clear();
+        ModRecipes.getRunicShearEntityRecipes().forEach((key, value) -> addBackup(Pair.of(key, value)));
+        ModRecipes.getRunicShearEntityRecipes().clear();
     }
 
     @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<Map.Entry<ResourceLocation, RunicShearEntityRecipe>> streamRecipes() {
-        return new SimpleObjectStream<>(getRunicShearEntityRecipes().entrySet())
+        return new SimpleObjectStream<>(ModRecipes.getRunicShearEntityRecipes().entrySet())
                 .setRemover(r -> this.removeByName(r.getKey()));
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/RunicShearEntity.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/RunicShearEntity.java
@@ -158,9 +158,9 @@ public class RunicShearEntity extends VirtualizedRegistry<Pair<ResourceLocation,
         public @Nullable RunicShearEntityRecipe register() {
             if (!validate()) return null;
             RunicShearEntityRecipe recipe;
-            if (functionMap == null) recipe = new RunicShearEntityRecipe(name, output.get(0), entity, cooldown);
-            else recipe = new RunicShearConditionalEntityRecipe(name, functionMap, new HashSet<>(output), entity, cooldown);
-            ModSupport.ROOTS.get().runicShearEntity.add(name, recipe);
+            if (functionMap == null) recipe = new RunicShearEntityRecipe(super.name, output.get(0), entity, cooldown);
+            else recipe = new RunicShearConditionalEntityRecipe(super.name, functionMap, new HashSet<>(output), entity, cooldown);
+            ModSupport.ROOTS.get().runicShearEntity.add(super.name, recipe);
             return recipe;
         }
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/RunicShearEntity.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/RunicShearEntity.java
@@ -139,6 +139,7 @@ public class RunicShearEntity extends VirtualizedRegistry<Pair<ResourceLocation,
             return "Error adding Roots Runic Shear Entity recipe";
         }
 
+        @Override
         public String getRecipeNamePrefix() {
             return "groovyscript_runic_shear_entity_";
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/RunicShearEntity.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/RunicShearEntity.java
@@ -13,7 +13,6 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.common.registry.EntityEntry;
-import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.HashSet;
@@ -21,7 +20,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 @RegistryDescription
-public class RunicShearEntity extends VirtualizedRegistry<Pair<ResourceLocation, RunicShearEntityRecipe>> {
+public class RunicShearEntity extends VirtualizedRegistry<RunicShearEntityRecipe> {
 
     @RecipeBuilderDescription(example = {
             @Example(".name('clay_from_wither_skeletons').entity(entity('minecraft:wither_skeleton')).output(item('minecraft:clay')).cooldown(1000)"),
@@ -35,8 +34,8 @@ public class RunicShearEntity extends VirtualizedRegistry<Pair<ResourceLocation,
     @Override
     public void onReload() {
         // FIXME Not currently reloadable due to being controlled by the Capability RunicShearsCapabilityProvider
-        removeScripted().forEach(pair -> ModRecipes.getRunicShearEntityRecipes().remove(pair.getKey()));
-        restoreFromBackup().forEach(pair -> ModRecipes.getRunicShearEntityRecipes().put(pair.getKey(), pair.getValue()));
+        removeScripted().forEach(recipe -> ModRecipes.getRunicShearEntityRecipes().remove(recipe.getRegistryName()));
+        restoreFromBackup().forEach(recipe -> ModRecipes.getRunicShearEntityRecipes().put(recipe.getRegistryName(), recipe));
     }
 
     public void add(RunicShearEntityRecipe recipe) {
@@ -45,7 +44,7 @@ public class RunicShearEntity extends VirtualizedRegistry<Pair<ResourceLocation,
 
     public void add(ResourceLocation name, RunicShearEntityRecipe recipe) {
         ModRecipes.getRunicShearEntityRecipes().put(name, recipe);
-        addScripted(Pair.of(name, recipe));
+        addScripted(recipe);
     }
 
     public ResourceLocation findRecipe(RunicShearEntityRecipe recipe) {
@@ -60,7 +59,7 @@ public class RunicShearEntity extends VirtualizedRegistry<Pair<ResourceLocation,
         RunicShearEntityRecipe recipe = ModRecipes.getRunicShearEntityRecipes().get(name);
         if (recipe == null) return false;
         ModRecipes.getRunicShearEntityRecipes().remove(name);
-        addBackup(Pair.of(name, recipe));
+        addBackup(recipe);
         return true;
     }
 
@@ -68,7 +67,7 @@ public class RunicShearEntity extends VirtualizedRegistry<Pair<ResourceLocation,
     public boolean removeByOutput(ItemStack output) {
         return ModRecipes.getRunicShearEntityRecipes().entrySet().removeIf(x -> {
             if (ItemStack.areItemsEqual(x.getValue().getDrop(), output)) {
-                addBackup(Pair.of(x.getKey(), x.getValue()));
+                addBackup(x.getValue());
                 return true;
             }
             return false;
@@ -85,7 +84,7 @@ public class RunicShearEntity extends VirtualizedRegistry<Pair<ResourceLocation,
         for (Map.Entry<ResourceLocation, RunicShearEntityRecipe> x : ModRecipes.getRunicShearEntityRecipes().entrySet()) {
             if (x.getValue().getClazz() == clazz) {
                 ModRecipes.getRunicShearEntityRecipes().remove(x.getKey());
-                addBackup(Pair.of(x.getKey(), x.getValue()));
+                addBackup(x.getValue());
                 return true;
             }
         }
@@ -94,7 +93,7 @@ public class RunicShearEntity extends VirtualizedRegistry<Pair<ResourceLocation,
 
     @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
-        ModRecipes.getRunicShearEntityRecipes().forEach((key, value) -> addBackup(Pair.of(key, value)));
+        ModRecipes.getRunicShearEntityRecipes().values().forEach(this::addBackup);
         ModRecipes.getRunicShearEntityRecipes().clear();
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Spells.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Spells.java
@@ -265,7 +265,7 @@ public class Spells extends VirtualizedRegistry<SpellBase> {
     public static class CostBuilder extends AbstractRecipeBuilder<Map<CostType, IModifierCost>> {
 
         @com.cleanroommc.groovyscript.api.documentation.annotations.Property
-        List<IModifierCost> list = new ArrayList<>();
+        private final List<IModifierCost> list = new ArrayList<>();
 
         @RecipeBuilderMethodDescription(field = "list")
         public CostBuilder cost(CostType cost, double value, IModifierCore herb) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/SummonCreature.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/SummonCreature.java
@@ -127,8 +127,8 @@ public class SummonCreature extends VirtualizedRegistry<Pair<ResourceLocation, S
         public @Nullable SummonCreatureRecipe register() {
             if (!validate()) return null;
             List<Ingredient> ingredients = input.stream().map(IIngredient::toMcIngredient).collect(Collectors.toList());
-            SummonCreatureRecipe recipe = new SummonCreatureRecipe(name, entity, ingredients);
-            ModSupport.ROOTS.get().summonCreature.add(name, recipe);
+            SummonCreatureRecipe recipe = new SummonCreatureRecipe(super.name, entity, ingredients);
+            ModSupport.ROOTS.get().summonCreature.add(super.name, recipe);
             return recipe;
         }
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/SummonCreature.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/SummonCreature.java
@@ -109,6 +109,7 @@ public class SummonCreature extends VirtualizedRegistry<Pair<ResourceLocation, S
             return "Error adding Roots Summon Creature recipe";
         }
 
+        @Override
         public String getRecipeNamePrefix() {
             return "groovyscript_summon_creature_";
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/SummonCreature.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/SummonCreature.java
@@ -8,6 +8,7 @@ import com.cleanroommc.groovyscript.core.mixin.roots.ModRecipesAccessor;
 import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
 import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import epicsquid.roots.init.ModRecipes;
 import epicsquid.roots.recipe.SummonCreatureRecipe;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.crafting.Ingredient;
@@ -20,8 +21,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static epicsquid.roots.init.ModRecipes.*;
-
 @RegistryDescription
 public class SummonCreature extends VirtualizedRegistry<Pair<ResourceLocation, SummonCreatureRecipe>> {
 
@@ -32,8 +31,8 @@ public class SummonCreature extends VirtualizedRegistry<Pair<ResourceLocation, S
 
     @Override
     public void onReload() {
-        removeScripted().forEach(pair -> removeSummonCreatureEntry(pair.getKey()));
-        restoreFromBackup().forEach(pair -> addSummonCreatureEntry(pair.getValue()));
+        removeScripted().forEach(pair -> ModRecipes.removeSummonCreatureEntry(pair.getKey()));
+        restoreFromBackup().forEach(pair -> ModRecipes.addSummonCreatureEntry(pair.getValue()));
     }
 
     public void add(SummonCreatureRecipe recipe) {
@@ -41,7 +40,7 @@ public class SummonCreature extends VirtualizedRegistry<Pair<ResourceLocation, S
     }
 
     public void add(ResourceLocation name, SummonCreatureRecipe recipe) {
-        addSummonCreatureEntry(recipe);
+        ModRecipes.addSummonCreatureEntry(recipe);
         addScripted(Pair.of(name, recipe));
     }
 
@@ -54,9 +53,9 @@ public class SummonCreature extends VirtualizedRegistry<Pair<ResourceLocation, S
 
     @MethodDescription(example = @Example("resource('roots:cow')"))
     public boolean removeByName(ResourceLocation name) {
-        SummonCreatureRecipe recipe = getSummonCreatureEntry(name);
+        SummonCreatureRecipe recipe = ModRecipes.getSummonCreatureEntry(name);
         if (recipe == null) return false;
-        removeSummonCreatureEntry(name);
+        ModRecipes.removeSummonCreatureEntry(name);
         addBackup(Pair.of(name, recipe));
         return true;
     }
@@ -70,7 +69,7 @@ public class SummonCreature extends VirtualizedRegistry<Pair<ResourceLocation, S
     public boolean removeByEntity(Class<? extends EntityLivingBase> clazz) {
         for (Map.Entry<ResourceLocation, SummonCreatureRecipe> x : ModRecipesAccessor.getSummonCreatureEntries().entrySet()) {
             if (x.getValue().getClazz() == clazz) {
-                removeSummonCreatureEntry(x.getKey());
+                ModRecipes.removeSummonCreatureEntry(x.getKey());
                 addBackup(Pair.of(x.getKey(), x.getValue()));
                 return true;
             }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/SummonCreature.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/SummonCreature.java
@@ -14,7 +14,6 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.crafting.Ingredient;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.common.registry.EntityEntry;
-import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
@@ -22,7 +21,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 @RegistryDescription
-public class SummonCreature extends VirtualizedRegistry<Pair<ResourceLocation, SummonCreatureRecipe>> {
+public class SummonCreature extends VirtualizedRegistry<SummonCreatureRecipe> {
 
     @RecipeBuilderDescription(example = @Example(".name('wither_skeleton_from_clay').input(item('minecraft:clay'), item('minecraft:clay'), item('minecraft:clay'), item('minecraft:clay'), item('minecraft:clay')).entity(entity('minecraft:wither_skeleton'))"))
     public static RecipeBuilder recipeBuilder() {
@@ -31,8 +30,8 @@ public class SummonCreature extends VirtualizedRegistry<Pair<ResourceLocation, S
 
     @Override
     public void onReload() {
-        removeScripted().forEach(pair -> ModRecipes.removeSummonCreatureEntry(pair.getKey()));
-        restoreFromBackup().forEach(pair -> ModRecipes.addSummonCreatureEntry(pair.getValue()));
+        removeScripted().forEach(recipe -> ModRecipes.removeSummonCreatureEntry(recipe.getRegistryName()));
+        restoreFromBackup().forEach(ModRecipes::addSummonCreatureEntry);
     }
 
     public void add(SummonCreatureRecipe recipe) {
@@ -41,7 +40,7 @@ public class SummonCreature extends VirtualizedRegistry<Pair<ResourceLocation, S
 
     public void add(ResourceLocation name, SummonCreatureRecipe recipe) {
         ModRecipes.addSummonCreatureEntry(recipe);
-        addScripted(Pair.of(name, recipe));
+        addScripted(recipe);
     }
 
     public ResourceLocation findRecipe(SummonCreatureRecipe recipe) {
@@ -56,7 +55,7 @@ public class SummonCreature extends VirtualizedRegistry<Pair<ResourceLocation, S
         SummonCreatureRecipe recipe = ModRecipes.getSummonCreatureEntry(name);
         if (recipe == null) return false;
         ModRecipes.removeSummonCreatureEntry(name);
-        addBackup(Pair.of(name, recipe));
+        addBackup(recipe);
         return true;
     }
 
@@ -70,7 +69,7 @@ public class SummonCreature extends VirtualizedRegistry<Pair<ResourceLocation, S
         for (Map.Entry<ResourceLocation, SummonCreatureRecipe> x : ModRecipesAccessor.getSummonCreatureEntries().entrySet()) {
             if (x.getValue().getClazz() == clazz) {
                 ModRecipes.removeSummonCreatureEntry(x.getKey());
-                addBackup(Pair.of(x.getKey(), x.getValue()));
+                addBackup(x.getValue());
                 return true;
             }
         }
@@ -79,7 +78,7 @@ public class SummonCreature extends VirtualizedRegistry<Pair<ResourceLocation, S
 
     @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
-        ModRecipesAccessor.getSummonCreatureEntries().forEach((key, value) -> addBackup(Pair.of(key, value)));
+        ModRecipesAccessor.getSummonCreatureEntries().values().forEach(this::addBackup);
         ModRecipesAccessor.getSummonCreatureEntries().clear();
         ModRecipesAccessor.getSummonCreatureClasses().clear();
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Transmutation.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Transmutation.java
@@ -187,11 +187,11 @@ public class Transmutation extends VirtualizedRegistry<Pair<ResourceLocation, Tr
         public @Nullable TransmutationRecipe register() {
             if (!validate()) return null;
             TransmutationRecipe recipe = new TransmutationRecipe(start);
-            recipe.setRegistryName(name);
+            recipe.setRegistryName(super.name);
             if (state == null) recipe.item(output.get(0));
             else recipe.state(state);
             recipe.condition(condition);
-            ModSupport.ROOTS.get().transmutation.add(name, recipe);
+            ModSupport.ROOTS.get().transmutation.add(super.name, recipe);
             return recipe;
         }
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Transmutation.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Transmutation.java
@@ -168,6 +168,7 @@ public class Transmutation extends VirtualizedRegistry<Pair<ResourceLocation, Tr
             return "Error adding Roots Transmutation recipe";
         }
 
+        @Override
         public String getRecipeNamePrefix() {
             return "groovyscript_transmutation_";
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Transmutation.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Transmutation.java
@@ -7,6 +7,7 @@ import com.cleanroommc.groovyscript.core.mixin.roots.ModRecipesAccessor;
 import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
 import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import epicsquid.roots.init.ModRecipes;
 import epicsquid.roots.recipe.TransmutationRecipe;
 import epicsquid.roots.recipe.transmutation.BlockStatePredicate;
 import epicsquid.roots.recipe.transmutation.StatePredicate;
@@ -22,8 +23,6 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 
-import static epicsquid.roots.init.ModRecipes.removeTransmutationRecipe;
-
 @RegistryDescription
 public class Transmutation extends VirtualizedRegistry<Pair<ResourceLocation, TransmutationRecipe>> {
 
@@ -38,7 +37,7 @@ public class Transmutation extends VirtualizedRegistry<Pair<ResourceLocation, Tr
 
     @Override
     public void onReload() {
-        removeScripted().forEach(pair -> removeTransmutationRecipe(pair.getKey()));
+        removeScripted().forEach(pair -> ModRecipes.removeTransmutationRecipe(pair.getKey()));
         restoreFromBackup().forEach(pair -> ModRecipesAccessor.getTransmutationRecipes().put(pair.getKey(), pair.getValue()));
     }
 
@@ -62,7 +61,7 @@ public class Transmutation extends VirtualizedRegistry<Pair<ResourceLocation, Tr
     public boolean removeByName(ResourceLocation name) {
         TransmutationRecipe recipe = ModRecipesAccessor.getTransmutationRecipes().get(name);
         if (recipe == null) return false;
-        removeTransmutationRecipe(name);
+        ModRecipes.removeTransmutationRecipe(name);
         addBackup(Pair.of(name, recipe));
         return true;
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/rustic/Alchemy.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/rustic/Alchemy.java
@@ -53,7 +53,7 @@ public class Alchemy extends VirtualizedRegistry<ICondenserRecipe> {
         return Recipes.condenserRecipes.remove(recipe);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("item('rustic:elixir').withNbt(['ElixirEffects': [['Effect': 'minecraft:night_vision', 'Duration': 3600, 'Amplifier': 0]]])"))
+    @MethodDescription(example = @Example("item('rustic:elixir').withNbt(['ElixirEffects': [['Effect': 'minecraft:night_vision', 'Duration': 3600, 'Amplifier': 0]]])"))
     public boolean removeByOutput(IIngredient output) {
         return Recipes.condenserRecipes.removeIf(entry -> {
             if (output.test(entry.getResult())) {
@@ -64,7 +64,7 @@ public class Alchemy extends VirtualizedRegistry<ICondenserRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('minecraft:sugar')"))
+    @MethodDescription(example = @Example("item('minecraft:sugar')"))
     public boolean removeByInput(IIngredient input) {
         return Recipes.condenserRecipes.removeIf(entry -> {
             if (entry.getInputs().stream().flatMap(Collection::stream).anyMatch(input)) {
@@ -75,13 +75,13 @@ public class Alchemy extends VirtualizedRegistry<ICondenserRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         Recipes.condenserRecipes.forEach(this::addBackup);
         Recipes.condenserRecipes.clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<ICondenserRecipe> streamRecipes() {
         return new SimpleObjectStream<>(Recipes.condenserRecipes).setRemover(this::remove);
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/rustic/BrewingBarrel.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/rustic/BrewingBarrel.java
@@ -39,7 +39,7 @@ public class BrewingBarrel extends VirtualizedRegistry<IBrewingBarrelRecipe> {
         return Recipes.brewingRecipes.remove(recipe);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example("fluid('ale')"))
+    @MethodDescription(example = @Example("fluid('ale')"))
     public boolean removeByOutput(IIngredient output) {
         return Recipes.brewingRecipes.removeIf(entry -> {
             if (output.test(entry.getOuput())) {
@@ -50,7 +50,7 @@ public class BrewingBarrel extends VirtualizedRegistry<IBrewingBarrelRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("fluid('ironberryjuice')"))
+    @MethodDescription(example = @Example("fluid('ironberryjuice')"))
     public boolean removeByInput(IIngredient input) {
         return Recipes.brewingRecipes.removeIf(entry -> {
             if (input.test(entry.getInput())) {
@@ -61,13 +61,13 @@ public class BrewingBarrel extends VirtualizedRegistry<IBrewingBarrelRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         Recipes.brewingRecipes.forEach(this::addBackup);
         Recipes.brewingRecipes.clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<IBrewingBarrelRecipe> streamRecipes() {
         return new SimpleObjectStream<>(Recipes.brewingRecipes).setRemover(this::remove);
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/rustic/CondenserRecipe.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/rustic/CondenserRecipe.java
@@ -59,6 +59,7 @@ public class CondenserRecipe implements ICondenserRecipe {
         this.advanced = advanced;
     }
 
+    @Override
     public boolean matches(Fluid fluid, ItemStack modifier, ItemStack bottle, ItemStack[] inputs) {
         if (fluid == this.fluid.getFluid() &&
             (this.modifier == null || this.modifier.test(modifier)) &&
@@ -89,42 +90,52 @@ public class CondenserRecipe implements ICondenserRecipe {
         return false;
     }
 
+    @Override
     public boolean isBasic() {
         return !this.advanced;
     }
 
+    @Override
     public boolean isAdvanced() {
         return this.advanced;
     }
 
+    @Override
     public FluidStack getFluid() {
         return this.fluid;
     }
 
+    @Override
     public List<ItemStack> getModifiers() {
         return modifier == null ? EMPTY_LIST : Arrays.asList(modifier.getMatchingStacks());
     }
 
+    @Override
     public List<ItemStack> getBottles() {
         return bottle == null ? EMPTY_LIST : Arrays.asList(bottle.getMatchingStacks());
     }
 
+    @Override
     public List<List<ItemStack>> getInputs() {
         return this.inputs.stream().map(x -> Arrays.asList(x.getMatchingStacks())).collect(Collectors.toList());
     }
 
+    @Override
     public int getTime() {
         return this.time;
     }
 
+    @Override
     public int getModifierConsumption(ItemStack modifier) {
         return this.modifier != null && this.modifier.test(modifier) ? modifier.getCount() : 0;
     }
 
+    @Override
     public int getBottleConsumption(ItemStack bottle) {
         return this.bottle != null && this.bottle.test(bottle) ? bottle.getCount() : 0;
     }
 
+    @Override
     public int[] getInputConsumption(ItemStack[] inputs) {
         int[] consume = new int[inputs.length];
         for (int i = 0; i < inputs.length; i++) {
@@ -141,6 +152,7 @@ public class CondenserRecipe implements ICondenserRecipe {
         return consume;
     }
 
+    @Override
     public ItemStack getResult() {
         return this.output.copy();
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/rustic/CrushingTub.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/rustic/CrushingTub.java
@@ -40,7 +40,7 @@ public class CrushingTub extends VirtualizedRegistry<ICrushingTubRecipe> {
         return Recipes.crushingTubRecipes.remove(recipe);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = {@Example("fluid('ironberryjuice')"), @Example("item('minecraft:sugar')")})
+    @MethodDescription(example = {@Example("fluid('ironberryjuice')"), @Example("item('minecraft:sugar')")})
     public boolean removeByOutput(IIngredient output) {
         return Recipes.crushingTubRecipes.removeIf(entry -> {
             if (output.test(entry.getResult()) || output.test(entry.getByproduct())) {
@@ -51,7 +51,7 @@ public class CrushingTub extends VirtualizedRegistry<ICrushingTubRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("item('rustic:wildberries')"))
+    @MethodDescription(example = @Example("item('rustic:wildberries')"))
     public boolean removeByInput(IIngredient input) {
         return Recipes.crushingTubRecipes.removeIf(entry -> {
             if (input.test(entry.getInput())) {
@@ -62,13 +62,13 @@ public class CrushingTub extends VirtualizedRegistry<ICrushingTubRecipe> {
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         Recipes.crushingTubRecipes.forEach(this::addBackup);
         Recipes.crushingTubRecipes.clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<ICrushingTubRecipe> streamRecipes() {
         return new SimpleObjectStream<>(Recipes.crushingTubRecipes).setRemover(this::remove);
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/rustic/EvaporatingBasin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/rustic/EvaporatingBasin.java
@@ -49,7 +49,7 @@ public class EvaporatingBasin extends VirtualizedRegistry<IEvaporatingBasinRecip
         return Recipes.evaporatingRecipes.remove(recipe);
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByOutput", example = @Example(value = "item('rustic:dust_tiny_iron')", commented = true))
+    @MethodDescription(example = @Example(value = "item('rustic:dust_tiny_iron')", commented = true))
     public boolean removeByOutput(IIngredient output) {
         return Recipes.evaporatingRecipes.removeIf(entry -> {
             if (output.test(entry.getOutput())) {
@@ -60,7 +60,7 @@ public class EvaporatingBasin extends VirtualizedRegistry<IEvaporatingBasinRecip
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeByInput", example = @Example("fluid('ironberryjuice')"))
+    @MethodDescription(example = @Example("fluid('ironberryjuice')"))
     public boolean removeByInput(IIngredient input) {
         return Recipes.evaporatingRecipes.removeIf(entry -> {
             if (input.test(entry.getInput())) {
@@ -71,13 +71,13 @@ public class EvaporatingBasin extends VirtualizedRegistry<IEvaporatingBasinRecip
         });
     }
 
-    @MethodDescription(description = "groovyscript.wiki.removeAll", priority = 2000, example = @Example(commented = true))
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         Recipes.evaporatingRecipes.forEach(this::addBackup);
         Recipes.evaporatingRecipes.clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<IEvaporatingBasinRecipe> streamRecipes() {
         return new SimpleObjectStream<>(Recipes.evaporatingRecipes).setRemover(this::remove);
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/rustic/ExtendedEvaporatingBasinRecipe.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/rustic/ExtendedEvaporatingBasinRecipe.java
@@ -13,6 +13,7 @@ public class ExtendedEvaporatingBasinRecipe extends EvaporatingBasinRecipe {
         this.time = time;
     }
 
+    @Override
     public int getTime() {
         return time;
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/tcomplement/HighOven.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/tcomplement/HighOven.java
@@ -47,6 +47,7 @@ public class HighOven extends MeltingRecipeRegistry {
         return recipe;
     }
 
+    @Override
     public void add(MeltingRecipe recipe) {
         if (recipe == null) return;
         addScripted(recipe);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/tcomplement/Melter.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/tcomplement/Melter.java
@@ -45,6 +45,7 @@ public class Melter extends MeltingRecipeRegistry {
         return recipe;
     }
 
+    @Override
     public void add(MeltingRecipe recipe) {
         if (recipe == null) return;
         addScripted(recipe);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/tcomplement/Melter.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/tcomplement/Melter.java
@@ -18,7 +18,7 @@ import slimeknights.tconstruct.library.smeltery.MeltingRecipe;
 public class Melter extends MeltingRecipeRegistry {
 
     @GroovyBlacklist
-    protected AbstractReloadableStorage<IBlacklist> backupStorage = new AbstractReloadableStorage<>();
+    protected final AbstractReloadableStorage<IBlacklist> backupStorage = new AbstractReloadableStorage<>();
 
     public MeltingRecipeBuilder recipeBuilder() {
         return new MeltingRecipeBuilder(this, "Tinkers Complement Melter override");

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/DustTrigger.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/DustTrigger.java
@@ -30,7 +30,7 @@ public class DustTrigger extends VirtualizedRegistry<IDustTrigger> {
 
     private Field simpleTriggerResult;
     private Field oreTriggerResult;
-    private boolean didReflection = false;
+    private boolean didReflection;
 
     private void doDirtyReflection() {
         if (!didReflection) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/InfusionCrafting.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/InfusionCrafting.java
@@ -93,8 +93,7 @@ public class InfusionCrafting extends VirtualizedRegistry<Pair<ResourceLocation,
         }
         List<InfusionRecipe> recipes = new ArrayList<>();
         for (IThaumcraftRecipe r : ThaumcraftApi.getCraftingRecipes().values()) {
-            if (r instanceof InfusionRecipe && ((InfusionRecipe) r).getRecipeOutput() instanceof ItemStack) {
-                ItemStack ro = (ItemStack) ((InfusionRecipe) r).getRecipeOutput();
+            if (r instanceof InfusionRecipe && ((InfusionRecipe) r).getRecipeOutput() instanceof ItemStack ro) {
                 if (output.test(ro)) {
                     recipes.add((InfusionRecipe) r);
                 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/LootBag.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/LootBag.java
@@ -43,17 +43,15 @@ public class LootBag extends VirtualizedRegistry<LootBag.InternalLootbag> {
     }
 
     private static ArrayList<WeightedRandomLoot> getLootbag(int rarity) {
-        switch (rarity) {
-            case 0:
-                return WeightedRandomLoot.lootBagCommon;
-            case 1:
-                return WeightedRandomLoot.lootBagUncommon;
-            case 2:
-                return WeightedRandomLoot.lootBagRare;
-            default:
+        return switch (rarity) {
+            case 0 -> WeightedRandomLoot.lootBagCommon;
+            case 1 -> WeightedRandomLoot.lootBagUncommon;
+            case 2 -> WeightedRandomLoot.lootBagRare;
+            default -> {
                 GroovyLog.msg("Error: Thaumcraft Lootbag type not specified. Please use Lootbag.getCommon(), Lootbag.getUncommon(), or Lootbag.getRare().").error().post();
-                return new ArrayList<>();
-        }
+                yield new ArrayList<>();
+            }
+        };
     }
 
     @MethodDescription(type = MethodDescription.Type.ADDITION, example = {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/LootBag.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/LootBag.java
@@ -67,7 +67,7 @@ public class LootBag extends VirtualizedRegistry<LootBag.InternalLootbag> {
 
     @MethodDescription(example = @Example("item('minecraft:ender_pearl'), 0"))
     public void remove(ItemStack item, int rarity) {
-        ArrayList<WeightedRandomLoot> list = getLootbag(rarity);
+        List<WeightedRandomLoot> list = getLootbag(rarity);
         List<WeightedRandomLoot> remove = new ArrayList<>();
         for (WeightedRandomLoot loot : list) {
             if (item.isItemEqual(loot.item)) {
@@ -80,7 +80,7 @@ public class LootBag extends VirtualizedRegistry<LootBag.InternalLootbag> {
 
     @MethodDescription(example = @Example("2"))
     public void removeAll(int rarity) {
-        ArrayList<WeightedRandomLoot> list = getLootbag(rarity);
+        List<WeightedRandomLoot> list = getLootbag(rarity);
         List<WeightedRandomLoot> remove = new ArrayList<>();
         for (WeightedRandomLoot loot : list) {
             remove.add(loot);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/Research.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/Research.java
@@ -150,7 +150,7 @@ public class Research extends VirtualizedRegistry<ResearchCategory> {
         @Property
         private ResourceLocation background;
         @Property
-        private ResourceLocation background2 = null;
+        private ResourceLocation background2;
 
         @RecipeBuilderMethodDescription
         public ResearchCategoryBuilder key(String key) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/Research.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/Research.java
@@ -22,7 +22,7 @@ import thaumcraft.common.lib.research.ScanPotion;
 @RegistryDescription
 public class Research extends VirtualizedRegistry<ResearchCategory> {
 
-    protected AbstractReloadableStorage<IScanThing> scanStorage = new AbstractReloadableStorage<>();
+    protected final AbstractReloadableStorage<IScanThing> scanStorage = new AbstractReloadableStorage<>();
 
     @Override
     public void onReload() {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/SmeltingBonus.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/SmeltingBonus.java
@@ -96,9 +96,9 @@ public class SmeltingBonus extends VirtualizedRegistry<ThaumcraftApi.SmeltBonus>
     public static class SmeltingBonusBuilder {
 
         @Property(valid = @Comp(value = "null", type = Comp.Type.NOT))
-        private IIngredient in = null;
+        private IIngredient in;
         @Property(valid = @Comp(value = "null", type = Comp.Type.NOT))
-        private ItemStack out = null;
+        private ItemStack out;
         @Property(defaultValue = "0.33F")
         private float chance = 0.33F;
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/arcane/ArcaneWorkbench.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/arcane/ArcaneWorkbench.java
@@ -1,6 +1,5 @@
 package com.cleanroommc.groovyscript.compat.mods.thaumcraft.arcane;
 
-import com.cleanroommc.groovyscript.api.GroovyBlacklist;
 import com.cleanroommc.groovyscript.api.IIngredient;
 import com.cleanroommc.groovyscript.api.documentation.annotations.Example;
 import com.cleanroommc.groovyscript.api.documentation.annotations.MethodDescription;
@@ -9,7 +8,6 @@ import com.cleanroommc.groovyscript.api.documentation.annotations.RegistryDescri
 import com.cleanroommc.groovyscript.compat.vanilla.VanillaModule;
 import com.cleanroommc.groovyscript.registry.NamedRegistry;
 import com.cleanroommc.groovyscript.registry.ReloadableRegistryManager;
-import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
 import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/arcane/ShapelessArcaneCR.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/arcane/ShapelessArcaneCR.java
@@ -79,6 +79,7 @@ public class ShapelessArcaneCR extends ShapelessArcaneRecipe implements ICraftin
     /**
      * Stolen from {@link thaumcraft.api.crafting.ShapelessArcaneRecipe#matches(InventoryCrafting, World)}
      */
+    @Override
     public boolean matches(@NotNull InventoryCrafting inv, @NotNull World world) {
         if (!(inv instanceof IArcaneWorkbench)) return false;
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/aspect/AspectHelper.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/aspect/AspectHelper.java
@@ -306,7 +306,7 @@ public class AspectHelper extends VirtualizedRegistry<AspectListHelper> {
         @Property(requirement = "groovyscript.wiki.thaumcraft.aspect_helper.target.required")
         private IIngredient object;
         @Property
-        private final ArrayList<AspectStack> aspects = new ArrayList<>();
+        private final List<AspectStack> aspects = new ArrayList<>();
         @Property
         private boolean stripAspects;
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Magmatic.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Magmatic.java
@@ -1,6 +1,5 @@
 package com.cleanroommc.groovyscript.compat.mods.thermalexpansion.dynamo;
 
-import cofh.core.inventory.ComparableItemStack;
 import com.cleanroommc.groovyscript.api.GroovyBlacklist;
 import com.cleanroommc.groovyscript.api.documentation.annotations.Example;
 import com.cleanroommc.groovyscript.api.documentation.annotations.MethodDescription;
@@ -9,7 +8,6 @@ import com.cleanroommc.groovyscript.core.mixin.thermalexpansion.MagmaticManagerA
 import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
 import com.github.bsideup.jabel.Desugar;
-import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 import org.jetbrains.annotations.ApiStatus;
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/machine/Compactor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/machine/Compactor.java
@@ -27,9 +27,9 @@ import java.util.stream.Collectors;
 public class Compactor extends VirtualizedRegistry<Pair<CompactorManager.Mode, CompactorRecipe>> {
 
     @RecipeBuilderDescription(example = {
-            @Example(".input(item('minecraft:clay')).output(item('minecraft:diamond') * 2).mode(mode('coin'))"),
-            @Example(".input(item('minecraft:clay')).output(item('minecraft:diamond')).mode(mode('all'))"),
-            @Example(".input(item('minecraft:diamond') * 2).output(item('minecraft:gold_ingot')).mode(mode('plate')).energy(1000)")
+            @Example(".input(item('minecraft:clay')).output(item('minecraft:diamond') * 2).mode(compactorMode('coin'))"),
+            @Example(".input(item('minecraft:clay')).output(item('minecraft:diamond')).mode(compactorMode('all'))"),
+            @Example(".input(item('minecraft:diamond') * 2).output(item('minecraft:gold_ingot')).mode(compactorMode('plate')).energy(1000)")
     })
     public RecipeBuilder recipeBuilder() {
         return new RecipeBuilder();
@@ -57,7 +57,7 @@ public class Compactor extends VirtualizedRegistry<Pair<CompactorManager.Mode, C
         addScripted(Pair.of(mode, recipe));
     }
 
-    @MethodDescription(type = MethodDescription.Type.ADDITION, example = @Example(value = "1000, mode('plate'), item('minecraft:obsidian') * 2, item('minecraft:gold_ingot')", commented = true))
+    @MethodDescription(type = MethodDescription.Type.ADDITION, example = @Example(value = "1000, compactorMode('plate'), item('minecraft:obsidian') * 2, item('minecraft:gold_ingot')", commented = true))
     public CompactorRecipe add(int energy, CompactorManager.Mode mode, IIngredient input, ItemStack output) {
         return recipeBuilder()
                 .energy(energy)
@@ -85,7 +85,7 @@ public class Compactor extends VirtualizedRegistry<Pair<CompactorManager.Mode, C
         return hasRemoved;
     }
 
-    @MethodDescription(example = @Example("mode('coin'), item('thermalfoundation:material:130')"))
+    @MethodDescription(example = @Example("compactorMode('coin'), item('thermalfoundation:material:130')"))
     public boolean removeByInput(CompactorManager.Mode mode, IIngredient input) {
         return map(mode).values().removeIf(r -> {
             if (input.test(r.getInput())) {
@@ -105,7 +105,7 @@ public class Compactor extends VirtualizedRegistry<Pair<CompactorManager.Mode, C
         return hasRemoved;
     }
 
-    @MethodDescription(example = @Example("mode('coin'), item('thermalfoundation:coin:102')"))
+    @MethodDescription(example = @Example("compactorMode('coin'), item('thermalfoundation:coin:102')"))
     public boolean removeByOutput(CompactorManager.Mode mode, IIngredient output) {
         return map(mode).values().removeIf(r -> {
             if (output.test(r.getOutput())) {
@@ -133,7 +133,7 @@ public class Compactor extends VirtualizedRegistry<Pair<CompactorManager.Mode, C
                 .setRemover(this::remove);
     }
 
-    @MethodDescription(example = @Example(value = "mode('plate')", commented = true))
+    @MethodDescription(example = @Example(value = "compactorMode('plate')", commented = true))
     public void removeByMode(CompactorManager.Mode mode) {
         map(mode).values().forEach(x -> addBackup(Pair.of(mode, x)));
         map(mode).clear();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/tinkersconstruct/CastingBasin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/tinkersconstruct/CastingBasin.java
@@ -115,7 +115,7 @@ public class CastingBasin extends VirtualizedRegistry<ICastingRecipe> {
         @Property(defaultValue = "200", valid = @Comp(value = "1", type = Comp.Type.GTE))
         private int time = 200;
         @Property
-        private boolean consumesCast = false;
+        private boolean consumesCast;
 
         @RecipeBuilderMethodDescription(field = "time")
         public RecipeBuilder coolingTime(int time) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/tinkersconstruct/CastingTable.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/tinkersconstruct/CastingTable.java
@@ -114,7 +114,7 @@ public class CastingTable extends VirtualizedRegistry<ICastingRecipe> {
         @Property(defaultValue = "200", valid = @Comp(value = "1", type = Comp.Type.GTE))
         private int time = 200;
         @Property
-        private boolean consumesCast = false;
+        private boolean consumesCast;
 
         @RecipeBuilderMethodDescription(field = "time")
         public RecipeBuilder coolingTime(int time) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/tinkersconstruct/EntityMelting.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/tinkersconstruct/EntityMelting.java
@@ -93,7 +93,7 @@ public class EntityMelting extends VirtualizedRegistry<EntityMeltingRecipe> {
         TinkerRegistryAccessor.getEntityMeltingRegistry().clear();
     }
 
-    @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
+    @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<EntityMeltingRecipe> streamRecipes() {
         return new SimpleObjectStream<>(getAllRecipes()).setRemover(this::remove);
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/tinkersconstruct/Melting.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/tinkersconstruct/Melting.java
@@ -38,6 +38,7 @@ public class Melting extends MeltingRecipeRegistry {
         return recipe;
     }
 
+    @Override
     public void add(MeltingRecipe recipe) {
         if (recipe == null) return;
         addScripted(recipe);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/tinkersconstruct/material/GroovyMaterial.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/tinkersconstruct/material/GroovyMaterial.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 
 public class GroovyMaterial extends Material {
 
-    public boolean hidden = false;
+    public boolean hidden;
     public IIngredient representativeItem;
     public IIngredient shard;
     public FluidStack fluidStack;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/tinkersconstruct/material/ToolMaterialBuilder.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/tinkersconstruct/material/ToolMaterialBuilder.java
@@ -35,8 +35,8 @@ public class ToolMaterialBuilder {
     public IIngredient representativeItem;
     public IIngredient shard;
     public BiFunction<Material, String, String> localizer;
-    protected Map<String, List<String>> traits = new HashMap<>();
-    protected List<MaterialRepairIngredient> repairIngredients = new ArrayList<>();
+    protected final Map<String, List<String>> traits = new HashMap<>();
+    protected final List<MaterialRepairIngredient> repairIngredients = new ArrayList<>();
     protected final Map<String, IMaterialStats> stats = new HashMap<>(8);
 
     public ToolMaterialBuilder(String name) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/tinkersconstruct/material/ToolMaterialBuilder.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/tinkersconstruct/material/ToolMaterialBuilder.java
@@ -27,8 +27,8 @@ public class ToolMaterialBuilder {
 
     public final String name;
     public int color = 0xFFFFFF;
-    public boolean hidden = false;
-    public boolean craftable = false;
+    public boolean hidden;
+    public boolean craftable;
     public boolean castable = true;
     public String displayName;
     public FluidStack fluid;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/tinkersconstruct/recipe/SmelteryFuelRecipe.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/tinkersconstruct/recipe/SmelteryFuelRecipe.java
@@ -21,9 +21,7 @@ public class SmelteryFuelRecipe {
     @Override
     public boolean equals(Object obj) {
         if (obj == null) return false;
-        if (!(obj instanceof SmelteryFuelRecipe)) return false;
-
-        SmelteryFuelRecipe other = (SmelteryFuelRecipe) obj;
+        if (!(obj instanceof SmelteryFuelRecipe other)) return false;
 
         if (other.duration != duration) return false;
         return !other.fluid.isFluidStackIdentical(fluid);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/woot/Drops.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/woot/Drops.java
@@ -145,6 +145,7 @@ public class Drops extends VirtualizedRegistry<Object> {
             return this;
         }
 
+        @Override
         @RecipeBuilderMethodDescription
         public RecipeBuilder name(String name) {
             this.name = new WootMobName(name);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/woot/Policy.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/woot/Policy.java
@@ -20,46 +20,22 @@ public class Policy extends VirtualizedRegistry<Pair<Policy.PolicyType, Object>>
     public void onReload() {
         restoreFromBackup().forEach(pair -> {
             switch (pair.getKey()) {
-                case ENTITY_MOD_BLACKLIST:
-                    ((PolicyRepositoryAccessor) Woot.policyRepository).getExternalModBlacklist().add((String) pair.getValue());
-                    break;
-                case ENTITY_BLACKLIST:
-                    ((PolicyRepositoryAccessor) Woot.policyRepository).getExternalEntityBlacklist().add((WootMobName) pair.getValue());
-                    break;
-                case ITEM_MOD_BLACKLIST:
-                    ((PolicyRepositoryAccessor) Woot.policyRepository).getExternalItemModBlacklist().add((String) pair.getValue());
-                    break;
-                case ITEM_BLACKLIST:
-                    ((PolicyRepositoryAccessor) Woot.policyRepository).getExternalItemBlacklist().add((ItemStack) pair.getValue());
-                    break;
-                case ENTITY_WHITELIST:
-                    ((PolicyRepositoryAccessor) Woot.policyRepository).getExternalEntityWhitelist().add((WootMobName) pair.getValue());
-                    break;
-                case GENERATE_ONLY_LIST:
-                    ((PolicyRepositoryAccessor) Woot.policyRepository).getExternalGenerateOnlyList().add((WootMobName) pair.getValue());
-                    break;
+                case ENTITY_MOD_BLACKLIST -> ((PolicyRepositoryAccessor) Woot.policyRepository).getExternalModBlacklist().add((String) pair.getValue());
+                case ENTITY_BLACKLIST -> ((PolicyRepositoryAccessor) Woot.policyRepository).getExternalEntityBlacklist().add((WootMobName) pair.getValue());
+                case ITEM_MOD_BLACKLIST -> ((PolicyRepositoryAccessor) Woot.policyRepository).getExternalItemModBlacklist().add((String) pair.getValue());
+                case ITEM_BLACKLIST -> ((PolicyRepositoryAccessor) Woot.policyRepository).getExternalItemBlacklist().add((ItemStack) pair.getValue());
+                case ENTITY_WHITELIST -> ((PolicyRepositoryAccessor) Woot.policyRepository).getExternalEntityWhitelist().add((WootMobName) pair.getValue());
+                case GENERATE_ONLY_LIST -> ((PolicyRepositoryAccessor) Woot.policyRepository).getExternalGenerateOnlyList().add((WootMobName) pair.getValue());
             }
         });
         removeScripted().forEach(pair -> {
             switch (pair.getKey()) {
-                case ENTITY_MOD_BLACKLIST:
-                    ((PolicyRepositoryAccessor) Woot.policyRepository).getExternalModBlacklist().remove((String) pair.getValue());
-                    break;
-                case ENTITY_BLACKLIST:
-                    ((PolicyRepositoryAccessor) Woot.policyRepository).getExternalEntityBlacklist().remove((WootMobName) pair.getValue());
-                    break;
-                case ITEM_MOD_BLACKLIST:
-                    ((PolicyRepositoryAccessor) Woot.policyRepository).getExternalItemModBlacklist().remove((String) pair.getValue());
-                    break;
-                case ITEM_BLACKLIST:
-                    ((PolicyRepositoryAccessor) Woot.policyRepository).getExternalItemBlacklist().remove((ItemStack) pair.getValue());
-                    break;
-                case ENTITY_WHITELIST:
-                    ((PolicyRepositoryAccessor) Woot.policyRepository).getExternalEntityWhitelist().remove((WootMobName) pair.getValue());
-                    break;
-                case GENERATE_ONLY_LIST:
-                    ((PolicyRepositoryAccessor) Woot.policyRepository).getExternalGenerateOnlyList().remove((WootMobName) pair.getValue());
-                    break;
+                case ENTITY_MOD_BLACKLIST -> ((PolicyRepositoryAccessor) Woot.policyRepository).getExternalModBlacklist().remove((String) pair.getValue());
+                case ENTITY_BLACKLIST -> ((PolicyRepositoryAccessor) Woot.policyRepository).getExternalEntityBlacklist().remove((WootMobName) pair.getValue());
+                case ITEM_MOD_BLACKLIST -> ((PolicyRepositoryAccessor) Woot.policyRepository).getExternalItemModBlacklist().remove((String) pair.getValue());
+                case ITEM_BLACKLIST -> ((PolicyRepositoryAccessor) Woot.policyRepository).getExternalItemBlacklist().remove((ItemStack) pair.getValue());
+                case ENTITY_WHITELIST -> ((PolicyRepositoryAccessor) Woot.policyRepository).getExternalEntityWhitelist().remove((WootMobName) pair.getValue());
+                case GENERATE_ONLY_LIST -> ((PolicyRepositoryAccessor) Woot.policyRepository).getExternalGenerateOnlyList().remove((WootMobName) pair.getValue());
             }
         });
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/woot/Spawning.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/woot/Spawning.java
@@ -134,6 +134,7 @@ public class Spawning extends VirtualizedRegistry<Pair<WootMobName, SpawnRecipe>
             return this;
         }
 
+        @Override
         @RecipeBuilderMethodDescription
         public RecipeBuilder name(String name) {
             this.name = new WootMobName(name);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/woot/Spawning.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/woot/Spawning.java
@@ -104,7 +104,7 @@ public class Spawning extends VirtualizedRegistry<Pair<WootMobName, SpawnRecipe>
     public static class RecipeBuilder extends AbstractRecipeBuilder<ISpawnRecipe> {
 
         @Property(requirement = "groovyscript.wiki.woot.spawning.modifying.required")
-        private boolean defaultSpawnRecipe = false;
+        private boolean defaultSpawnRecipe;
         @Property(ignoresInheritedMethods = true, requirement = "groovyscript.wiki.woot.spawning.modifying.required")
         private WootMobName name;
         //@Property

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/woot/StygianIronAnvil.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/woot/StygianIronAnvil.java
@@ -106,7 +106,7 @@ public class StygianIronAnvil extends VirtualizedRegistry<IAnvilRecipe> {
         @Property(defaultValue = "ItemStack.EMPTY", valid = @Comp(value = "isEmpty", type = Comp.Type.NOT))
         private ItemStack base = ItemStack.EMPTY;
         @Property
-        private boolean preserveBase = false;
+        private boolean preserveBase;
 
         @RecipeBuilderMethodDescription
         public RecipeBuilder base(ItemStack base) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/CraftingRecipe.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/CraftingRecipe.java
@@ -54,8 +54,7 @@ public abstract class CraftingRecipe extends IForgeRegistryEntry.Impl<IRecipe> i
             MatchList matchList = getMatchingList(inv);
             Object2ObjectOpenHashMap<String, ItemStack> marks = new Object2ObjectOpenHashMap<>();
             for (SlotMatchResult matchResult : matchList) {
-                if (matchResult.getRecipeIngredient() instanceof IMarkable) {
-                    IMarkable markable = (IMarkable) matchResult.getRecipeIngredient();
+                if (matchResult.getRecipeIngredient() instanceof IMarkable markable) {
                     if (!input.isEmpty() && markable.hasMark()) {
                         marks.put(markable.getMark(), matchResult.getGivenInput().copy());
                     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/Furnace.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/Furnace.java
@@ -188,11 +188,13 @@ public class Furnace extends VirtualizedRegistry<Furnace.Recipe> {
         private ItemStack output;
         private float exp = 0.1f;
 
+        @Override
         public RecipeBuilder input(IIngredient input) {
             this.input = input;
             return this;
         }
 
+        @Override
         public RecipeBuilder output(ItemStack output) {
             this.output = output;
             return this;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/FurnaceRecipeManager.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/FurnaceRecipeManager.java
@@ -11,7 +11,7 @@ import java.util.Objects;
 @GroovyBlacklist
 public class FurnaceRecipeManager {
 
-    public static ObjectOpenCustomHashSet<ItemStack> inputMap = new ObjectOpenCustomHashSet<>(new Hash.Strategy<>() {
+    public static final ObjectOpenCustomHashSet<ItemStack> inputMap = new ObjectOpenCustomHashSet<>(new Hash.Strategy<>() {
         @Override
         public int hashCode(ItemStack o) {
             return Objects.hash(o.getItem(), o.getMetadata());

--- a/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/Player.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/Player.java
@@ -15,8 +15,8 @@ public class Player extends NamedRegistry implements IScriptReloadable {
 
     public static final String GIVEN_ITEMS = "GroovyScript:GivenItems";
 
-    public boolean testingStartingItems = false;
-    public boolean replaceDefaultInventory = false;
+    public boolean testingStartingItems;
+    public boolean replaceDefaultInventory;
 
     private final List<ItemStack> givenItemsAnySlot = new ArrayList<>();
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/Rarity.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/Rarity.java
@@ -67,17 +67,13 @@ public class Rarity extends NamedRegistry {
     }
 
     private String getAppropriateRarityName(TextFormatting formatting) {
-        switch (formatting) {
-            case WHITE:
-                return EnumRarity.COMMON.rarityName;
-            case YELLOW:
-                return EnumRarity.UNCOMMON.rarityName;
-            case AQUA:
-                return EnumRarity.RARE.rarityName;
-            case LIGHT_PURPLE:
-                return EnumRarity.EPIC.rarityName;
-        }
-        return StringUtils.capitalize(formatting.getFriendlyName());
+        return switch (formatting) {
+            case WHITE -> EnumRarity.COMMON.rarityName;
+            case YELLOW -> EnumRarity.UNCOMMON.rarityName;
+            case AQUA -> EnumRarity.RARE.rarityName;
+            case LIGHT_PURPLE -> EnumRarity.EPIC.rarityName;
+            default -> StringUtils.capitalize(formatting.getFriendlyName());
+        };
     }
 
     private static class RarityImpl implements IRarity {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/ShapedCraftingRecipe.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/ShapedCraftingRecipe.java
@@ -12,7 +12,8 @@ import java.util.List;
 
 public class ShapedCraftingRecipe extends CraftingRecipe implements IShapedRecipe {
 
-    private final int width, height;
+    private final int width;
+    private final int height;
     private final boolean mirrored;
 
     public ShapedCraftingRecipe(ItemStack output, List<IIngredient> input, int width, int height, boolean mirrored, @Nullable Closure<ItemStack> recipeFunction, @Nullable Closure<Void> recipeAction) {

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/EventBusMixin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/EventBusMixin.java
@@ -11,7 +11,6 @@ import org.spongepowered.asm.mixin.Shadow;
 
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
-import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Mixin(value = EventBus.class, remap = false)

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/EventBusMixin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/EventBusMixin.java
@@ -11,7 +11,7 @@ import org.spongepowered.asm.mixin.Shadow;
 
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.Map;
 
 @Mixin(value = EventBus.class, remap = false)
 public class EventBusMixin implements EventBusExtended {
@@ -21,7 +21,7 @@ public class EventBusMixin implements EventBusExtended {
     private int busID;
 
     @Shadow
-    private ConcurrentHashMap<Object, ArrayList<IEventListener>> listeners;
+    private Map<Object, ArrayList<IEventListener>> listeners;
 
     @Override
     public void register(Class<?> eventClass, EventPriority priority, IEventListener listener) {

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/EventBusMixin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/EventBusMixin.java
@@ -12,6 +12,7 @@ import org.spongepowered.asm.mixin.Shadow;
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Mixin(value = EventBus.class, remap = false)
 public class EventBusMixin implements EventBusExtended {
@@ -21,7 +22,7 @@ public class EventBusMixin implements EventBusExtended {
     private int busID;
 
     @Shadow
-    private Map<Object, ArrayList<IEventListener>> listeners;
+    private ConcurrentHashMap<Object, ArrayList<IEventListener>> listeners;
 
     @Override
     public void register(Class<?> eventClass, EventPriority priority, IEventListener listener) {

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/FluidStackMixin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/FluidStackMixin.java
@@ -46,7 +46,7 @@ public abstract class FluidStackMixin implements IIngredient, INbtIngredient, IN
     @Unique
     protected Closure<Object> transformer;
     @Unique
-    protected Closure<Object> nbtMatcher = null;
+    protected Closure<Object> nbtMatcher;
 
     @Override
     public IIngredient exactCopy() {

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/ForgeRegistryMixin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/ForgeRegistryMixin.java
@@ -26,6 +26,7 @@ import java.util.function.Supplier;
 @Mixin(value = ForgeRegistry.class, remap = false)
 public abstract class ForgeRegistryMixin<V extends IForgeRegistryEntry<V>> implements IForgeRegistry<V>, IReloadableForgeRegistry<V> {
 
+    @Override
     @Shadow
     public abstract void register(V value);
 

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/ItemStackMixin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/ItemStackMixin.java
@@ -34,7 +34,7 @@ public abstract class ItemStackMixin implements IIngredient, INbtIngredient, IMa
     @Unique
     protected Closure<Object> transformer;
     @Unique
-    protected Closure<Object> nbtMatcher = null;
+    protected Closure<Object> nbtMatcher;
     @Unique
     protected String mark;
 

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/ItemStackMixin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/ItemStackMixin.java
@@ -26,6 +26,7 @@ import org.spongepowered.asm.mixin.Unique;
 @Mixin(value = ItemStack.class)
 public abstract class ItemStackMixin implements IIngredient, INbtIngredient, IMarkable {
 
+    @Override
     @Shadow
     public abstract boolean isEmpty();
 

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/TileEntityPistonMixin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/TileEntityPistonMixin.java
@@ -86,7 +86,7 @@ public abstract class TileEntityPistonMixin {
                 boolean checkRecipes = !thisTile.getWorld().isRemote &&
                                        this.extending &&
                                        this.shouldHeadBeRendered &&
-                                       progress >= 1f &&
+                                       progress >= 1.0f &&
                                        !((pushingAgainst = thisTile.getWorld().getBlockState(thisTile.getPos().offset(enumfacing))).getBlock() instanceof BlockPistonMoving) &&
                                        pushingAgainst.getMaterial() != Material.AIR;
                 // groovyscript end
@@ -142,7 +142,7 @@ public abstract class TileEntityPistonMixin {
         if (d1 > 0.0D) {
             d1 = Math.min(d1, d0) + 0.01D;
             MOVING_ENTITY.set(enumfacing);
-            entity.move(MoverType.PISTON, d1 * (double) enumfacing.getXOffset(), d1 * (double) enumfacing.getYOffset(), d1 * (double) enumfacing.getZOffset());
+            entity.move(MoverType.PISTON, d1 * enumfacing.getXOffset(), d1 * enumfacing.getYOffset(), d1 * enumfacing.getZOffset());
             MOVING_ENTITY.set(null);
 
             if (!this.extending && this.shouldHeadBeRendered) {

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/TileEntityPistonMixin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/TileEntityPistonMixin.java
@@ -113,14 +113,9 @@ public abstract class TileEntityPistonMixin {
     private void groovyscript$pushEntity(List<AxisAlignedBB> list, double d0, EnumFacing enumfacing, Entity entity, boolean sticky) {
         if (sticky) {
             switch (enumfacing.getAxis()) {
-                case X:
-                    entity.motionX = enumfacing.getXOffset();
-                    break;
-                case Y:
-                    entity.motionY = enumfacing.getYOffset();
-                    break;
-                case Z:
-                    entity.motionZ = enumfacing.getZOffset();
+                case X -> entity.motionX = enumfacing.getXOffset();
+                case Y -> entity.motionY = enumfacing.getYOffset();
+                case Z -> entity.motionZ = enumfacing.getZOffset();
             }
         }
 

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/TileEntityPistonMixin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/TileEntityPistonMixin.java
@@ -95,8 +95,7 @@ public abstract class TileEntityPistonMixin {
                     Entity entity = list1.get(i);
                     if (entity.getPushReaction() != EnumPushReaction.IGNORE) {
                         // groovyscript start
-                        if (checkRecipes && i < tryRecipesUntil && entity instanceof EntityItem) {
-                            EntityItem entityItem = (EntityItem) entity;
+                        if (checkRecipes && i < tryRecipesUntil && entity instanceof EntityItem entityItem) {
                             VanillaModule.inWorldCrafting.pistonPush.findAndRunRecipe(entityItem1 -> {
                                 entityItem1.getEntityWorld().spawnEntity(entityItem1);
                                 list1.add(entityItem1);

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/draconicevolution/TileInvisECoreBlockMixin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/draconicevolution/TileInvisECoreBlockMixin.java
@@ -21,7 +21,7 @@ public class TileInvisECoreBlockMixin implements TileInvisECoreBlockState {
     @Unique
     boolean isDefault = true;
     @Unique
-    int metadata = 0;
+    int metadata;
 
     @Override
     public boolean getDefault() {

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/draconicevolution/TileInvisECoreBlockMixin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/draconicevolution/TileInvisECoreBlockMixin.java
@@ -34,6 +34,7 @@ public class TileInvisECoreBlockMixin implements TileInvisECoreBlockState {
         this.metadata = 0;
     }
 
+    @Override
     public int getMetadata() {
         return metadata;
     }

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/extendedcrafting/ItemRecipeMakerMixin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/extendedcrafting/ItemRecipeMakerMixin.java
@@ -72,7 +72,8 @@ public abstract class ItemRecipeMakerMixin {
         List<List<String>> matrix = new ArrayList<>();
         int row = 0;
         int column = 0;
-        boolean rowEmpty = true, allEmpty = true;
+        boolean rowEmpty = true;
+        boolean allEmpty = true;
         matrix.add(new ArrayList<>());
         for (ItemStack stack : table.getMatrix()) {
             String s = stack.isEmpty() ? null : groovyscript$makeItem(stack);

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/extrautils2/PassiveBlockGeneratorMillMixin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/extrautils2/PassiveBlockGeneratorMillMixin.java
@@ -35,7 +35,7 @@ public class PassiveBlockGeneratorMillMixin {
     public void getPowerLevel(TilePassiveGenerator generator, World world, CallbackInfoReturnable<Float> cir) {
         Closure<Float> value = ModSupport.EXTRA_UTILITIES_2.get().gridPowerPassiveGenerator.powerLevelMap.get(((GeneratorTypeAccessor) this).getKey());
         if (value != null) {
-            cir.setReturnValue(ClosureHelper.call(0f, value, generator, world));
+            cir.setReturnValue(ClosureHelper.call(0.0f, value, generator, world));
         }
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/documentation/Builder.java
+++ b/src/main/java/com/cleanroommc/groovyscript/documentation/Builder.java
@@ -2,8 +2,6 @@ package com.cleanroommc.groovyscript.documentation;
 
 import com.cleanroommc.groovyscript.api.GroovyLog;
 import com.cleanroommc.groovyscript.api.documentation.annotations.*;
-import com.cleanroommc.groovyscript.compat.mods.GroovyContainer;
-import com.cleanroommc.groovyscript.compat.mods.GroovyPropertyContainer;
 import com.google.common.collect.ComparisonChain;
 import it.unimi.dsi.fastutil.chars.Char2CharArrayMap;
 import it.unimi.dsi.fastutil.chars.Char2CharMap;
@@ -29,7 +27,6 @@ public class Builder {
         defaultReturnValue(Character.MIN_VALUE);
     }};
 
-    private final GroovyContainer<? extends GroovyPropertyContainer> mod;
     private final String reference;
     private final Method builderMethod;
     private final RecipeBuilderDescription annotation;
@@ -37,8 +34,7 @@ public class Builder {
     private final Map<String, List<RecipeBuilderMethod>> methods;
     private final List<Method> registrationMethods;
 
-    public Builder(GroovyContainer<? extends GroovyPropertyContainer> mod, Method builderMethod, String reference, String baseTranslationKey) {
-        this.mod = mod;
+    public Builder(Method builderMethod, String reference, String baseTranslationKey) {
         this.builderMethod = builderMethod;
         this.reference = reference;
         this.annotation = builderMethod.getAnnotation(RecipeBuilderDescription.class);

--- a/src/main/java/com/cleanroommc/groovyscript/documentation/Builder.java
+++ b/src/main/java/com/cleanroommc/groovyscript/documentation/Builder.java
@@ -153,7 +153,7 @@ public class Builder {
      * Otherwise, each line starts with a period (`.`) provided that it is not contained within any special zones (comment, string, brackets, etc)
      */
     private static List<String> generateParts(String content) {
-        ArrayList<String> parts = new ArrayList<>();
+        List<String> parts = new ArrayList<>();
 
         ArrayList<Character> req = new ArrayList<>();
         String next = "";

--- a/src/main/java/com/cleanroommc/groovyscript/documentation/Documentation.java
+++ b/src/main/java/com/cleanroommc/groovyscript/documentation/Documentation.java
@@ -41,9 +41,26 @@ public class Documentation {
     private static final Set<String> missingLangKeys = new ObjectLinkedOpenHashSet<>();
 
     public static void generate() {
-        if (GENERATE_EXAMPLES) generateExamples();
-        if (GENERATE_WIKI) generateWiki();
-        if (TEST_AND_CRASH) FMLCommonHandler.instance().exitJava(0, false);
+        if (isGenerateExamples()) generateExamples();
+        if (isGenerateWiki()) generateWiki();
+        if (isTestAndCrash()) FMLCommonHandler.instance().exitJava(0, false);
+    }
+
+    private static boolean isGenerateExamples() {
+        return GENERATE_EXAMPLES || Boolean.parseBoolean(System.getProperty("groovyscript.generate_examples"));
+    }
+
+    private static boolean isGenerateWiki() {
+        return GENERATE_WIKI || Boolean.parseBoolean(System.getProperty("groovyscript.generate_wiki"));
+    }
+
+    private static boolean isTestAndCrash() {
+        return TEST_AND_CRASH || Boolean.parseBoolean(System.getProperty("groovyscript.generate_and_crash"));
+    }
+
+    private static boolean isLogMissingKeys() {
+        String property = System.getProperty("groovyscript.log_missing_lang_keys");
+        return property == null ? LOG_MISSING_KEYS : Boolean.parseBoolean(property);
     }
 
     public static void generateExamples() {
@@ -92,7 +109,7 @@ public class Documentation {
     }
 
     public static String translate(String translateKey, Object... parameters) {
-        if (LOG_MISSING_KEYS && !I18n.hasKey(translateKey)) {
+        if (isLogMissingKeys() && !I18n.hasKey(translateKey)) {
             missingLangKeys.add(translateKey);
         }
         return I18n.format(translateKey, parameters);

--- a/src/main/java/com/cleanroommc/groovyscript/documentation/Exporter.java
+++ b/src/main/java/com/cleanroommc/groovyscript/documentation/Exporter.java
@@ -3,7 +3,6 @@ package com.cleanroommc.groovyscript.documentation;
 import com.cleanroommc.groovyscript.GroovyScript;
 import com.cleanroommc.groovyscript.api.GroovyLog;
 import com.cleanroommc.groovyscript.api.INamed;
-import com.cleanroommc.groovyscript.api.IScriptReloadable;
 import com.cleanroommc.groovyscript.api.documentation.annotations.RegistryDescription;
 import com.cleanroommc.groovyscript.compat.mods.GroovyContainer;
 import com.cleanroommc.groovyscript.compat.mods.GroovyPropertyContainer;

--- a/src/main/java/com/cleanroommc/groovyscript/documentation/Registry.java
+++ b/src/main/java/com/cleanroommc/groovyscript/documentation/Registry.java
@@ -121,7 +121,7 @@ public class Registry {
         out.append("// ").append(getTitle()).append(":").append("\n");
         out.append("// ").append(WordUtils.wrap(getDescription(), Documentation.MAX_LINE_LENGTH, "\n// ", false)).append("\n\n");
         out.append(documentMethodDescriptionType(MethodDescription.Type.REMOVAL));
-        for (Method method : recipeBuilderMethods) out.append(new Builder(mod, method, reference, baseTranslationKey).builderExampleFile()).append("\n");
+        for (Method method : recipeBuilderMethods) out.append(new Builder(method, reference, baseTranslationKey).builderExampleFile()).append("\n");
         if (!recipeBuilderMethods.isEmpty()) out.append("\n");
         out.append(documentMethodDescriptionType(MethodDescription.Type.ADDITION));
         out.append(documentMethodDescriptionType(MethodDescription.Type.VALUE));
@@ -206,7 +206,7 @@ public class Registry {
                 .append(I18n.format("groovyscript.wiki.recipe_builder_note", Documentation.DEFAULT_FORMAT.linkToBuilder())).append("\n\n");
 
         for (int i = 0; i < recipeBuilderMethods.size(); i++) {
-            Builder builder = new Builder(mod, recipeBuilderMethods.get(i), reference, baseTranslationKey);
+            Builder builder = new Builder(recipeBuilderMethods.get(i), reference, baseTranslationKey);
             out.append(new AdmonitionBuilder()
                                .type(Admonition.Type.ABSTRACT)
                                .hasTitle(true)

--- a/src/main/java/com/cleanroommc/groovyscript/documentation/Registry.java
+++ b/src/main/java/com/cleanroommc/groovyscript/documentation/Registry.java
@@ -2,7 +2,6 @@ package com.cleanroommc.groovyscript.documentation;
 
 import com.cleanroommc.groovyscript.api.GroovyBlacklist;
 import com.cleanroommc.groovyscript.api.INamed;
-import com.cleanroommc.groovyscript.api.IScriptReloadable;
 import com.cleanroommc.groovyscript.api.documentation.annotations.*;
 import com.cleanroommc.groovyscript.compat.mods.GroovyContainer;
 import com.cleanroommc.groovyscript.compat.mods.GroovyPropertyContainer;
@@ -38,7 +37,7 @@ public class Registry {
         this.description = registryClass.getAnnotation(RegistryDescription.class);
 
         List<Method> recipeBuilderMethods = new ArrayList<>();
-        EnumMap<MethodDescription.Type, List<Method>> methods = new EnumMap<>(MethodDescription.Type.class);
+        Map<MethodDescription.Type, List<Method>> methods = new EnumMap<>(MethodDescription.Type.class);
         for (MethodDescription.Type value : MethodDescription.Type.values()) methods.put(value, new ArrayList<>());
         List<String> imports = new ArrayList<>();
 

--- a/src/main/java/com/cleanroommc/groovyscript/documentation/format/MKDocsMaterial.java
+++ b/src/main/java/com/cleanroommc/groovyscript/documentation/format/MKDocsMaterial.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 
 public class MKDocsMaterial implements IFormat {
 
+    @Override
     public String linkToBuilder() {
         return "../../../groovy/builder.md";
     }
@@ -33,22 +34,27 @@ public class MKDocsMaterial implements IFormat {
         return " hl_lines=\"" + String.join(" ", highlight) + "\"";
     }
 
+    @Override
     public String removeTableOfContentsText() {
         return "hide: toc";
     }
 
+    @Override
     public boolean hasTitleTemplate() {
         return false;
     }
 
+    @Override
     public boolean allowsIndentation() {
         return true;
     }
 
+    @Override
     public boolean requiresNavFile() {
         return true;
     }
 
+    @Override
     public boolean usesFocusInCodeBlocks() {
         return false;
     }

--- a/src/main/java/com/cleanroommc/groovyscript/documentation/format/OutputFormat.java
+++ b/src/main/java/com/cleanroommc/groovyscript/documentation/format/OutputFormat.java
@@ -3,8 +3,8 @@ package com.cleanroommc.groovyscript.documentation.format;
 
 public class OutputFormat {
 
-    public static MKDocsMaterial MKDOCS_MATERIAL = new MKDocsMaterial();
-    public static VitePress VITEPRESS = new VitePress();
+    public static final MKDocsMaterial MKDOCS_MATERIAL = new MKDocsMaterial();
+    public static final VitePress VITEPRESS = new VitePress();
 
     private OutputFormat() {
     }

--- a/src/main/java/com/cleanroommc/groovyscript/documentation/format/VitePress.java
+++ b/src/main/java/com/cleanroommc/groovyscript/documentation/format/VitePress.java
@@ -10,6 +10,7 @@ import java.util.stream.Collectors;
 
 public class VitePress implements IFormat {
 
+    @Override
     public String linkToBuilder() {
         return "../../groovy/builder.md";
     }
@@ -39,22 +40,27 @@ public class VitePress implements IFormat {
         return ":no-line-numbers {" + String.join(",", highlight) + "}";
     }
 
+    @Override
     public String removeTableOfContentsText() {
         return "aside: false";
     }
 
+    @Override
     public boolean hasTitleTemplate() {
         return true;
     }
 
+    @Override
     public boolean allowsIndentation() {
         return false;
     }
 
+    @Override
     public boolean requiresNavFile() {
         return false;
     }
 
+    @Override
     public boolean usesFocusInCodeBlocks() {
         return true;
     }

--- a/src/main/java/com/cleanroommc/groovyscript/documentation/linkgenerator/BasicLinkGenerator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/documentation/linkgenerator/BasicLinkGenerator.java
@@ -15,6 +15,7 @@ import com.cleanroommc.groovyscript.documentation.Documentation;
  */
 public class BasicLinkGenerator implements ILinkGenerator {
 
+    @Override
     public String id() {
         return GroovyScript.ID;
     }

--- a/src/main/java/com/cleanroommc/groovyscript/event/EventHandler.java
+++ b/src/main/java/com/cleanroommc/groovyscript/event/EventHandler.java
@@ -111,8 +111,7 @@ public class EventHandler {
 
     @SubscribeEvent
     public static void onItemCrafted(PlayerEvent.ItemCraftedEvent event) {
-        if (event.craftMatrix instanceof InventoryCrafting) {
-            InventoryCrafting inventoryCrafting = (InventoryCrafting) event.craftMatrix;
+        if (event.craftMatrix instanceof InventoryCrafting inventoryCrafting) {
             InventoryCraftResult craftResult = null;
             EntityPlayer player = null;
             Container container = ((InventoryCraftingAccess) inventoryCrafting).getEventHandler();

--- a/src/main/java/com/cleanroommc/groovyscript/event/GroovyEventManager.java
+++ b/src/main/java/com/cleanroommc/groovyscript/event/GroovyEventManager.java
@@ -97,17 +97,11 @@ public enum GroovyEventManager {
         }
 
         private EventListener(EventBusType busType, EventPriority priority, Class<?> eventClass, Consumer<?> listener) {
-            switch (busType) {
-                case ORE_GENERATION:
-                    this.eventBus = MinecraftForge.ORE_GEN_BUS;
-                    break;
-                case TERRAIN_GENERATION:
-                    this.eventBus = MinecraftForge.TERRAIN_GEN_BUS;
-                    break;
-                default:
-                    this.eventBus = MinecraftForge.EVENT_BUS;
-                    break;
-            }
+            this.eventBus = switch (busType) {
+                case ORE_GENERATION -> MinecraftForge.ORE_GEN_BUS;
+                case TERRAIN_GENERATION -> MinecraftForge.TERRAIN_GEN_BUS;
+                default -> MinecraftForge.EVENT_BUS;
+            };
             this.listener = (Consumer<Object>) listener;
             this.register(priority, eventClass);
         }

--- a/src/main/java/com/cleanroommc/groovyscript/helper/Alias.java
+++ b/src/main/java/com/cleanroommc/groovyscript/helper/Alias.java
@@ -77,7 +77,7 @@ public class Alias extends ArrayList<String> {
     }
 
     public static <T extends Collection<String>> T generateAliases(T aliases, String name, CaseFormat caseFormat) {
-        String baseName = caseFormat == CaseFormat.UPPER_CAMEL ? caseFormat.to(CaseFormat.UPPER_CAMEL, name) : name;
+        String baseName = caseFormat == CaseFormat.UPPER_CAMEL ? name : caseFormat.to(CaseFormat.UPPER_CAMEL, name);
         if (baseName.split("[A-Z]").length > 2) {
             aliases.add(CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, baseName));
             aliases.add(baseName.toLowerCase(Locale.ROOT));

--- a/src/main/java/com/cleanroommc/groovyscript/helper/Alias.java
+++ b/src/main/java/com/cleanroommc/groovyscript/helper/Alias.java
@@ -77,17 +77,15 @@ public class Alias extends ArrayList<String> {
     }
 
     public static <T extends Collection<String>> T generateAliases(T aliases, String name, CaseFormat caseFormat) {
-        if (caseFormat != CaseFormat.UPPER_CAMEL) {
-            name = caseFormat.to(CaseFormat.UPPER_CAMEL, name);
-        }
-        if (name.split("[A-Z]").length > 2) {
-            aliases.add(CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, name));
-            aliases.add(name.toLowerCase(Locale.ROOT));
-            aliases.add(CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, name));
-            aliases.add(name);
+        String baseName = caseFormat == CaseFormat.UPPER_CAMEL ? caseFormat.to(CaseFormat.UPPER_CAMEL, name) : name;
+        if (baseName.split("[A-Z]").length > 2) {
+            aliases.add(CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, baseName));
+            aliases.add(baseName.toLowerCase(Locale.ROOT));
+            aliases.add(CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, baseName));
+            aliases.add(baseName);
         } else {
-            aliases.add(name.toLowerCase(Locale.ROOT));
-            aliases.add(name);
+            aliases.add(baseName.toLowerCase(Locale.ROOT));
+            aliases.add(baseName);
         }
         return aliases;
     }

--- a/src/main/java/com/cleanroommc/groovyscript/helper/SimpleObjectStream.java
+++ b/src/main/java/com/cleanroommc/groovyscript/helper/SimpleObjectStream.java
@@ -102,10 +102,12 @@ public class SimpleObjectStream<T> extends AbstractList<T> {
         return this;
     }
 
+    @Override
     public int size() {
         return this.recipes.size();
     }
 
+    @Override
     public boolean isEmpty() {
         return this.recipes.isEmpty();
     }

--- a/src/main/java/com/cleanroommc/groovyscript/helper/ingredient/NbtHelper.java
+++ b/src/main/java/com/cleanroommc/groovyscript/helper/ingredient/NbtHelper.java
@@ -102,19 +102,18 @@ public class NbtHelper {
         if (colored) builder.append(TextFormatting.GRAY);
         builder.append('[');
         if (!nbt.isEmpty()) {
-            indent++;
+            int internalIndent = indent + 1;
             for (String key : nbt.getKeySet()) {
-                newLine(builder, indent, pretty);
+                newLine(builder, internalIndent, pretty);
                 if (colored) builder.append(TextFormatting.GREEN);
                 builder.append('\'').append(key).append('\'');
                 if (colored) builder.append(TextFormatting.GRAY);
                 builder.append(": ");
-                builder.append(toGroovyCode(nbt.getTag(key), indent, pretty, colored));
+                builder.append(toGroovyCode(nbt.getTag(key), internalIndent, pretty, colored));
                 if (colored) builder.append(TextFormatting.GRAY);
                 builder.append(", ");
             }
             builder.delete(builder.length() - 2, builder.length());
-            indent--;
             newLine(builder, indent, pretty);
             if (colored) builder.append(TextFormatting.GRAY);
         }
@@ -127,15 +126,14 @@ public class NbtHelper {
         if (colored) builder.append(TextFormatting.GRAY);
         builder.append('[');
         if (!nbt.isEmpty()) {
-            indent++;
+            int internalIndent = indent + 1;
             for (NBTBase nbtBase : nbt) {
-                newLine(builder, indent, pretty);
-                builder.append(toGroovyCode(nbtBase, indent, pretty, colored));
+                newLine(builder, internalIndent, pretty);
+                builder.append(toGroovyCode(nbtBase, internalIndent, pretty, colored));
                 if (colored) builder.append(TextFormatting.GRAY);
                 builder.append(", ");
             }
             builder.delete(builder.length() - 2, builder.length());
-            indent--;
             newLine(builder, indent, pretty);
             if (colored) builder.append(TextFormatting.GRAY);
         }

--- a/src/main/java/com/cleanroommc/groovyscript/helper/ingredient/NbtHelper.java
+++ b/src/main/java/com/cleanroommc/groovyscript/helper/ingredient/NbtHelper.java
@@ -66,50 +66,76 @@ public class NbtHelper {
             }
             return list;
         }
-        if (o instanceof Integer) {
-            return new NBTTagInt((Integer) o);
-        }
-        if (o instanceof Long) {
-            return new NBTTagLong((Long) o);
-        }
-        if (o instanceof Short) {
-            return new NBTTagShort((Short) o);
-        }
-        if (o instanceof Byte) {
-            return new NBTTagByte((Byte) o);
-        }
-        if (o instanceof Boolean) {
-            return new NBTTagByte((byte) ((boolean) o ? 1 : 0));
-        }
-        if (o instanceof Float) {
-            return new NBTTagFloat((Float) o);
-        }
-        if (o instanceof Double) {
-            return new NBTTagDouble((Double) o);
-        }
-        if (o instanceof String) {
-            return new NBTTagString((String) o);
-        }
+
+        if (o instanceof Integer x) return new NBTTagInt(x);
+        if (o instanceof Long x) return new NBTTagLong(x);
+        if (o instanceof Short x) return new NBTTagShort(x);
+        if (o instanceof Byte x) return new NBTTagByte(x);
+        if (o instanceof Boolean x) return new NBTTagByte((byte) (x ? 1 : 0));
+        if (o instanceof Float x) return new NBTTagFloat(x);
+        if (o instanceof Double x) return new NBTTagDouble(x);
+        if (o instanceof String x) return new NBTTagString(x);
+
         throw new IllegalArgumentException("Error parsing Object to NBT: Invalid type " + o.getClass());
     }
 
-    public static String toGroovyCode(NBTTagCompound nbt, boolean pretty, boolean colored) {
-        return toGroovyCode(nbt, 0, pretty, colored);
+    public static String toGroovyCode(NBTTagByte nbt, boolean colored) {
+        StringBuilder builder = new StringBuilder();
+        if (colored) builder.append(TextFormatting.GRAY);
+        builder.append("(byte) ");
+        if (colored) builder.append(TextFormatting.GOLD);
+        builder.append(nbt.getByte());
+        return builder.toString();
     }
 
-    public static String toGroovyCode(NBTTagCompound nbt, int indent, boolean pretty, boolean colored) {
+    public static String toGroovyCode(NBTTagShort nbt, boolean colored) {
+        StringBuilder builder = new StringBuilder();
+        if (colored) builder.append(TextFormatting.GRAY);
+        builder.append("(short) ");
+        if (colored) builder.append(TextFormatting.GOLD);
+        builder.append(nbt.getShort());
+        return builder.toString();
+    }
+
+    public static String toGroovyCode(NBTTagInt nbt, boolean colored) {
+        StringBuilder builder = new StringBuilder();
+        if (colored) builder.append(TextFormatting.GREEN);
+        builder.append(nbt.getInt());
+        return builder.toString();
+    }
+
+    public static String toGroovyCode(NBTTagLong nbt, boolean colored) {
+        StringBuilder builder = new StringBuilder();
+        if (colored) builder.append(TextFormatting.GREEN);
+        builder.append(nbt.getLong()).append("L");
+        return builder.toString();
+    }
+
+    public static String toGroovyCode(NBTTagFloat nbt, boolean colored) {
+        StringBuilder builder = new StringBuilder();
+        if (colored) builder.append(TextFormatting.GREEN);
+        builder.append(nbt.getFloat()).append("F");
+        return builder.toString();
+    }
+
+    public static String toGroovyCode(NBTTagDouble nbt, boolean colored) {
+        StringBuilder builder = new StringBuilder();
+        if (colored) builder.append(TextFormatting.GREEN);
+        builder.append(nbt.getDouble()).append("D");
+        return builder.toString();
+    }
+
+    public static String toGroovyCode(NBTTagByteArray nbt, int indent, boolean pretty, boolean colored) {
         StringBuilder builder = new StringBuilder();
         if (colored) builder.append(TextFormatting.GRAY);
         builder.append('[');
         if (!nbt.isEmpty()) {
-            int internalIndent = indent + 1;
-            for (String key : nbt.getKeySet()) {
-                newLine(builder, internalIndent, pretty);
-                if (colored) builder.append(TextFormatting.GREEN);
-                builder.append('\'').append(key).append('\'');
+            newLine(builder, indent, pretty);
+            for (byte value : nbt.getByteArray()) {
                 if (colored) builder.append(TextFormatting.GRAY);
-                builder.append(": ");
-                builder.append(toGroovyCode(nbt.getTag(key), internalIndent, pretty, colored));
+                builder.append("(byte) ");
+                if (colored) builder.append(TextFormatting.GOLD);
+                builder.append(value);
                 if (colored) builder.append(TextFormatting.GRAY);
                 builder.append(", ");
             }
@@ -118,6 +144,13 @@ public class NbtHelper {
             if (colored) builder.append(TextFormatting.GRAY);
         }
         builder.append(']');
+        return builder.toString();
+    }
+
+    public static String toGroovyCode(NBTTagString nbt, boolean colored) {
+        StringBuilder builder = new StringBuilder();
+        if (colored) builder.append(TextFormatting.GREEN);
+        builder.append('\'').append(nbt.getString()).append('\'');
         return builder.toString();
     }
 
@@ -141,17 +174,23 @@ public class NbtHelper {
         return builder.toString();
     }
 
-    public static String toGroovyCode(NBTTagByteArray nbt, int indent, boolean pretty, boolean colored) {
+    public static String toGroovyCode(NBTTagCompound nbt, boolean pretty, boolean colored) {
+        return toGroovyCode(nbt, 0, pretty, colored);
+    }
+
+    public static String toGroovyCode(NBTTagCompound nbt, int indent, boolean pretty, boolean colored) {
         StringBuilder builder = new StringBuilder();
         if (colored) builder.append(TextFormatting.GRAY);
         builder.append('[');
         if (!nbt.isEmpty()) {
-            newLine(builder, indent, pretty);
-            for (byte value : nbt.getByteArray()) {
+            int internalIndent = indent + 1;
+            for (String key : nbt.getKeySet()) {
+                newLine(builder, internalIndent, pretty);
+                if (colored) builder.append(TextFormatting.GREEN);
+                builder.append('\'').append(key).append('\'');
                 if (colored) builder.append(TextFormatting.GRAY);
-                builder.append("(byte) ");
-                if (colored) builder.append(TextFormatting.GOLD);
-                builder.append(value);
+                builder.append(": ");
+                builder.append(toGroovyCode(nbt.getTag(key), internalIndent, pretty, colored));
                 if (colored) builder.append(TextFormatting.GRAY);
                 builder.append(", ");
             }
@@ -186,71 +225,19 @@ public class NbtHelper {
     public static String toGroovyCode(NBTBase nbt, int indent, boolean pretty, boolean colored) {
         StringBuilder builder = new StringBuilder();
         switch (nbt.getId()) {
+            case Constants.NBT.TAG_BYTE -> builder.append(toGroovyCode((NBTTagByte) nbt, colored));
+            case Constants.NBT.TAG_SHORT -> builder.append(toGroovyCode((NBTTagShort) nbt, colored));
+            case Constants.NBT.TAG_INT -> builder.append(toGroovyCode((NBTTagInt) nbt, colored));
+            case Constants.NBT.TAG_LONG -> builder.append(toGroovyCode((NBTTagLong) nbt, colored));
+            case Constants.NBT.TAG_FLOAT -> builder.append(toGroovyCode((NBTTagFloat) nbt, colored));
+            case Constants.NBT.TAG_DOUBLE -> builder.append(toGroovyCode((NBTTagDouble) nbt, colored));
+            case Constants.NBT.TAG_BYTE_ARRAY -> builder.append(toGroovyCode((NBTTagByteArray) nbt, indent, pretty, colored));
+            case Constants.NBT.TAG_STRING -> builder.append(toGroovyCode((NBTTagString) nbt, colored));
+            case Constants.NBT.TAG_LIST -> builder.append(toGroovyCode((NBTTagList) nbt, indent, pretty, colored));
+            case Constants.NBT.TAG_COMPOUND -> builder.append(toGroovyCode((NBTTagCompound) nbt, indent, pretty, colored));
+            case Constants.NBT.TAG_INT_ARRAY -> builder.append(toGroovyCode((NBTTagIntArray) nbt, indent, pretty, colored));
             //TAG_LONG_ARRAY
-            case Constants.NBT.TAG_INT_ARRAY: {
-                if (colored) builder.append(TextFormatting.GREEN);
-                builder.append(toGroovyCode((NBTTagIntArray) nbt, indent, pretty, colored));
-                break;
-            }
-            case Constants.NBT.TAG_COMPOUND: {
-                builder.append(toGroovyCode((NBTTagCompound) nbt, indent, pretty, colored));
-                break;
-            }
-            case Constants.NBT.TAG_LIST: {
-                builder.append(toGroovyCode((NBTTagList) nbt, indent, pretty, colored));
-                break;
-            }
-            case Constants.NBT.TAG_STRING: {
-                if (colored) builder.append(TextFormatting.GREEN);
-                builder.append('\'')
-                        .append(((NBTTagString) nbt).getString())
-                        .append('\'');
-                break;
-            }
-            case Constants.NBT.TAG_BYTE_ARRAY: {
-                if (colored) builder.append(TextFormatting.GREEN);
-                builder.append(toGroovyCode((NBTTagByteArray) nbt, indent, pretty, colored));
-                break;
-            }
-            case Constants.NBT.TAG_DOUBLE: {
-                if (colored) builder.append(TextFormatting.GOLD);
-                builder.append(((NBTTagDouble) nbt).getDouble())
-                        .append("D");
-                break;
-            }
-            case Constants.NBT.TAG_FLOAT: {
-                if (colored) builder.append(TextFormatting.GOLD);
-                builder.append(((NBTTagFloat) nbt).getFloat())
-                        .append("F");
-                break;
-            }
-            case Constants.NBT.TAG_LONG: {
-                if (colored) builder.append(TextFormatting.GOLD);
-                builder.append(((NBTTagLong) nbt).getLong())
-                        .append("L");
-                break;
-            }
-            case Constants.NBT.TAG_INT: {
-                if (colored) builder.append(TextFormatting.GOLD);
-                builder.append(((NBTTagInt) nbt).getInt());
-                break;
-            }
-            case Constants.NBT.TAG_SHORT: {
-                if (colored) builder.append(TextFormatting.GRAY);
-                builder.append("(short) ");
-                if (colored) builder.append(TextFormatting.GOLD);
-                builder.append(((NBTTagShort) nbt).getShort());
-                break;
-            }
-            case Constants.NBT.TAG_BYTE: {
-                if (colored) builder.append(TextFormatting.GRAY);
-                builder.append("(byte) ");
-                if (colored) builder.append(TextFormatting.GOLD);
-                builder.append(((NBTTagByte) nbt).getByte());
-                break;
-            }
-            default:
-                throw new IllegalArgumentException(nbt.toString());
+            default -> throw new IllegalArgumentException(nbt.toString());
         }
         return builder.toString();
     }

--- a/src/main/java/com/cleanroommc/groovyscript/network/NetworkHandler.java
+++ b/src/main/java/com/cleanroommc/groovyscript/network/NetworkHandler.java
@@ -18,7 +18,7 @@ import net.minecraftforge.fml.relauncher.Side;
 public class NetworkHandler {
 
     public static final SimpleNetworkWrapper network = NetworkRegistry.INSTANCE.newSimpleChannel(GroovyScript.ID);
-    private static int packetId = 0;
+    private static int packetId;
 
     public static void init() {
         registerS2C(SReloadScripts.class);

--- a/src/main/java/com/cleanroommc/groovyscript/registry/NamedRegistry.java
+++ b/src/main/java/com/cleanroommc/groovyscript/registry/NamedRegistry.java
@@ -28,10 +28,12 @@ public abstract class NamedRegistry implements INamed {
         this.name = this.aliases.get(0).toLowerCase(Locale.ENGLISH);
     }
 
+    @Override
     public String getName() {
         return name;
     }
 
+    @Override
     public List<String> getAliases() {
         return aliases;
     }

--- a/src/main/java/com/cleanroommc/groovyscript/registry/ReloadableRegistryManager.java
+++ b/src/main/java/com/cleanroommc/groovyscript/registry/ReloadableRegistryManager.java
@@ -8,7 +8,6 @@ import com.cleanroommc.groovyscript.api.IScriptReloadable;
 import com.cleanroommc.groovyscript.compat.mods.GroovyContainer;
 import com.cleanroommc.groovyscript.compat.mods.GroovyPropertyContainer;
 import com.cleanroommc.groovyscript.compat.mods.ModSupport;
-import com.cleanroommc.groovyscript.compat.mods.jei.JeiPlugin;
 import com.cleanroommc.groovyscript.compat.vanilla.VanillaModule;
 import com.cleanroommc.groovyscript.core.mixin.jei.JeiProxyAccessor;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;

--- a/src/main/java/com/cleanroommc/groovyscript/registry/VirtualizedRegistry.java
+++ b/src/main/java/com/cleanroommc/groovyscript/registry/VirtualizedRegistry.java
@@ -20,10 +20,12 @@ public abstract class VirtualizedRegistry<R> extends NamedRegistry implements IS
         this.recipeStorage = createRecipeStorage();
     }
 
+    @Override
     @GroovyBlacklist
     @ApiStatus.OverrideOnly
     public abstract void onReload();
 
+    @Override
     @GroovyBlacklist
     @ApiStatus.OverrideOnly
     public void afterScriptLoad() {

--- a/src/main/java/com/cleanroommc/groovyscript/sandbox/CompiledScript.java
+++ b/src/main/java/com/cleanroommc/groovyscript/sandbox/CompiledScript.java
@@ -17,7 +17,7 @@ class CompiledScript extends CompiledClass {
 
     final List<CompiledClass> innerClasses = new ArrayList<>();
     long lastEdited;
-    List<String> preprocessors = null;
+    List<String> preprocessors;
 
     public CompiledScript(String path, long lastEdited) {
         this(path, null, lastEdited);

--- a/src/main/java/com/cleanroommc/groovyscript/sandbox/GroovyLogImpl.java
+++ b/src/main/java/com/cleanroommc/groovyscript/sandbox/GroovyLogImpl.java
@@ -141,6 +141,7 @@ public class GroovyLogImpl implements GroovyLog {
      * @param msg  message
      * @param args arguments
      */
+    @Override
     public void infoMC(String msg, Object... args) {
         info(msg, args);
         logger.info(msg, args);
@@ -152,6 +153,7 @@ public class GroovyLogImpl implements GroovyLog {
      * @param msg  message
      * @param args arguments
      */
+    @Override
     public void info(String msg, Object... args) {
         writeLogLine(formatLine("INFO", GroovyLog.format(msg, args)));
     }
@@ -162,6 +164,7 @@ public class GroovyLogImpl implements GroovyLog {
      * @param msg  message
      * @param args arguments
      */
+    @Override
     public void debugMC(String msg, Object... args) {
         if (isDebug()) {
             debug(msg, args);
@@ -175,6 +178,7 @@ public class GroovyLogImpl implements GroovyLog {
      * @param msg  message
      * @param args arguments
      */
+    @Override
     public void debug(String msg, Object... args) {
         if (isDebug()) {
             writeLogLine(formatLine("DEBUG", GroovyLog.format(msg, args)));
@@ -187,6 +191,7 @@ public class GroovyLogImpl implements GroovyLog {
      * @param msg  message
      * @param args arguments
      */
+    @Override
     public void warnMC(String msg, Object... args) {
         warn(msg, args);
         logger.warn(msg, args);
@@ -211,6 +216,7 @@ public class GroovyLogImpl implements GroovyLog {
      * @param msg  message
      * @param args arguments
      */
+    @Override
     public void warn(String msg, Object... args) {
         writeLogLine(formatLine("WARN", GroovyLog.format(msg, args)));
     }
@@ -221,6 +227,7 @@ public class GroovyLogImpl implements GroovyLog {
      * @param msg  message
      * @param args arguments
      */
+    @Override
     public void error(String msg, Object... args) {
         msg = GroovyLog.format(msg, args);
         this.errors.add(msg);
@@ -240,6 +247,7 @@ public class GroovyLogImpl implements GroovyLog {
      *
      * @param throwable exception
      */
+    @Override
     public void exception(Throwable throwable) {
         String msg = throwable.toString();
         this.errors.add(msg);
@@ -328,6 +336,7 @@ public class GroovyLogImpl implements GroovyLog {
             return level != null;
         }
 
+        @Override
         public Msg add(String msg, Object... data) {
             this.messages.add(GroovyLog.format(msg, data));
             return this;
@@ -341,6 +350,7 @@ public class GroovyLogImpl implements GroovyLog {
             return this;
         }
 
+        @Override
         public Msg add(boolean condition, Supplier<String> msg) {
             if (condition) {
                 return add(msg.get());
@@ -367,22 +377,27 @@ public class GroovyLogImpl implements GroovyLog {
             return this;
         }
 
+        @Override
         public Msg info() {
             return level(Level.INFO);
         }
 
+        @Override
         public Msg debug() {
             return level(Level.DEBUG);
         }
 
+        @Override
         public Msg warn() {
             return level(Level.WARN);
         }
 
+        @Override
         public Msg fatal() {
             return level(Level.FATAL);
         }
 
+        @Override
         public Msg error() {
             return level(Level.ERROR);
         }

--- a/src/main/java/com/cleanroommc/groovyscript/sandbox/GroovyLogImpl.java
+++ b/src/main/java/com/cleanroommc/groovyscript/sandbox/GroovyLogImpl.java
@@ -315,7 +315,7 @@ public class GroovyLogImpl implements GroovyLog {
         private final String mainMsg;
         private final List<String> messages = new ArrayList<>();
         private Level level = Level.INFO;
-        private boolean logToMcLog = false;
+        private boolean logToMcLog;
         @Nullable
         private Throwable throwable;
 

--- a/src/main/java/com/cleanroommc/groovyscript/sandbox/GroovySandbox.java
+++ b/src/main/java/com/cleanroommc/groovyscript/sandbox/GroovySandbox.java
@@ -31,7 +31,7 @@ import java.util.*;
  */
 public abstract class GroovySandbox {
 
-    private String currentScript = null;
+    private String currentScript;
 
     private final URL[] scriptEnvironment;
     private final ThreadLocal<Boolean> running = ThreadLocal.withInitial(() -> false);

--- a/src/main/java/com/cleanroommc/groovyscript/sandbox/RunConfig.java
+++ b/src/main/java/com/cleanroommc/groovyscript/sandbox/RunConfig.java
@@ -73,14 +73,14 @@ public class RunConfig {
     private final List<String> packmodeList = new ArrayList<>();
     private final Set<String> packmodeSet = new ObjectOpenHashSet<>();
     private final Map<String, List<String>> packmodePaths = new Object2ObjectOpenHashMap<>();
-    private boolean integratePackmodeMod = false;
+    private boolean integratePackmodeMod;
     // TODO asm
     private final String asmClass = null;
     private boolean debug;
 
 
     private final boolean invalidPackId;
-    private boolean warnedAboutInvalidPackId = false;
+    private boolean warnedAboutInvalidPackId;
     private int packmodeConfigState;
 
     public static final String[] GROOVY_SUFFIXES = {".groovy", ".gvy", ".gy", ".gsh"};

--- a/src/main/java/com/cleanroommc/groovyscript/sandbox/expand/ExpansionHelper.java
+++ b/src/main/java/com/cleanroommc/groovyscript/sandbox/expand/ExpansionHelper.java
@@ -149,6 +149,7 @@ public class ExpansionHelper {
                     metaMethod = new NewInstanceMetaMethod(method);
                 else
                     metaMethod = new NewInstanceMetaMethod(method) {
+                        @Override
                         public CachedClass getDeclaringClass() {
                             return ReflectionCache.getCachedClass(self.getTheClass());
                         }

--- a/src/main/java/com/cleanroommc/groovyscript/sandbox/expand/ExpansionHelper.java
+++ b/src/main/java/com/cleanroommc/groovyscript/sandbox/expand/ExpansionHelper.java
@@ -70,8 +70,7 @@ public class ExpansionHelper {
     }
 
     private static boolean isValidProperty(MetaProperty prop) {
-        if (prop instanceof MetaBeanProperty) {
-            MetaBeanProperty beanProperty = (MetaBeanProperty) prop;
+        if (prop instanceof MetaBeanProperty beanProperty) {
             if (!isValid(beanProperty.getField())) return false;
             if (!(beanProperty.getGetter() instanceof CachedMethod) || isValid((CachedMethod) beanProperty.getGetter()))
                 return false;

--- a/src/main/java/com/cleanroommc/groovyscript/sandbox/security/GroovySecurityManager.java
+++ b/src/main/java/com/cleanroommc/groovyscript/sandbox/security/GroovySecurityManager.java
@@ -1,7 +1,6 @@
 package com.cleanroommc.groovyscript.sandbox.security;
 
 import com.cleanroommc.groovyscript.api.GroovyBlacklist;
-import com.cleanroommc.groovyscript.compat.mods.ModSupport;
 import com.cleanroommc.groovyscript.sandbox.GroovyLogImpl;
 import com.cleanroommc.groovyscript.sandbox.expand.LambdaClosure;
 import groovy.lang.GroovyClassLoader;
@@ -12,7 +11,6 @@ import groovy.util.Eval;
 import groovy.util.GroovyScriptEngine;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
-import mezz.jei.util.FileUtil;
 import org.apache.commons.io.FileUtils;
 import org.codehaus.groovy.runtime.FormatHelper;
 import org.codehaus.groovy.runtime.GStringImpl;

--- a/src/main/java/com/cleanroommc/groovyscript/sandbox/transformer/GroovyScriptCompiler.java
+++ b/src/main/java/com/cleanroommc/groovyscript/sandbox/transformer/GroovyScriptCompiler.java
@@ -47,8 +47,7 @@ public class GroovyScriptCompiler extends CompilationCustomizer {
         for (AnnotationNode annotatedNode : node.getAnnotations()) {
             if (annotatedNode.getClassNode().getName().equals(SIDE_ONLY_CLASS)) {
                 Expression expr = annotatedNode.getMember("value");
-                if (expr instanceof PropertyExpression) {
-                    PropertyExpression prop = (PropertyExpression) expr;
+                if (expr instanceof PropertyExpression prop) {
                     if (prop.getObjectExpression() instanceof ClassExpression &&
                         prop.getObjectExpression().getType().getName().equals(SIDE_CLASS)) {
                         String elementSide = prop.getPropertyAsString();


### PR DESCRIPTION
changes in this PR:
- engage in a significant amount of "IDE warning gets autofixed" action
	- weaken overly strong variables
	- less modification of method parameters
	- one line per variable/field declaration
	- remove redundant field creation (eg `null` or `0`, when that is already the default)
	- apply `@Override` annotations where they ought to be
	- make `name` use `super.name` in recipe builders where it can be confused for the `name` in the parent class
	- remove unused imports
	- use pattern variable
	- use improved switch format
	- make finalizable fields final
	- a few more minor things
- make Blood Magic return the recipe in `register` correctly
- store only the recipe in most roots stuff, instead of `Pair<ResourceLocation, Recipe>` (Recipe has the RL, its pointless)
- fix some extended crafting shapeless recipes actually being shaped recipes
- remove some instances of `@MethodDescription(description = "x")` where `x` could be assumed
- add the ability for java arguments to control documentation, and add settings to `gradle.properties` to allow that
- reorder the `gradle.properties` debug stuff and comment it
- fix `mode` being renamed to `compactorMode` not having documentation or examples updated

removes ~480 warnings, which according to my IDE, means only 460 left in the groovyscript folder.