### PR TITLE
add allowedSoils for Flower Generation

### DIFF
--- a/examples/postInit/roots.groovy
+++ b/examples/postInit/roots.groovy
@@ -122,6 +122,11 @@ mods.roots.flower_generation.recipeBuilder()
     .flower(blockstate('minecraft:clay'))
     .register()
 
+mods.roots.flower_generation.recipeBuilder()
+    .flower(blockstate('minecraft:gold_block'))
+    .allowedSoils(item('minecraft:dirt'), item('minecraft:sandstone'))
+    .register()
+
 
 // Life Essence:
 // When shift right clicking a mob in the Life Essence Pool with Runic Shears, it will drop a Life-Essence, which allows

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/FlowerGeneration.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/FlowerGeneration.java
@@ -1,6 +1,7 @@
 package com.cleanroommc.groovyscript.compat.mods.roots;
 
 import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
 import com.cleanroommc.groovyscript.api.documentation.annotations.*;
 import com.cleanroommc.groovyscript.compat.mods.ModSupport;
 import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
@@ -17,6 +18,7 @@ import net.minecraft.util.ResourceLocation;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -25,7 +27,10 @@ import java.util.Map;
 )
 public class FlowerGeneration extends VirtualizedRegistry<FlowerRecipe> {
 
-    @RecipeBuilderDescription(example = @Example(".name('clay_flower').flower(blockstate('minecraft:clay'))"))
+    @RecipeBuilderDescription(example = {
+            @Example(".name('clay_flower').flower(blockstate('minecraft:clay'))"),
+            @Example(".flower(blockstate('minecraft:gold_block')).allowedSoils(item('minecraft:dirt'), item('minecraft:sandstone'))")
+    })
     public static RecipeBuilder recipeBuilder() {
         return new RecipeBuilder();
     }
@@ -109,6 +114,7 @@ public class FlowerGeneration extends VirtualizedRegistry<FlowerRecipe> {
 
         @Property(valid = @Comp(value = "null", type = Comp.Type.NOT))
         private IBlockState flower;
+        @Property
         private final List<Ingredient> allowedSoils = new ArrayList<>();
 
         @RecipeBuilderMethodDescription
@@ -123,12 +129,13 @@ public class FlowerGeneration extends VirtualizedRegistry<FlowerRecipe> {
             return this;
         }
 
-        /*
+        @RecipeBuilderMethodDescription
         public RecipeBuilder allowedSoils(IIngredient allowedSoils) {
             this.allowedSoils.add(allowedSoils.toMcIngredient());
             return this;
         }
 
+        @RecipeBuilderMethodDescription
         public RecipeBuilder allowedSoils(IIngredient... allowedSoilss) {
             for (IIngredient allowedSoils : allowedSoilss) {
                 allowedSoils(allowedSoils);
@@ -136,13 +143,13 @@ public class FlowerGeneration extends VirtualizedRegistry<FlowerRecipe> {
             return this;
         }
 
+        @RecipeBuilderMethodDescription
         public RecipeBuilder allowedSoils(Collection<IIngredient> allowedSoilss) {
             for (IIngredient allowedSoils : allowedSoilss) {
                 allowedSoils(allowedSoils);
             }
             return this;
         }
-        */
 
         @Override
         public String getErrorMsg() {

--- a/src/main/resources/assets/groovyscript/lang/en_us.lang
+++ b/src/main/resources/assets/groovyscript/lang/en_us.lang
@@ -1301,8 +1301,9 @@ groovyscript.wiki.roots.fey_crafter.removeByName=Removes the Fey Crafter recipe 
 groovyscript.wiki.roots.fey_crafter.removeByOutput=Removes the Fey Crafter recipe with the given output itemstack
 
 groovyscript.wiki.roots.flower_generation.title=Flower Generation
-groovyscript.wiki.roots.flower_generation.description=When running the Flower Growth Ritual, allowed flowers will generate in the area. Additionally, using the spell Growth Infusion's Floral Reproduction modifier will duplicate the flower.
+groovyscript.wiki.roots.flower_generation.description=When running the Flower Growth Ritual, allowed flowers will generate in the area if they can be placed on the given soil block. Additionally, using the spell Growth Infusion's Floral Reproduction modifier will duplicate the flower, regardless of the soil block.
 groovyscript.wiki.roots.flower_generation.flower.value=Sets the flower blockstate
+groovyscript.wiki.roots.flower_generation.allowedSoils.value=Sets the list of allowed blocks beneath the flower, where an empty list allows any block, in the form of an IIngredient that is converted into a IBlockState
 groovyscript.wiki.roots.flower_generation.removeByFlower0=Removes the Flower Generation entry with the given IBlockState
 groovyscript.wiki.roots.flower_generation.removeByFlower1=Removes the Flower Generation entry with the given Block and int metadata
 groovyscript.wiki.roots.flower_generation.removeByFlower2=Removes all Flower Generation entries with the given Block


### PR DESCRIPTION
changes in this PR:
- adds the `allowedSoils` feature for Flower Generation
- technically just uncomments it
- i18n key and example