### PR TITLE
Fix some IE Recipe Builders not using IIngredient properly

### DIFF
--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/ArcFurnace.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/ArcFurnace.java
@@ -221,7 +221,7 @@ public class ArcFurnace extends VirtualizedRegistry<ArcFurnaceRecipe> {
         public @Nullable ArcFurnaceRecipe register() {
             if (!validate()) return null;
             Object[] additives = ArrayUtils.mapToArray(input, ImmersiveEngineering::toIngredientStack);
-            ArcFurnaceRecipe recipe = new ArcFurnaceRecipe(output.get(0), mainInput, slag, time, energyPerTick, additives);
+            ArcFurnaceRecipe recipe = new ArcFurnaceRecipe(output.get(0), ImmersiveEngineering.toIngredientStack(mainInput), slag, time, energyPerTick, additives);
             if (specialRecipeType != null) recipe.setSpecialRecipeType(specialRecipeType);
             ModSupport.IMMERSIVE_ENGINEERING.get().arcFurnace.add(recipe);
             return recipe;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/Crusher.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/Crusher.java
@@ -151,7 +151,7 @@ public class Crusher extends VirtualizedRegistry<CrusherRecipe> {
         @RecipeBuilderRegistrationMethod
         public @Nullable CrusherRecipe register() {
             if (!validate()) return null;
-            CrusherRecipe recipe = new CrusherRecipe(output.get(0), input.get(0), energy);
+            CrusherRecipe recipe = new CrusherRecipe(output.get(0), ImmersiveEngineering.toIngredientStack(input.get(0)), energy);
             if (!secondaryOutputItems.isEmpty()) {
                 recipe.secondaryOutput = secondaryOutputItems.toArray(new ItemStack[0]);
                 recipe.secondaryChance = secondaryOutputChances.elements();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/Fermenter.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/Fermenter.java
@@ -133,7 +133,7 @@ public class Fermenter extends VirtualizedRegistry<FermenterRecipe> {
         @RecipeBuilderRegistrationMethod
         public @Nullable FermenterRecipe register() {
             if (!validate()) return null;
-            FermenterRecipe recipe = new FermenterRecipe(fluidOutput.get(0), output.getOrEmpty(0), input.get(0), energy);
+            FermenterRecipe recipe = new FermenterRecipe(fluidOutput.get(0), output.getOrEmpty(0), ImmersiveEngineering.toIngredientStack(input.get(0)), energy);
             ModSupport.IMMERSIVE_ENGINEERING.get().fermenter.add(recipe);
             return recipe;
         }


### PR DESCRIPTION
changes in this PR:
- make sure the input `IIngredient` is converted into an IE `IngredientStack` for three IE compats that it was before. 

resolves #195