### PR TITLE
fix botania lexicon not being added

### DIFF
--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/Botania.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/Botania.java
@@ -23,6 +23,12 @@ public class Botania extends GroovyPropertyContainer {
     public final Magnet magnet = new Magnet();
     public final Flowers flowers = new Flowers();
 
+    public Botania() {
+        addProperty(lexicon.category);
+        addProperty(lexicon.entry);
+        addProperty(lexicon.page);
+    }
+
     public static LexiconCategory getCategory(String name) {
         for (LexiconCategory category : BotaniaAPI.getAllCategories())
             if (category.getUnlocalizedName().equals(name)) return category;


### PR DESCRIPTION
changes in this PR:
- makes lexicon category/entry/page work again
- broken by this change: https://github.com/CleanroomMC/GroovyScript/commit/6b5a6591ad6f9ddbb0355e2fec39dfec10816e17#diff-b554e3ef8e3d9073eb8c44f7c67d3920a2f59310f091ca41237afddca77891e8

