### PR TITLE
add Primal Tech compat

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -77,6 +77,7 @@ final def mod_dependencies = [
         'mekanism-268560:2835175'                             : [project.debug_mekanism],
         'natures-aura-306626:2882138'                         : [project.debug_natures_aura],
         'packmode-278398:2567799'                             : [project.debug_packmode],
+        'primal-tech-290612:2801696'                          : [project.debug_primal_tech],
         'pneumaticcraft-repressurized-281849:2978408'         : [project.debug_pneumaticcraft],
         'projecte-226410:2702991'                             : [project.debug_projecte],
         'athenaeum-284350:4633750'                            : [project.debug_pyrotech],

--- a/examples/postInit/primal_tech.groovy
+++ b/examples/postInit/primal_tech.groovy
@@ -1,0 +1,91 @@
+
+// Auto generated groovyscript example file
+// MODS_LOADED: primal_tech
+
+println 'mod \'primal_tech\' detected, running script'
+
+// Clay Kiln:
+// Converts an input item into an output itemstack after a given amount of time. Requires the block below to be Minecraft
+// Fire or a Primal Tech Flame Grilled Wopper. Takes some time to heat up before beginning to smelt items.
+
+mods.primal_tech.clay_kiln.removeByInput(item('minecraft:gravel'))
+mods.primal_tech.clay_kiln.removeByOutput(item('primal_tech:charcoal_block'))
+// mods.primal_tech.clay_kiln.removeAll()
+
+mods.primal_tech.clay_kiln.recipeBuilder()
+    .input(item('minecraft:diamond'))
+    .output(item('minecraft:clay'))
+    .cookTime(50)
+    .register()
+
+mods.primal_tech.clay_kiln.recipeBuilder()
+    .input(item('minecraft:gold_ingot'))
+    .output(item('minecraft:diamond') * 4)
+    .cookTime(100)
+    .register()
+
+
+
+// Stone Anvil:
+// Converts an input item into an output itemstack after being interacted with by a player using a Stone Mallet.
+
+// mods.primal_tech.stone_anvil.removeByInput(item('primal_tech:flint_block'))
+mods.primal_tech.stone_anvil.removeByOutput(item('minecraft:flint'))
+// mods.primal_tech.stone_anvil.removeAll()
+
+mods.primal_tech.stone_anvil.recipeBuilder()
+    .input(item('minecraft:diamond'))
+    .output(item('minecraft:clay'))
+    .register()
+
+mods.primal_tech.stone_anvil.recipeBuilder()
+    .input(item('minecraft:gold_ingot'))
+    .output(item('minecraft:diamond') * 4)
+    .register()
+
+
+
+// Water Saw:
+// Converts an input item into an output itemstack after a given amount of time. Requires the block below it to be a water
+// source block, and the block below and behind it flowing water.
+
+mods.primal_tech.water_saw.removeByInput(item('minecraft:log'))
+mods.primal_tech.water_saw.removeByOutput(item('minecraft:planks:1'))
+// mods.primal_tech.water_saw.removeAll()
+
+mods.primal_tech.water_saw.recipeBuilder()
+    .input(item('minecraft:diamond'))
+    .output(item('minecraft:clay'))
+    .choppingTime(50)
+    .register()
+
+mods.primal_tech.water_saw.recipeBuilder()
+    .input(item('minecraft:gold_ingot'))
+    .output(item('minecraft:diamond') * 4)
+    .choppingTime(100)
+    .register()
+
+
+
+// Wooden Basin:
+// Converts up to 4 items and 1000mb of fluid into an output itemstack.
+
+mods.primal_tech.wooden_basin.removeByInput(fluid('lava'))
+// mods.primal_tech.wooden_basin.removeByInput(item('minecraft:cobblestone'))
+// mods.primal_tech.wooden_basin.removeByOutput(item('minecraft:obsidian'))
+// mods.primal_tech.wooden_basin.removeAll()
+
+mods.primal_tech.wooden_basin.recipeBuilder()
+    .input(item('minecraft:diamond'))
+    .fluidInput(fluid('lava'))
+    .output(item('minecraft:clay'))
+    .register()
+
+mods.primal_tech.wooden_basin.recipeBuilder()
+    .input(item('minecraft:gold_ingot'), item('minecraft:clay'), item('minecraft:gold_ingot'), item('minecraft:clay'))
+    .fluidInput(fluid('water'))
+    .output(item('minecraft:diamond') * 4)
+    .register()
+
+
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -45,6 +45,7 @@ debug_mekanism = false
 debug_natures_aura = false
 debug_packmode = false
 debug_pneumaticcraft = false
+debug_primal_tech = false
 debug_prodigytech = false
 debug_projecte = false
 debug_pyrotech = false

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ModSupport.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ModSupport.java
@@ -35,6 +35,7 @@ import com.cleanroommc.groovyscript.compat.mods.lazyae2.LazyAE2;
 import com.cleanroommc.groovyscript.compat.mods.mekanism.Mekanism;
 import com.cleanroommc.groovyscript.compat.mods.naturesaura.NaturesAura;
 import com.cleanroommc.groovyscript.compat.mods.pneumaticcraft.PneumaticCraft;
+import com.cleanroommc.groovyscript.compat.mods.primaltech.PrimalTech;
 import com.cleanroommc.groovyscript.compat.mods.prodigytech.ProdigyTech;
 import com.cleanroommc.groovyscript.compat.mods.projecte.ProjectE;
 import com.cleanroommc.groovyscript.compat.mods.pyrotech.PyroTech;
@@ -99,6 +100,7 @@ public class ModSupport {
     public static final GroovyContainer<LazyAE2> LAZYAE2 = new InternalModContainer<>("threng", "LazyAE2", LazyAE2::new, "lazyae2");
     public static final GroovyContainer<NaturesAura> NATURES_AURA = new InternalModContainer<>("naturesaura", "Nature's Aura", NaturesAura::new);
     public static final GroovyContainer<PneumaticCraft> PNEUMATIC_CRAFT = new InternalModContainer<>("pneumaticcraft", "PneumaticCraft: Repressurized", PneumaticCraft::new);
+    public static final GroovyContainer<PrimalTech> PRIMAL_TECH = new InternalModContainer<>("primal_tech", "Primal Tech", PrimalTech::new, "primaltech");
     public static final GroovyContainer<ProdigyTech> PRODIGY_TECH = new InternalModContainer<>("prodigytech", "Prodigy Tech", ProdigyTech::new);
     public static final GroovyContainer<ProjectE> PROJECT_E = new InternalModContainer<>("projecte", "ProjectE", ProjectE::new);
     public static final GroovyContainer<PyroTech> PYROTECH = new InternalModContainer<>("pyrotech", "Pyrotech", PyroTech::new);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/primaltech/ClayKiln.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/primaltech/ClayKiln.java
@@ -1,0 +1,126 @@
+package com.cleanroommc.groovyscript.compat.mods.primaltech;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.core.mixin.primal_tech.ClayKilnRecipesAccessor;
+import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import net.minecraft.item.ItemStack;
+import org.jetbrains.annotations.Nullable;
+import primal_tech.recipes.ClayKilnRecipes;
+
+@RegistryDescription
+public class ClayKiln extends VirtualizedRegistry<ClayKilnRecipes> {
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:diamond')).output(item('minecraft:clay')).cookTime(50)"),
+            @Example(".input(item('minecraft:gold_ingot')).output(item('minecraft:diamond') * 4).cookTime(100)")
+    })
+    public static RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @Override
+    public void onReload() {
+        ClayKilnRecipesAccessor.getRecipes().removeAll(removeScripted());
+        ClayKilnRecipesAccessor.getRecipes().addAll(restoreFromBackup());
+    }
+
+    public void add(ClayKilnRecipes recipe) {
+        if (recipe != null) {
+            addScripted(recipe);
+            ClayKilnRecipesAccessor.getRecipes().add(recipe);
+        }
+    }
+
+    @MethodDescription(type = MethodDescription.Type.ADDITION)
+    public ClayKilnRecipes add(ItemStack output, IIngredient input, int cookTime) {
+        return recipeBuilder()
+                .cookTime(cookTime)
+                .input(input)
+                .output(output)
+                .register();
+    }
+
+    public boolean remove(ClayKilnRecipes recipe) {
+        if (ClayKilnRecipesAccessor.getRecipes().removeIf(r -> r == recipe)) {
+            addBackup(recipe);
+            return true;
+        }
+        return false;
+    }
+
+    @MethodDescription(example = @Example("item('minecraft:gravel')"))
+    public boolean removeByInput(IIngredient input) {
+        return ClayKilnRecipesAccessor.getRecipes().removeIf(recipe -> {
+            if (input.test(recipe.getInput())) {
+                addBackup(recipe);
+                return true;
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(example = @Example("item('primal_tech:charcoal_block')"))
+    public boolean removeByOutput(IIngredient output) {
+        return ClayKilnRecipesAccessor.getRecipes().removeIf(recipe -> {
+            if (output.test(recipe.getOutput())) {
+                addBackup(recipe);
+                return true;
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(type = MethodDescription.Type.QUERY)
+    public SimpleObjectStream<ClayKilnRecipes> streamRecipes() {
+        return new SimpleObjectStream<>(ClayKilnRecipesAccessor.getRecipes()).setRemover(this::remove);
+    }
+
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
+    public void removeAll() {
+        ClayKilnRecipesAccessor.getRecipes().forEach(this::addBackup);
+        ClayKilnRecipesAccessor.getRecipes().clear();
+    }
+
+    @Property(property = "input", valid = @Comp("1"))
+    @Property(property = "output", valid = @Comp("1"))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<ClayKilnRecipes> {
+
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GTE))
+        private int cookTime;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder cookTime(int cookTime) {
+            this.cookTime = cookTime;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Primal Tech Clay Kiln recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 1, 1, 1, 1);
+            validateFluids(msg);
+            msg.add(cookTime < 0, "cookTime must be greater than or equal to 0, yet it was {}", cookTime);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable ClayKilnRecipes register() {
+            if (!validate()) return null;
+            ClayKilnRecipes recipe = null;
+            for (ItemStack matchingStack : input.get(0).getMatchingStacks()) {
+                recipe = ClayKilnRecipesAccessor.createClayKilnRecipes(output.get(0), matchingStack, cookTime);
+                ModSupport.PRIMAL_TECH.get().clayKiln.add(recipe);
+            }
+            return recipe;
+        }
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/primaltech/PrimalTech.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/primaltech/PrimalTech.java
@@ -1,0 +1,12 @@
+package com.cleanroommc.groovyscript.compat.mods.primaltech;
+
+import com.cleanroommc.groovyscript.compat.mods.GroovyPropertyContainer;
+
+public class PrimalTech extends GroovyPropertyContainer {
+
+    public final ClayKiln clayKiln = new ClayKiln();
+    public final StoneAnvil stoneAnvil = new StoneAnvil();
+    public final WaterSaw waterSaw = new WaterSaw();
+    public final WoodenBasin woodenBasin = new WoodenBasin();
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/primaltech/StoneAnvil.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/primaltech/StoneAnvil.java
@@ -1,0 +1,115 @@
+package com.cleanroommc.groovyscript.compat.mods.primaltech;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.core.mixin.primal_tech.StoneAnvilRecipesAccessor;
+import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import net.minecraft.item.ItemStack;
+import org.jetbrains.annotations.Nullable;
+import primal_tech.recipes.StoneAnvilRecipes;
+
+@RegistryDescription
+public class StoneAnvil extends VirtualizedRegistry<StoneAnvilRecipes> {
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:diamond')).output(item('minecraft:clay'))"),
+            @Example(".input(item('minecraft:gold_ingot')).output(item('minecraft:diamond') * 4)")
+    })
+    public static RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @Override
+    public void onReload() {
+        StoneAnvilRecipesAccessor.getRecipes().removeAll(removeScripted());
+        StoneAnvilRecipesAccessor.getRecipes().addAll(restoreFromBackup());
+    }
+
+    public void add(StoneAnvilRecipes recipe) {
+        if (recipe != null) {
+            addScripted(recipe);
+            StoneAnvilRecipesAccessor.getRecipes().add(recipe);
+        }
+    }
+
+    @MethodDescription(type = MethodDescription.Type.ADDITION)
+    public StoneAnvilRecipes add(ItemStack output, IIngredient input) {
+        return recipeBuilder()
+                .input(input)
+                .output(output)
+                .register();
+    }
+
+    public boolean remove(StoneAnvilRecipes recipe) {
+        if (StoneAnvilRecipesAccessor.getRecipes().removeIf(r -> r == recipe)) {
+            addBackup(recipe);
+            return true;
+        }
+        return false;
+    }
+
+    @MethodDescription(example = @Example(value = "item('primal_tech:flint_block')", commented = true))
+    public boolean removeByInput(IIngredient input) {
+        return StoneAnvilRecipesAccessor.getRecipes().removeIf(recipe -> {
+            if (input.test(recipe.getInput())) {
+                addBackup(recipe);
+                return true;
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(example = @Example("item('minecraft:flint')"))
+    public boolean removeByOutput(IIngredient output) {
+        return StoneAnvilRecipesAccessor.getRecipes().removeIf(recipe -> {
+            if (output.test(recipe.getOutput())) {
+                addBackup(recipe);
+                return true;
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(type = MethodDescription.Type.QUERY)
+    public SimpleObjectStream<StoneAnvilRecipes> streamRecipes() {
+        return new SimpleObjectStream<>(StoneAnvilRecipesAccessor.getRecipes()).setRemover(this::remove);
+    }
+
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
+    public void removeAll() {
+        StoneAnvilRecipesAccessor.getRecipes().forEach(this::addBackup);
+        StoneAnvilRecipesAccessor.getRecipes().clear();
+    }
+
+    @Property(property = "input", valid = @Comp("1"))
+    @Property(property = "output", valid = @Comp("1"))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<StoneAnvilRecipes> {
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Primal Tech Stone Anvil recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 1, 1, 1, 1);
+            validateFluids(msg);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable StoneAnvilRecipes register() {
+            if (!validate()) return null;
+            StoneAnvilRecipes recipe = null;
+            for (ItemStack matchingStack : input.get(0).getMatchingStacks()) {
+                recipe = StoneAnvilRecipesAccessor.createStoneAnvilRecipes(output.get(0), matchingStack);
+                ModSupport.PRIMAL_TECH.get().stoneAnvil.add(recipe);
+            }
+            return recipe;
+        }
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/primaltech/WaterSaw.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/primaltech/WaterSaw.java
@@ -1,0 +1,126 @@
+package com.cleanroommc.groovyscript.compat.mods.primaltech;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.core.mixin.primal_tech.WaterSawRecipesAccessor;
+import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import net.minecraft.item.ItemStack;
+import org.jetbrains.annotations.Nullable;
+import primal_tech.recipes.WaterSawRecipes;
+
+@RegistryDescription
+public class WaterSaw extends VirtualizedRegistry<WaterSawRecipes> {
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:diamond')).output(item('minecraft:clay')).choppingTime(50)"),
+            @Example(".input(item('minecraft:gold_ingot')).output(item('minecraft:diamond') * 4).choppingTime(100)")
+    })
+    public static RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @Override
+    public void onReload() {
+        WaterSawRecipesAccessor.getRecipes().removeAll(removeScripted());
+        WaterSawRecipesAccessor.getRecipes().addAll(restoreFromBackup());
+    }
+
+    public void add(WaterSawRecipes recipe) {
+        if (recipe != null) {
+            addScripted(recipe);
+            WaterSawRecipesAccessor.getRecipes().add(recipe);
+        }
+    }
+
+    @MethodDescription(type = MethodDescription.Type.ADDITION)
+    public WaterSawRecipes add(ItemStack output, IIngredient input, int choppingTime) {
+        return recipeBuilder()
+                .choppingTime(choppingTime)
+                .input(input)
+                .output(output)
+                .register();
+    }
+
+    public boolean remove(WaterSawRecipes recipe) {
+        if (WaterSawRecipesAccessor.getRecipes().removeIf(r -> r == recipe)) {
+            addBackup(recipe);
+            return true;
+        }
+        return false;
+    }
+
+    @MethodDescription(example = @Example("item('minecraft:log')"))
+    public boolean removeByInput(IIngredient input) {
+        return WaterSawRecipesAccessor.getRecipes().removeIf(recipe -> {
+            if (input.test(recipe.getInput())) {
+                addBackup(recipe);
+                return true;
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(example = @Example("item('minecraft:planks:1')"))
+    public boolean removeByOutput(IIngredient output) {
+        return WaterSawRecipesAccessor.getRecipes().removeIf(recipe -> {
+            if (output.test(recipe.getOutput())) {
+                addBackup(recipe);
+                return true;
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(type = MethodDescription.Type.QUERY)
+    public SimpleObjectStream<WaterSawRecipes> streamRecipes() {
+        return new SimpleObjectStream<>(WaterSawRecipesAccessor.getRecipes()).setRemover(this::remove);
+    }
+
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
+    public void removeAll() {
+        WaterSawRecipesAccessor.getRecipes().forEach(this::addBackup);
+        WaterSawRecipesAccessor.getRecipes().clear();
+    }
+
+    @Property(property = "input", valid = @Comp("1"))
+    @Property(property = "output", valid = @Comp("1"))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<WaterSawRecipes> {
+
+        @Property(valid = @Comp(value = "0", type = Comp.Type.GTE))
+        private int choppingTime;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder choppingTime(int choppingTime) {
+            this.choppingTime = choppingTime;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Primal Tech Water Saw recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 1, 1, 1, 1);
+            validateFluids(msg);
+            msg.add(choppingTime < 0, "choppingTime must be greater than or equal to 0, yet it was {}", choppingTime);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable WaterSawRecipes register() {
+            if (!validate()) return null;
+            WaterSawRecipes recipe = null;
+            for (ItemStack matchingStack : input.get(0).getMatchingStacks()) {
+                recipe = WaterSawRecipesAccessor.createWaterSawRecipes(output.get(0), matchingStack, choppingTime);
+                ModSupport.PRIMAL_TECH.get().waterSaw.add(recipe);
+            }
+            return recipe;
+        }
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/primaltech/WoodenBasin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/primaltech/WoodenBasin.java
@@ -1,0 +1,137 @@
+package com.cleanroommc.groovyscript.compat.mods.primaltech;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.core.mixin.primal_tech.WoodenBasinRecipesAccessor;
+import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
+import com.cleanroommc.groovyscript.helper.ingredient.OreDictIngredient;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import com.google.common.collect.Lists;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
+import org.jetbrains.annotations.Nullable;
+import primal_tech.recipes.WoodenBasinRecipes;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RegistryDescription(
+        admonition = @Admonition(type = Admonition.Type.WARNING, value = "groovyscript.wiki.primal_tech.wooden_basin.note0")
+)
+public class WoodenBasin extends VirtualizedRegistry<WoodenBasinRecipes> {
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:diamond')).fluidInput(fluid('lava')).output(item('minecraft:clay'))"),
+            @Example(".input(item('minecraft:gold_ingot'), item('minecraft:clay'), item('minecraft:gold_ingot'), item('minecraft:clay')).fluidInput(fluid('water')).output(item('minecraft:diamond') * 4)")
+    })
+    public static RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @Override
+    public void onReload() {
+        WoodenBasinRecipesAccessor.getRecipes().removeAll(removeScripted());
+        WoodenBasinRecipesAccessor.getRecipes().addAll(restoreFromBackup());
+    }
+
+    public void add(WoodenBasinRecipes recipe) {
+        if (recipe != null) {
+            addScripted(recipe);
+            WoodenBasinRecipesAccessor.getRecipes().add(recipe);
+        }
+    }
+
+    @MethodDescription(type = MethodDescription.Type.ADDITION)
+    public WoodenBasinRecipes add(ItemStack output, FluidStack fluid, IIngredient... inputs) {
+        return recipeBuilder()
+                .input(inputs)
+                .fluidInput(fluid)
+                .output(output)
+                .register();
+    }
+
+    public boolean remove(WoodenBasinRecipes recipe) {
+        if (WoodenBasinRecipesAccessor.getRecipes().removeIf(r -> r == recipe)) {
+            addBackup(recipe);
+            return true;
+        }
+        return false;
+    }
+
+    @MethodDescription(example = {@Example("fluid('lava')"), @Example(value = "item('minecraft:cobblestone')", commented = true)})
+    public boolean removeByInput(IIngredient input) {
+        return WoodenBasinRecipesAccessor.getRecipes().removeIf(recipe -> {
+            if (input.test(recipe.getFluidStack()) ||
+                Arrays.stream(recipe.getInputs()).anyMatch(x -> {
+                    if (x instanceof ItemStack is) return input.test(is);
+                    if (x instanceof List<?> list) return list.stream().map(i -> (ItemStack) i).anyMatch(input);
+                    return false;
+                })) {
+                addBackup(recipe);
+                return true;
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(example = @Example(value = "item('minecraft:obsidian')", commented = true))
+    public boolean removeByOutput(IIngredient output) {
+        return WoodenBasinRecipesAccessor.getRecipes().removeIf(recipe -> {
+            if (output.test(recipe.getOutput())) {
+                addBackup(recipe);
+                return true;
+            }
+            return false;
+        });
+    }
+
+    @MethodDescription(type = MethodDescription.Type.QUERY)
+    public SimpleObjectStream<WoodenBasinRecipes> streamRecipes() {
+        return new SimpleObjectStream<>(WoodenBasinRecipesAccessor.getRecipes()).setRemover(this::remove);
+    }
+
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
+    public void removeAll() {
+        WoodenBasinRecipesAccessor.getRecipes().forEach(this::addBackup);
+        WoodenBasinRecipesAccessor.getRecipes().clear();
+    }
+
+    @Property(property = "input", valid = {@Comp(value = "1", type = Comp.Type.GTE), @Comp(value = "4", type = Comp.Type.LTE)})
+    @Property(property = "fluidInput", valid = @Comp("1"))
+    @Property(property = "output", valid = @Comp("1"))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<WoodenBasinRecipes> {
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Primal Tech Wooden Basin recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 1, 4, 1, 1);
+            validateFluids(msg, 1, 1, 0, 0);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable WoodenBasinRecipes register() {
+            if (!validate()) return null;
+            WoodenBasinRecipes recipe = null;
+            List<List<Object>> cartesian = Lists.cartesianProduct(
+                    input.stream().map(x -> x instanceof OreDictIngredient ore
+                                            ? Collections.singletonList(ore.getOreDict())
+                                            : Arrays.asList(x.toMcIngredient().getMatchingStacks()))
+                            .collect(Collectors.toList()));
+            for (List<Object> entry : cartesian) {
+                recipe = WoodenBasinRecipesAccessor.createWoodenBasinRecipes(output.get(0), fluidInput.get(0), entry.toArray());
+                ModSupport.PRIMAL_TECH.get().woodenBasin.add(recipe);
+            }
+            return recipe;
+        }
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/core/LateMixin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/LateMixin.java
@@ -31,6 +31,7 @@ public class LateMixin implements ILateMixinLoader {
             "jei",
             "mekanism",
             "pneumaticcraft",
+            "primal_tech",
             "projecte",
             "pyrotech",
             "roots",

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/primal_tech/ClayKilnRecipesAccessor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/primal_tech/ClayKilnRecipesAccessor.java
@@ -1,0 +1,24 @@
+package com.cleanroommc.groovyscript.core.mixin.primal_tech;
+
+import net.minecraft.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+import org.spongepowered.asm.mixin.gen.Invoker;
+import primal_tech.recipes.ClayKilnRecipes;
+
+import java.util.List;
+
+@Mixin(value = ClayKilnRecipes.class, remap = false)
+public interface ClayKilnRecipesAccessor {
+
+    @Accessor
+    static List<ClayKilnRecipes> getRecipes() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Invoker("<init>")
+    static ClayKilnRecipes createClayKilnRecipes(ItemStack output, ItemStack input, int itemCookTime) {
+        throw new UnsupportedOperationException();
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/primal_tech/StoneAnvilRecipesAccessor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/primal_tech/StoneAnvilRecipesAccessor.java
@@ -1,0 +1,24 @@
+package com.cleanroommc.groovyscript.core.mixin.primal_tech;
+
+import net.minecraft.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+import org.spongepowered.asm.mixin.gen.Invoker;
+import primal_tech.recipes.StoneAnvilRecipes;
+
+import java.util.List;
+
+@Mixin(value = StoneAnvilRecipes.class, remap = false)
+public interface StoneAnvilRecipesAccessor {
+
+    @Accessor
+    static List<StoneAnvilRecipes> getRecipes() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Invoker("<init>")
+    static StoneAnvilRecipes createStoneAnvilRecipes(ItemStack output, ItemStack input) {
+        throw new UnsupportedOperationException();
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/primal_tech/WaterSawRecipesAccessor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/primal_tech/WaterSawRecipesAccessor.java
@@ -1,0 +1,24 @@
+package com.cleanroommc.groovyscript.core.mixin.primal_tech;
+
+import net.minecraft.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+import org.spongepowered.asm.mixin.gen.Invoker;
+import primal_tech.recipes.WaterSawRecipes;
+
+import java.util.List;
+
+@Mixin(value = WaterSawRecipes.class, remap = false)
+public interface WaterSawRecipesAccessor {
+
+    @Accessor
+    static List<WaterSawRecipes> getRecipes() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Invoker("<init>")
+    static WaterSawRecipes createWaterSawRecipes(ItemStack output, ItemStack input, int choppingTime) {
+        throw new UnsupportedOperationException();
+    }
+
+}

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/primal_tech/WoodenBasinRecipesAccessor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/primal_tech/WoodenBasinRecipesAccessor.java
@@ -1,0 +1,25 @@
+package com.cleanroommc.groovyscript.core.mixin.primal_tech;
+
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+import org.spongepowered.asm.mixin.gen.Invoker;
+import primal_tech.recipes.WoodenBasinRecipes;
+
+import java.util.List;
+
+@Mixin(value = WoodenBasinRecipes.class, remap = false)
+public interface WoodenBasinRecipesAccessor {
+
+    @Accessor
+    static List<WoodenBasinRecipes> getRecipes() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Invoker("<init>")
+    static WoodenBasinRecipes createWoodenBasinRecipes(ItemStack output, FluidStack fluidIn, Object... input) {
+        throw new UnsupportedOperationException();
+    }
+
+}

--- a/src/main/resources/assets/groovyscript/lang/en_us.lang
+++ b/src/main/resources/assets/groovyscript/lang/en_us.lang
@@ -1323,6 +1323,28 @@ groovyscript.wiki.naturesaura.spawning.entity.value=Sets the entity spawned
 groovyscript.wiki.naturesaura.spawning.removeByEntity=Removes all Altar of Birthing recipes that summon the given entity
 groovyscript.wiki.naturesaura.spawning.removeByName=Removes the Altar of Birthing recipe with the given name
 
+
+# Primal Tech
+groovyscript.wiki.primal_tech.clay_kiln.title=Clay Kiln
+groovyscript.wiki.primal_tech.clay_kiln.description=Converts an input item into an output itemstack after a given amount of time. Requires the block below to be Minecraft Fire or a Primal Tech Flame Grilled Wopper. Takes some time to heat up before beginning to smelt items.
+groovyscript.wiki.primal_tech.clay_kiln.add=Adds recipes in the format `output`, `input`, `cookTime`
+groovyscript.wiki.primal_tech.clay_kiln.cookTime.value=Sets the time in ticks for the recipe to complete after the Clay Kiln is heated up enough
+
+groovyscript.wiki.primal_tech.stone_anvil.title=Stone Anvil
+groovyscript.wiki.primal_tech.stone_anvil.description=Converts an input item into an output itemstack after being interacted with by a player using a Stone Mallet.
+groovyscript.wiki.primal_tech.stone_anvil.add=Adds recipes in the format `output`, `input`
+
+groovyscript.wiki.primal_tech.water_saw.title=Water Saw
+groovyscript.wiki.primal_tech.water_saw.description=Converts an input item into an output itemstack after a given amount of time. Requires the block below it to be a water source block, and the block below and behind it flowing water.
+groovyscript.wiki.primal_tech.water_saw.add=Adds recipes in the format `output`, `input`, `choppingTime`
+groovyscript.wiki.primal_tech.water_saw.choppingTime.value=Sets the time in ticks for the recipe to complete
+
+groovyscript.wiki.primal_tech.wooden_basin.title=Wooden Basin
+groovyscript.wiki.primal_tech.wooden_basin.description=Converts up to 4 items and 1000mb of fluid into an output itemstack.
+groovyscript.wiki.primal_tech.wooden_basin.note0=The recipe requires items to be inserted in a specific order, which is displayed in JEI as top, left, right, bottom. Consider only one type of item to avoid issues.
+groovyscript.wiki.primal_tech.wooden_basin.add=Adds recipes in the format `output`, `fluid`, `inputs`
+
+
 # ProdigyTech
 groovyscript.wiki.prodigytech.atomic_reshaper.title=Atomic Reshaper
 groovyscript.wiki.prodigytech.atomic_reshaper.description=Uses Hot Air and Primordium to convert items. Can have a weighted random based output.

--- a/src/main/resources/mixin.groovyscript.primal_tech.json
+++ b/src/main/resources/mixin.groovyscript.primal_tech.json
@@ -1,0 +1,13 @@
+{
+  "package": "com.cleanroommc.groovyscript.core.mixin.primal_tech",
+  "refmap": "mixins.groovyscript.refmap.json",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": [
+    "ClayKilnRecipesAccessor",
+    "StoneAnvilRecipesAccessor",
+    "WaterSawRecipesAccessor",
+    "WoodenBasinRecipesAccessor"
+  ]
+}


### PR DESCRIPTION
changes in this PR:
- adds`ClayKiln`, `StoneAnvil`, `WaterSaw`, and `WoodenBasin` compat.
- adds examples file and i18n wiki keys for the above compat.
- use a mixin for each compat, as init method is private
