### PR TITLE
add Atum 2 compat

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -40,6 +40,7 @@ final def mod_dependencies = [
         'astralsorcery-sorcery-241721:3044416'                : [project.debug_astral],
         'baubles-227083:2518667'                              : [project.debug_astral, project.debug_botania, project.debug_thaum, project.debug_essentialcraft_4],
         'avaritia_1_10-261348:3143349'                        : [project.debug_avaritia],
+        'atum-2-59621:3116599'                                : [project.debug_atum],
         'bwm-core-294335:2624990'                             : [project.debug_better_with_mods],
         'bwm-suite-246760:3289033'                            : [project.debug_better_with_mods],
         'blood-magic-224791:2822288'                          : [project.debug_blood_magic],

--- a/examples/postInit/atum.groovy
+++ b/examples/postInit/atum.groovy
@@ -1,0 +1,69 @@
+
+// Auto generated groovyscript example file
+// MODS_LOADED: atum
+
+println 'mod \'atum\' detected, running script'
+
+// Kiln:
+// Smelts an input item into an output itemstack and giving experience similar to a Furnace, but can process up to 4 stacks
+// simultaneously. Makes a copy of the vanilla furnace recipes, excluding entries on a blacklist.
+
+mods.atum.kiln.removeByInput(item('minecraft:netherrack'))
+mods.atum.kiln.removeByOutput(item('minecraft:stone'))
+// mods.atum.kiln.removeAll()
+
+mods.atum.kiln.recipeBuilder()
+    .input(item('minecraft:diamond'))
+    .output(item('minecraft:clay'))
+    .register()
+
+mods.atum.kiln.recipeBuilder()
+    .input(item('minecraft:gold_ingot'))
+    .output(item('minecraft:clay') * 4)
+    .experience(0.5f)
+    .register()
+
+
+// Quern:
+// Converts an input item into an output itemstack after a given number of rotations, which are done via a player right
+// clicking the Quern.
+
+mods.atum.quern.removeByInput(item('minecraft:blaze_rod'))
+mods.atum.quern.removeByOutput(item('minecraft:sugar'))
+// mods.atum.quern.removeAll()
+
+mods.atum.quern.recipeBuilder()
+    .input(item('minecraft:diamond'))
+    .output(item('minecraft:clay'))
+    .rotations(1)
+    .register()
+
+mods.atum.quern.recipeBuilder()
+    .input(item('minecraft:gold_ingot'))
+    .output(item('minecraft:clay') * 4)
+    .rotations(5)
+    .register()
+
+
+// Spinning Wheel:
+// Converts three input items into an output itemstack after a given number of rotations for each input item, items are
+// inserted by interacting with the top, rotations are increased by interacting with the top, and output items are
+// extracted by interacting with the spool side.
+
+mods.atum.spinning_wheel.removeByInput(item('atum:flax'))
+mods.atum.spinning_wheel.removeByOutput(item('minecraft:string'))
+// mods.atum.spinning_wheel.removeAll()
+
+mods.atum.spinning_wheel.recipeBuilder()
+    .input(item('minecraft:diamond'))
+    .output(item('minecraft:clay'))
+    .rotations(1)
+    .register()
+
+mods.atum.spinning_wheel.recipeBuilder()
+    .input(item('minecraft:gold_ingot'))
+    .output(item('minecraft:clay') * 4)
+    .rotations(5)
+    .register()
+
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,6 +19,7 @@ debug_alchemistry = false
 debug_applied_energistics_2 = false
 debug_arcane_archives = false
 debug_astral = false
+debug_atum = false
 debug_avaritia = false
 debug_better_with_mods = false
 debug_blood_magic = false

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ModSupport.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ModSupport.java
@@ -10,6 +10,7 @@ import com.cleanroommc.groovyscript.compat.mods.alchemistry.Alchemistry;
 import com.cleanroommc.groovyscript.compat.mods.appliedenergistics2.AppliedEnergistics2;
 import com.cleanroommc.groovyscript.compat.mods.arcanearchives.ArcaneArchives;
 import com.cleanroommc.groovyscript.compat.mods.astralsorcery.AstralSorcery;
+import com.cleanroommc.groovyscript.compat.mods.atum.Atum;
 import com.cleanroommc.groovyscript.compat.mods.avaritia.Avaritia;
 import com.cleanroommc.groovyscript.compat.mods.betterwithmods.BetterWithMods;
 import com.cleanroommc.groovyscript.compat.mods.bloodmagic.BloodMagic;
@@ -75,6 +76,7 @@ public class ModSupport {
     public static final GroovyContainer<ArcaneArchives> ARCANE_ARCHIVES = new InternalModContainer<>("arcanearchives", "Arcane Archives", ArcaneArchives::new);
     public static final GroovyContainer<AstralSorcery> ASTRAL_SORCERY = new InternalModContainer<>("astralsorcery", "Astral Sorcery", AstralSorcery::new, "astral");
     public static final GroovyContainer<Avaritia> AVARITIA = new InternalModContainer<>("avaritia", "Avaritia", Avaritia::new);
+    public static final GroovyContainer<Atum> ATUM = new InternalModContainer<>("atum", "Atum 2", Atum::new);
     public static final GroovyContainer<BetterWithMods> BETTER_WITH_MODS = new InternalModContainer<>("betterwithmods", "Better With Mods", BetterWithMods::new);
     public static final GroovyContainer<BloodMagic> BLOOD_MAGIC = new InternalModContainer<>("bloodmagic", "Blood Magic: Alchemical Wizardry", BloodMagic::new, "bm");
     public static final GroovyContainer<Botania> BOTANIA = new InternalModContainer<>("botania", "Botania", Botania::new);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ModSupport.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ModSupport.java
@@ -75,8 +75,8 @@ public class ModSupport {
     public static final GroovyContainer<AppliedEnergistics2> APPLIED_ENERGISTICS_2 = new InternalModContainer<>("appliedenergistics2", "Applied Energistics 2", AppliedEnergistics2::new, "ae2");
     public static final GroovyContainer<ArcaneArchives> ARCANE_ARCHIVES = new InternalModContainer<>("arcanearchives", "Arcane Archives", ArcaneArchives::new);
     public static final GroovyContainer<AstralSorcery> ASTRAL_SORCERY = new InternalModContainer<>("astralsorcery", "Astral Sorcery", AstralSorcery::new, "astral");
-    public static final GroovyContainer<Avaritia> AVARITIA = new InternalModContainer<>("avaritia", "Avaritia", Avaritia::new);
     public static final GroovyContainer<Atum> ATUM = new InternalModContainer<>("atum", "Atum 2", Atum::new);
+    public static final GroovyContainer<Avaritia> AVARITIA = new InternalModContainer<>("avaritia", "Avaritia", Avaritia::new);
     public static final GroovyContainer<BetterWithMods> BETTER_WITH_MODS = new InternalModContainer<>("betterwithmods", "Better With Mods", BetterWithMods::new);
     public static final GroovyContainer<BloodMagic> BLOOD_MAGIC = new InternalModContainer<>("bloodmagic", "Blood Magic: Alchemical Wizardry", BloodMagic::new, "bm");
     public static final GroovyContainer<Botania> BOTANIA = new InternalModContainer<>("botania", "Botania", Botania::new);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/atum/Atum.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/atum/Atum.java
@@ -1,0 +1,11 @@
+package com.cleanroommc.groovyscript.compat.mods.atum;
+
+import com.cleanroommc.groovyscript.compat.mods.GroovyPropertyContainer;
+
+public class Atum extends GroovyPropertyContainer {
+
+    public final Kiln kiln = new Kiln();
+    public final Quern quern = new Quern();
+    public final SpinningWheel spinningWheel = new SpinningWheel();
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/atum/Kiln.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/atum/Kiln.java
@@ -1,0 +1,111 @@
+package com.cleanroommc.groovyscript.compat.mods.atum;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.ingredient.OreDictIngredient;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import com.cleanroommc.groovyscript.registry.ForgeRegistryWrapper;
+import com.teammetallurgy.atum.api.recipe.RecipeHandlers;
+import com.teammetallurgy.atum.api.recipe.kiln.IKilnRecipe;
+import com.teammetallurgy.atum.api.recipe.kiln.KilnRecipe;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
+import org.jetbrains.annotations.Nullable;
+
+@RegistryDescription
+public class Kiln extends ForgeRegistryWrapper<IKilnRecipe> {
+
+    public Kiln() {
+        super(RecipeHandlers.kilnRecipes);
+    }
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:diamond')).output(item('minecraft:clay'))"),
+            @Example(".input(item('minecraft:gold_ingot')).output(item('minecraft:clay') * 4).experience(0.5f)")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    public IKilnRecipe add(IIngredient input, ItemStack output) {
+        return add(input, output, 0);
+    }
+
+    public IKilnRecipe add(IIngredient input, ItemStack output, float experience) {
+        return recipeBuilder()
+                .experience(experience)
+                .input(input)
+                .output(output)
+                .register();
+    }
+
+    @MethodDescription(example = @Example("item('minecraft:netherrack')"))
+    public void removeByInput(IIngredient input) {
+        for (IKilnRecipe recipe : getRegistry()) {
+            if (recipe.getInput().stream().anyMatch(input)) {
+                remove(recipe);
+            }
+        }
+    }
+
+    @MethodDescription(example = @Example("item('minecraft:stone')"))
+    public void removeByOutput(IIngredient output) {
+        for (IKilnRecipe recipe : getRegistry()) {
+            if (output.test(recipe.getOutput())) {
+                remove(recipe);
+            }
+        }
+    }
+
+    @Property(property = "name")
+    @Property(property = "input", valid = @Comp("1"))
+    @Property(property = "output", valid = @Comp("1"))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<IKilnRecipe> {
+
+        @Property(valid = @Comp(type = Comp.Type.GTE, value = "0"))
+        private float experience;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder experience(float experience) {
+            this.experience = experience;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Atum 2 Kiln recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateName();
+            validateItems(msg, 1, 1, 1, 1);
+            validateFluids(msg);
+            msg.add(experience < 0, "experience must be a non negative float, yet it was {}", experience);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable IKilnRecipe register() {
+            if (!validate()) return null;
+            IKilnRecipe recipe = null;
+            if (input.get(0) instanceof OreDictIngredient oreDictIngredient) {
+                recipe = new KilnRecipe(oreDictIngredient.getOreDict(), output.get(0), experience);
+                recipe.setRegistryName(super.name);
+                ModSupport.ATUM.get().kiln.add(recipe);
+                return recipe;
+            } else {
+                ItemStack[] matchingStacks = input.get(0).getMatchingStacks();
+                for (int i = 0; i < matchingStacks.length; i++) {
+                    recipe = new KilnRecipe(matchingStacks[i], output.get(0), experience);
+                    var location = new ResourceLocation(super.name.getNamespace(), super.name.getPath() + i);
+                    recipe.setRegistryName(location);
+                    ModSupport.ATUM.get().kiln.add(recipe);
+                }
+            }
+            return recipe;
+        }
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/atum/Quern.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/atum/Quern.java
@@ -1,0 +1,111 @@
+package com.cleanroommc.groovyscript.compat.mods.atum;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.ingredient.OreDictIngredient;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import com.cleanroommc.groovyscript.registry.ForgeRegistryWrapper;
+import com.teammetallurgy.atum.api.recipe.RecipeHandlers;
+import com.teammetallurgy.atum.api.recipe.quern.IQuernRecipe;
+import com.teammetallurgy.atum.api.recipe.quern.QuernRecipe;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
+import org.jetbrains.annotations.Nullable;
+
+@RegistryDescription
+public class Quern extends ForgeRegistryWrapper<IQuernRecipe> {
+
+    public Quern() {
+        super(RecipeHandlers.quernRecipes);
+    }
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:diamond')).output(item('minecraft:clay')).rotations(1)"),
+            @Example(".input(item('minecraft:gold_ingot')).output(item('minecraft:clay') * 4).rotations(5)")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    public IQuernRecipe add(IIngredient input, ItemStack output) {
+        return add(input, output, 1);
+    }
+
+    public IQuernRecipe add(IIngredient input, ItemStack output, int rotations) {
+        return recipeBuilder()
+                .rotations(rotations)
+                .input(input)
+                .output(output)
+                .register();
+    }
+
+    @MethodDescription(example = @Example("item('minecraft:blaze_rod')"))
+    public void removeByInput(IIngredient input) {
+        for (IQuernRecipe recipe : getRegistry()) {
+            if (recipe.getInput().stream().anyMatch(input)) {
+                remove(recipe);
+            }
+        }
+    }
+
+    @MethodDescription(example = @Example("item('minecraft:sugar')"))
+    public void removeByOutput(IIngredient output) {
+        for (IQuernRecipe recipe : getRegistry()) {
+            if (output.test(recipe.getOutput())) {
+                remove(recipe);
+            }
+        }
+    }
+
+    @Property(property = "name")
+    @Property(property = "input", valid = @Comp("1"))
+    @Property(property = "output", valid = @Comp("1"))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<IQuernRecipe> {
+
+        @Property(valid = @Comp(type = Comp.Type.GT, value = "0"))
+        private int rotations;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder rotations(int rotations) {
+            this.rotations = rotations;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Atum 2 Quern recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateName();
+            validateItems(msg, 1, 1, 1, 1);
+            validateFluids(msg);
+            msg.add(rotations <= 0, "rotations must be a greater than 0, yet it was {}", rotations);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable IQuernRecipe register() {
+            if (!validate()) return null;
+            IQuernRecipe recipe = null;
+            if (input.get(0) instanceof OreDictIngredient oreDictIngredient) {
+                recipe = new QuernRecipe(oreDictIngredient.getOreDict(), output.get(0), rotations);
+                recipe.setRegistryName(super.name);
+                ModSupport.ATUM.get().quern.add(recipe);
+                return recipe;
+            } else {
+                ItemStack[] matchingStacks = input.get(0).getMatchingStacks();
+                for (int i = 0; i < matchingStacks.length; i++) {
+                    recipe = new QuernRecipe(matchingStacks[i], output.get(0), rotations);
+                    var location = new ResourceLocation(super.name.getNamespace(), super.name.getPath() + i);
+                    recipe.setRegistryName(location);
+                    ModSupport.ATUM.get().quern.add(recipe);
+                }
+            }
+            return recipe;
+        }
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/atum/SpinningWheel.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/atum/SpinningWheel.java
@@ -1,0 +1,111 @@
+package com.cleanroommc.groovyscript.compat.mods.atum;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.ingredient.OreDictIngredient;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import com.cleanroommc.groovyscript.registry.ForgeRegistryWrapper;
+import com.teammetallurgy.atum.api.recipe.RecipeHandlers;
+import com.teammetallurgy.atum.api.recipe.spinningwheel.ISpinningWheelRecipe;
+import com.teammetallurgy.atum.api.recipe.spinningwheel.SpinningWheelRecipe;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
+import org.jetbrains.annotations.Nullable;
+
+@RegistryDescription
+public class SpinningWheel extends ForgeRegistryWrapper<ISpinningWheelRecipe> {
+
+    public SpinningWheel() {
+        super(RecipeHandlers.spinningWheelRecipes);
+    }
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:diamond')).output(item('minecraft:clay')).rotations(1)"),
+            @Example(".input(item('minecraft:gold_ingot')).output(item('minecraft:clay') * 4).rotations(5)")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    public ISpinningWheelRecipe add(IIngredient input, ItemStack output) {
+        return add(input, output, 1);
+    }
+
+    public ISpinningWheelRecipe add(IIngredient input, ItemStack output, int rotations) {
+        return recipeBuilder()
+                .rotations(rotations)
+                .input(input)
+                .output(output)
+                .register();
+    }
+
+    @MethodDescription(example = @Example("item('atum:flax')"))
+    public void removeByInput(IIngredient input) {
+        for (ISpinningWheelRecipe recipe : getRegistry()) {
+            if (recipe.getInput().stream().anyMatch(input)) {
+                remove(recipe);
+            }
+        }
+    }
+
+    @MethodDescription(example = @Example("item('minecraft:string')"))
+    public void removeByOutput(IIngredient output) {
+        for (ISpinningWheelRecipe recipe : getRegistry()) {
+            if (output.test(recipe.getOutput())) {
+                remove(recipe);
+            }
+        }
+    }
+
+    @Property(property = "name")
+    @Property(property = "input", valid = @Comp("1"))
+    @Property(property = "output", valid = @Comp("1"))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<ISpinningWheelRecipe> {
+
+        @Property(valid = @Comp(type = Comp.Type.GT, value = "0"))
+        private int rotations;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder rotations(int rotations) {
+            this.rotations = rotations;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Atum 2 Spinning Wheel recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateName();
+            validateItems(msg, 1, 1, 1, 1);
+            validateFluids(msg);
+            msg.add(rotations <= 0, "rotations must be a greater than 0, yet it was {}", rotations);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable ISpinningWheelRecipe register() {
+            if (!validate()) return null;
+            ISpinningWheelRecipe recipe = null;
+            if (input.get(0) instanceof OreDictIngredient oreDictIngredient) {
+                recipe = new SpinningWheelRecipe(oreDictIngredient.getOreDict(), output.get(0), rotations);
+                recipe.setRegistryName(super.name);
+                ModSupport.ATUM.get().spinningWheel.add(recipe);
+                return recipe;
+            } else {
+                ItemStack[] matchingStacks = input.get(0).getMatchingStacks();
+                for (int i = 0; i < matchingStacks.length; i++) {
+                    recipe = new SpinningWheelRecipe(matchingStacks[i], output.get(0), rotations);
+                    var location = new ResourceLocation(super.name.getNamespace(), super.name.getPath() + i);
+                    recipe.setRegistryName(location);
+                    ModSupport.ATUM.get().spinningWheel.add(recipe);
+                }
+            }
+            return recipe;
+        }
+    }
+}

--- a/src/main/resources/assets/groovyscript/lang/en_us.lang
+++ b/src/main/resources/assets/groovyscript/lang/en_us.lang
@@ -391,6 +391,21 @@ groovyscript.wiki.avaritia.extreme_crafting.description=A normal crafting table,
 groovyscript.wiki.avaritia.extreme_crafting.addShaped=Adds a shaped crafting recipe in the format `output`, `input`
 groovyscript.wiki.avaritia.extreme_crafting.addShapeless=Adds a shapeless crafting recipe in the format `output`, `input`
 
+
+# Atum 2
+groovyscript.wiki.atum.kiln.title=Kiln
+groovyscript.wiki.atum.kiln.description=Smelts an input item into an output itemstack and giving experience similar to a Furnace, but can process up to 4 stacks simultaneously. Makes a copy of the vanilla furnace recipes, excluding entries on a blacklist.
+groovyscript.wiki.atum.kiln.experience.value=Sets the experience gained by taking the output item out of the Kiln
+
+groovyscript.wiki.atum.quern.title=Quern
+groovyscript.wiki.atum.quern.description=Converts an input item into an output itemstack after a given number of rotations, which are done via a player right clicking the Quern.
+groovyscript.wiki.atum.quern.rotations.value=Sets the amount of rotation required to convert the input into the output
+
+groovyscript.wiki.atum.spinning_wheel.title=Spinning Wheel
+groovyscript.wiki.atum.spinning_wheel.description=Converts three input items into an output itemstack after a given number of rotations for each input item, items are inserted by interacting with the top, rotations are increased by interacting with the top, and output items are extracted by interacting with the spool side.
+groovyscript.wiki.atum.spinning_wheel.rotations.value=Sets the amount of rotation required to convert the input into the output
+
+
 # Better With Mods
 groovyscript.wiki.betterwithmods.anvil_crafting.title=Anvil Crafting
 groovyscript.wiki.betterwithmods.anvil_crafting.description=Similar to a normal crafting table, but 4x4 instead.


### PR DESCRIPTION
changes in this PR:
- adds `Kiln`, `Quern`, and `SpinningWheel` compat.
- adds examples file and i18n wiki keys for the above compat.

does not add compat for the `KilnBlacklist`