### PR TITLE
Create recipes using a RecipeBuilder in more situations

### DIFF
--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/actuallyadditions/AtomicReconstructor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/actuallyadditions/AtomicReconstructor.java
@@ -94,6 +94,8 @@ public class AtomicReconstructor extends VirtualizedRegistry<LensConversionRecip
 
         @Property(defaultValue = "1", valid = @Comp(type = Comp.Type.GT, value = "0"))
         private int energyUse = 1;
+        @Property(defaultValue = "ActuallyAdditionsAPI.lensDefaultConversion", valid = @Comp(value = "null", type = Comp.Type.NOT))
+        private Lens type = ActuallyAdditionsAPI.lensDefaultConversion;
 
         @RecipeBuilderMethodDescription
         public RecipeBuilder energyUse(int energyUse) {
@@ -107,6 +109,12 @@ public class AtomicReconstructor extends VirtualizedRegistry<LensConversionRecip
             return this;
         }
 
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder type(Lens type) {
+            this.type = type;
+            return this;
+        }
+
         @Override
         public String getErrorMsg() {
             return "Error adding Actually Additions Atomic Reconstructor recipe";
@@ -117,13 +125,14 @@ public class AtomicReconstructor extends VirtualizedRegistry<LensConversionRecip
             validateItems(msg, 1, 1, 1, 1);
             validateFluids(msg);
             msg.add(energyUse <= 0, "energyUse must be an integer greater than 0, yet it was {}", energyUse);
+            msg.add(type == null, "type must not be null!");
         }
 
         @Override
         @RecipeBuilderRegistrationMethod
         public @Nullable LensConversionRecipe register() {
             if (!validate()) return null;
-            LensConversionRecipe recipe = new LensConversionRecipe(input.get(0).toMcIngredient(), output.get(0), energyUse, ActuallyAdditionsAPI.lensDefaultConversion);
+            LensConversionRecipe recipe = new LensConversionRecipe(input.get(0).toMcIngredient(), output.get(0), energyUse, type);
             ModSupport.ACTUALLY_ADDITIONS.get().atomicReconstructor.add(recipe);
             return recipe;
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/actuallyadditions/AtomicReconstructor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/actuallyadditions/AtomicReconstructor.java
@@ -13,7 +13,6 @@ import de.ellpeck.actuallyadditions.api.ActuallyAdditionsAPI;
 import de.ellpeck.actuallyadditions.api.lens.Lens;
 import de.ellpeck.actuallyadditions.api.recipe.LensConversionRecipe;
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.crafting.Ingredient;
 import org.jetbrains.annotations.Nullable;
 
 @RegistryDescription
@@ -35,10 +34,13 @@ public class AtomicReconstructor extends VirtualizedRegistry<LensConversionRecip
         ActuallyAdditionsAPI.RECONSTRUCTOR_LENS_CONVERSION_RECIPES.addAll(restoreFromBackup());
     }
 
-    public LensConversionRecipe add(Ingredient input, ItemStack output, int energy, Lens type) {
-        LensConversionRecipe recipe = new LensConversionRecipe(input, output, energy, type);
-        add(recipe);
-        return recipe;
+    public LensConversionRecipe add(IIngredient input, ItemStack output, int energy, Lens type) {
+        return recipeBuilder()
+                .type(type)
+                .energy(energy)
+                .input(input)
+                .output(output)
+                .register();
     }
 
     public void add(LensConversionRecipe recipe) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Atomizer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Atomizer.java
@@ -33,7 +33,7 @@ public class Atomizer extends VirtualizedRegistry<AtomizerRecipe> {
 
     @MethodDescription(type = MethodDescription.Type.ADDITION)
     public AtomizerRecipe add(FluidStack input, ItemStack output) {
-        return new RecipeBuilder().fluidInput(input).output(output).register();
+        return recipeBuilder().fluidInput(input).output(output).register();
     }
 
     public AtomizerRecipe add(AtomizerRecipe recipe) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Evaporator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Evaporator.java
@@ -32,7 +32,7 @@ public class Evaporator extends VirtualizedRegistry<EvaporatorRecipe> {
 
     @MethodDescription(type = MethodDescription.Type.ADDITION)
     public EvaporatorRecipe add(FluidStack input, ItemStack output) {
-        return new RecipeBuilder().fluidInput(input).output(output).register();
+        return recipeBuilder().fluidInput(input).output(output).register();
     }
 
     public EvaporatorRecipe add(EvaporatorRecipe recipe) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Liquifier.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Liquifier.java
@@ -32,7 +32,7 @@ public class Liquifier extends VirtualizedRegistry<LiquifierRecipe> {
 
     @MethodDescription(type = MethodDescription.Type.ADDITION)
     public LiquifierRecipe add(IIngredient input, FluidStack output) {
-        return new RecipeBuilder().input(input).fluidOutput(output).register();
+        return recipeBuilder().input(input).fluidOutput(output).register();
     }
 
     public LiquifierRecipe add(LiquifierRecipe recipe) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/bloodmagic/AlchemyArray.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/bloodmagic/AlchemyArray.java
@@ -13,7 +13,6 @@ import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
 import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.crafting.Ingredient;
 import net.minecraft.util.ResourceLocation;
 import org.jetbrains.annotations.Nullable;
 
@@ -36,22 +35,27 @@ public class AlchemyArray extends VirtualizedRegistry<RecipeAlchemyArray> {
     }
 
     @MethodDescription(description = "groovyscript.wiki.bloodmagic.alchemy_array.add0", type = MethodDescription.Type.ADDITION)
-    public RecipeAlchemyArray add(Ingredient input, Ingredient catalyst, ItemStack output) {
-        RecipeAlchemyArray recipe = new RecipeAlchemyArray(input, catalyst, output, null);
-        add(recipe);
-        return recipe;
+    public RecipeAlchemyArray add(IIngredient input, IIngredient catalyst, ItemStack output) {
+        return recipeBuilder()
+                .catalyst(catalyst)
+                .input(input)
+                .output(output)
+                .register();
     }
 
     @MethodDescription(description = "groovyscript.wiki.bloodmagic.alchemy_array.add1", type = MethodDescription.Type.ADDITION)
-    public RecipeAlchemyArray add(Ingredient input, Ingredient catalyst, ItemStack output, String circleTexture) {
+    public RecipeAlchemyArray add(IIngredient input, IIngredient catalyst, ItemStack output, String circleTexture) {
         return add(input, catalyst, output, new ResourceLocation(circleTexture));
     }
 
     @MethodDescription(description = "groovyscript.wiki.bloodmagic.alchemy_array.add1", type = MethodDescription.Type.ADDITION)
-    public RecipeAlchemyArray add(Ingredient input, Ingredient catalyst, ItemStack output, ResourceLocation circleTexture) {
-        RecipeAlchemyArray recipe = new RecipeAlchemyArray(input, catalyst, output, circleTexture);
-        add(recipe);
-        return recipe;
+    public RecipeAlchemyArray add(IIngredient input, IIngredient catalyst, ItemStack output, ResourceLocation circleTexture) {
+        return recipeBuilder()
+                .catalyst(catalyst)
+                .texture(circleTexture)
+                .input(input)
+                .output(output)
+                .register();
     }
 
     public void add(RecipeAlchemyArray recipe) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/bloodmagic/BloodAltar.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/bloodmagic/BloodAltar.java
@@ -14,7 +14,6 @@ import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
 import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.crafting.Ingredient;
 import org.jetbrains.annotations.Nullable;
 
 @RegistryDescription(
@@ -44,10 +43,14 @@ public class BloodAltar extends VirtualizedRegistry<RecipeBloodAltar> {
     }
 
     @MethodDescription(type = MethodDescription.Type.ADDITION)
-    public RecipeBloodAltar add(Ingredient input, ItemStack output, int minimumTier, int syphon, int consumeRate, int drainRate) {
-        RecipeBloodAltar recipe = new RecipeBloodAltar(input, output, minimumTier, syphon, consumeRate, drainRate);
-        add(recipe);
-        return recipe;
+    public RecipeBloodAltar add(IIngredient input, ItemStack output, int minimumTier, int syphon, int consumeRate, int drainRate) {
+        return recipeBuilder()
+                .minimumTier(minimumTier)
+                .consumeRate(consumeRate)
+                .drainRate(drainRate)
+                .input(input)
+                .output(output)
+                .register();
     }
 
     public void add(RecipeBloodAltar recipe) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/bloodmagic/TartaricForge.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/bloodmagic/TartaricForge.java
@@ -17,6 +17,7 @@ import net.minecraft.item.crafting.Ingredient;
 import net.minecraft.util.NonNullList;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
 import java.util.Collections;
 
 @RegistryDescription
@@ -38,21 +39,13 @@ public class TartaricForge extends VirtualizedRegistry<RecipeTartaricForge> {
     }
 
     @MethodDescription(type = MethodDescription.Type.ADDITION)
-    public RecipeTartaricForge add(NonNullList<Ingredient> input, ItemStack output, double minimumSouls, double soulDrain) {
-        double minimum;
-        if (minimumSouls < soulDrain) {
-            GroovyLog.msg("Warning creating Blood Magic Tartaric Forge recipe")
-                    .add("minimumSouls should be greater than soulDrain, yet minimumSouls was {} and soulDrain was {}", minimumSouls, soulDrain)
-                    .add("set minimumSouls equal to soulDrain")
-                    .warn()
-                    .post();
-            minimum = soulDrain;
-        } else {
-            minimum = minimumSouls;
-        }
-        RecipeTartaricForge recipe = new RecipeTartaricForge(input, output, minimum, soulDrain);
-        add(recipe);
-        return recipe;
+    public RecipeTartaricForge add(Collection<IIngredient> input, ItemStack output, double minimumSouls, double soulDrain) {
+        return recipeBuilder()
+                .soulDrain(soulDrain)
+                .minimumSouls(minimumSouls)
+                .output(output)
+                .input(input)
+                .register();
     }
 
     public void add(RecipeTartaricForge recipe) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/Apothecary.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/Apothecary.java
@@ -39,10 +39,10 @@ public class Apothecary extends VirtualizedRegistry<RecipePetals> {
 
     @MethodDescription(type = MethodDescription.Type.ADDITION)
     public RecipePetals add(ItemStack output, IIngredient... inputs) {
-        RecipePetals recipe = new RecipePetals(output, Arrays.stream(inputs).map(i -> i instanceof OreDictIngredient ? ((OreDictIngredient) i).getOreDict()
-                                                                                                                     : i.getMatchingStacks()[0]).toArray());
-        add(recipe);
-        return recipe;
+        return recipeBuilder()
+                .output(output)
+                .input(inputs)
+                .register();
     }
 
     public void add(RecipePetals recipe) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/ElvenTrade.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/ElvenTrade.java
@@ -14,6 +14,7 @@ import vazkii.botania.api.BotaniaAPI;
 import vazkii.botania.api.recipe.RecipeElvenTrade;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 
 @RegistryDescription
@@ -37,12 +38,22 @@ public class ElvenTrade extends VirtualizedRegistry<RecipeElvenTrade> {
     }
 
     @MethodDescription(type = MethodDescription.Type.ADDITION)
-    public RecipeElvenTrade add(ItemStack[] outputs, IIngredient[] inputs) {
+    public RecipeElvenTrade add(ItemStack[] outputs, IIngredient... inputs) {
         return recipeBuilder().input(inputs).output(outputs).register();
     }
 
     @MethodDescription(type = MethodDescription.Type.ADDITION)
-    public RecipeElvenTrade add(ItemStack output, IIngredient[] inputs) {
+    public RecipeElvenTrade add(Collection<ItemStack> outputs, Collection<IIngredient> inputs) {
+        return recipeBuilder().input(inputs).output(outputs).register();
+    }
+
+    @MethodDescription(type = MethodDescription.Type.ADDITION)
+    public RecipeElvenTrade add(ItemStack output, IIngredient... inputs) {
+        return recipeBuilder().input(inputs).output(output).register();
+    }
+
+    @MethodDescription(type = MethodDescription.Type.ADDITION)
+    public RecipeElvenTrade add(ItemStack output, Collection<IIngredient> inputs) {
         return recipeBuilder().input(inputs).output(output).register();
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/ElvenTrade.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/ElvenTrade.java
@@ -38,14 +38,12 @@ public class ElvenTrade extends VirtualizedRegistry<RecipeElvenTrade> {
 
     @MethodDescription(type = MethodDescription.Type.ADDITION)
     public RecipeElvenTrade add(ItemStack[] outputs, IIngredient[] inputs) {
-        RecipeElvenTrade recipe = new RecipeElvenTrade(outputs, convertIngredients(inputs));
-        add(recipe);
-        return recipe;
+        return recipeBuilder().input(inputs).output(outputs).register();
     }
 
     @MethodDescription(type = MethodDescription.Type.ADDITION)
     public RecipeElvenTrade add(ItemStack output, IIngredient[] inputs) {
-        return add(new ItemStack[]{output}, inputs);
+        return recipeBuilder().input(inputs).output(output).register();
     }
 
     public void add(RecipeElvenTrade recipe) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/Lexicon.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/Lexicon.java
@@ -251,14 +251,12 @@ public class Lexicon {
 
         @MethodDescription(type = MethodDescription.Type.ADDITION)
         public LexiconEntry add(String name, LexiconCategory category) {
-            LexiconEntry entry = new LexiconEntry(name, category);
-            add(entry);
-            return entry;
+            return entryBuilder().name(name).category(category).register();
         }
 
         @MethodDescription(type = MethodDescription.Type.ADDITION)
         public LexiconEntry add(String name, String category) {
-            return add(name, Botania.getCategory(category));
+            return entryBuilder().name(name).category(category).register();
         }
 
         public void add(LexiconEntry entry) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/ManaInfusion.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/ManaInfusion.java
@@ -33,10 +33,7 @@ public class ManaInfusion extends VirtualizedRegistry<RecipeManaInfusion> {
 
     @MethodDescription(type = MethodDescription.Type.ADDITION)
     public RecipeManaInfusion add(ItemStack output, IIngredient input, int mana) {
-        RecipeManaInfusion recipe = new RecipeManaInfusion(output, input instanceof OreDictIngredient ? ((OreDictIngredient) input).getOreDict()
-                                                                                                      : input.getMatchingStacks()[0], mana);
-        add(recipe);
-        return recipe;
+        return recipeBuilder().mana(mana).output(output).input(input).register();
     }
 
     public void add(RecipeManaInfusion recipe) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/PureDaisy.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/PureDaisy.java
@@ -30,14 +30,12 @@ public class PureDaisy extends VirtualizedRegistry<RecipePureDaisy> {
 
     @MethodDescription(description = "groovyscript.wiki.botania.pure_daisy.add0", type = MethodDescription.Type.ADDITION)
     public RecipePureDaisy add(IBlockState output, IBlockState input, int time) {
-        RecipePureDaisy recipe = new RecipePureDaisy(input, output, time);
-        add(recipe);
-        return recipe;
+        return recipeBuilder().time(time).output(output).input(input).register();
     }
 
     @MethodDescription(description = "groovyscript.wiki.botania.pure_daisy.add1", type = MethodDescription.Type.ADDITION)
     public RecipePureDaisy add(IBlockState output, IBlockState input) {
-        return add(output, input, RecipePureDaisy.DEFAULT_TIME);
+        return recipeBuilder().output(output).input(input).register();
     }
 
     public void add(RecipePureDaisy recipe) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/RuneAltar.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/RuneAltar.java
@@ -36,11 +36,7 @@ public class RuneAltar extends VirtualizedRegistry<RecipeRuneAltar> {
 
     @MethodDescription(type = MethodDescription.Type.ADDITION)
     public RecipeRuneAltar add(ItemStack output, int mana, IIngredient... inputs) {
-        RecipeRuneAltar recipe = new RecipeRuneAltar(output, mana, Arrays.stream(inputs).map(i -> i instanceof OreDictIngredient
-                                                                                                  ? ((OreDictIngredient) i).getOreDict()
-                                                                                                  : i.getMatchingStacks()[0]).toArray());
-        add(recipe);
-        return recipe;
+        return recipeBuilder().mana(mana).output(output).input(inputs).register();
     }
 
     public void add(RecipeRuneAltar recipe) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/forestry/Moistener.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/forestry/Moistener.java
@@ -26,9 +26,7 @@ public class Moistener extends ForestryRegistry<IMoistenerRecipe> {
     }
 
     public IMoistenerRecipe add(ItemStack output, IIngredient input, int time) {
-        IMoistenerRecipe recipe = new MoistenerRecipe(input.getMatchingStacks()[0], output, time);
-        add(recipe);
-        return recipe;
+        return recipeBuilder().time(time).output(output).input(input).register();
     }
 
     public void add(IMoistenerRecipe recipe) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/forestry/Squeezer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/forestry/Squeezer.java
@@ -31,10 +31,8 @@ public class Squeezer extends ForestryRegistry<ISqueezerRecipe> {
         restoreFromBackup().forEach(SqueezerRecipeManagerAccessor.getRecipes()::add);
     }
 
-    public ISqueezerRecipe add(FluidStack output, IIngredient remnant, int time, int remnantChance, IIngredient... inputs) {
-        ISqueezerRecipe recipe = new SqueezerRecipe(time, NonNullList.from(ItemStack.EMPTY, Arrays.stream(inputs).map(i -> i.getMatchingStacks()[0]).toArray(ItemStack[]::new)), output, remnant.getMatchingStacks()[0], remnantChance);
-        add(recipe);
-        return recipe;
+    public ISqueezerRecipe add(FluidStack output, ItemStack remnant, int time, int remnantChance, IIngredient... inputs) {
+        return recipeBuilder().chance(remnantChance).time(time).output(remnant).fluidOutput(output).input(inputs).register();
     }
 
     public void add(ISqueezerRecipe recipe) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/forestry/Still.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/forestry/Still.java
@@ -25,9 +25,7 @@ public class Still extends ForestryRegistry<IStillRecipe> {
     }
 
     public IStillRecipe add(FluidStack output, int time, FluidStack input) {
-        IStillRecipe recipe = new StillRecipe(time, input, output);
-        add(recipe);
-        return recipe;
+        return recipeBuilder().time(time).fluidOutput(output).fluidInput(input).register();
     }
 
     public void add(IStillRecipe recipe) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/ChemicalInfuser.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/ChemicalInfuser.java
@@ -25,16 +25,7 @@ public class ChemicalInfuser extends VirtualizedMekanismRegistry<ChemicalInfuser
 
     @MethodDescription(type = MethodDescription.Type.ADDITION, example = @Example(value = "gas('copper') * 10, gas('iron'), gas('gold') * 15", commented = true))
     public ChemicalInfuserRecipe add(GasStack leftInput, GasStack rightInput, GasStack output) {
-        GroovyLog.Msg msg = GroovyLog.msg("Error adding Mekanism Chemical Infuser recipe").error();
-        msg.add(Mekanism.isEmpty(leftInput), () -> "left gas input must not be empty");
-        msg.add(Mekanism.isEmpty(rightInput), () -> "right gas input must not be empty");
-        msg.add(Mekanism.isEmpty(output), () -> "gas output must not be empty");
-        if (msg.postIfNotEmpty()) return null;
-
-        ChemicalInfuserRecipe recipe = new ChemicalInfuserRecipe(leftInput, rightInput, output);
-        addScripted(recipe);
-        recipeRegistry.put(recipe);
-        return recipe;
+        return recipeBuilder().gasInput(leftInput, rightInput).gasOutput(output).register();
     }
 
     @MethodDescription(example = @Example("gas('hydrogen'), gas('chlorine')"))

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/ChemicalOxidizer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/ChemicalOxidizer.java
@@ -29,19 +29,7 @@ public class ChemicalOxidizer extends VirtualizedMekanismRegistry<OxidationRecip
 
     @MethodDescription(type = MethodDescription.Type.ADDITION, example = @Example(value = "ore('dustGold'), gas('gold')", commented = true))
     public OxidationRecipe add(IIngredient ingredient, GasStack output) {
-        GroovyLog.Msg msg = GroovyLog.msg("Error adding Mekanism Oxidizer recipe").error();
-        msg.add(IngredientHelper.isEmpty(ingredient), () -> "input must not be empty");
-        msg.add(Mekanism.isEmpty(output), () -> "output must not be empty");
-        if (msg.postIfNotEmpty()) return null;
-
-        OxidationRecipe recipe1 = null;
-        for (ItemStack itemStack : ingredient.getMatchingStacks()) {
-            OxidationRecipe recipe = new OxidationRecipe(itemStack, output);
-            if (recipe1 == null) recipe1 = recipe;
-            recipeRegistry.put(recipe);
-            addScripted(recipe);
-        }
-        return recipe1;
+        return recipeBuilder().gasOutput(output).input(ingredient).register();
     }
 
     @MethodDescription(example = @Example("ore('dustSulfur')"))

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Combiner.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Combiner.java
@@ -27,20 +27,7 @@ public class Combiner extends VirtualizedMekanismRegistry<CombinerRecipe> {
 
     @MethodDescription(type = MethodDescription.Type.ADDITION, example = @Example(value = "ore('gemQuartz') * 8, item('minecraft:netherrack'), item('minecraft:quartz_ore')", commented = true))
     public CombinerRecipe add(IIngredient ingredient, ItemStack extra, ItemStack output) {
-        GroovyLog.Msg msg = GroovyLog.msg("Error adding Mekanism Crusher recipe").error();
-        msg.add(IngredientHelper.isEmpty(ingredient), () -> "input must not be empty");
-        msg.add(IngredientHelper.isEmpty(extra), () -> "extra input must not be empty");
-        msg.add(IngredientHelper.isEmpty(output), () -> "output must not be empty");
-        if (msg.postIfNotEmpty()) return null;
-
-        CombinerRecipe recipe1 = null;
-        for (ItemStack itemStack : ingredient.getMatchingStacks()) {
-            CombinerRecipe recipe = new CombinerRecipe(itemStack, extra, output);
-            if (recipe1 == null) recipe1 = recipe;
-            recipeRegistry.put(recipe);
-            addScripted(recipe);
-        }
-        return recipe1;
+        return recipeBuilder().extra(extra).output(output).input(ingredient).register();
     }
 
     @MethodDescription(example = @Example("item('minecraft:flint'), item('minecraft:cobblestone')"))

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Crusher.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Crusher.java
@@ -27,19 +27,7 @@ public class Crusher extends VirtualizedMekanismRegistry<CrusherRecipe> {
 
     @MethodDescription(type = MethodDescription.Type.ADDITION, example = @Example(value = "item('minecraft:clay_ball'), item('minecraft:gold_ingot')", commented = true))
     public CrusherRecipe add(IIngredient ingredient, ItemStack output) {
-        GroovyLog.Msg msg = GroovyLog.msg("Error adding Mekanism Crusher recipe").error();
-        msg.add(IngredientHelper.isEmpty(ingredient), () -> "input must not be empty");
-        msg.add(IngredientHelper.isEmpty(output), () -> "output must not be empty");
-        if (msg.postIfNotEmpty()) return null;
-
-        CrusherRecipe recipe1 = null;
-        for (ItemStack itemStack : ingredient.getMatchingStacks()) {
-            CrusherRecipe recipe = new CrusherRecipe(itemStack, output);
-            if (recipe1 == null) recipe1 = recipe;
-            recipeRegistry.put(recipe);
-            addScripted(recipe);
-        }
-        return recipe1;
+        return recipeBuilder().output(output).input(ingredient).register();
     }
 
     @MethodDescription(example = @Example("ore('ingotTin')"))

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Crystallizer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Crystallizer.java
@@ -5,7 +5,6 @@ import com.cleanroommc.groovyscript.api.documentation.annotations.*;
 import com.cleanroommc.groovyscript.compat.mods.ModSupport;
 import com.cleanroommc.groovyscript.compat.mods.mekanism.recipe.GasRecipeBuilder;
 import com.cleanroommc.groovyscript.compat.mods.mekanism.recipe.VirtualizedMekanismRegistry;
-import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
 import mekanism.api.gas.GasStack;
 import mekanism.common.recipe.RecipeHandler;
 import mekanism.common.recipe.inputs.GasInput;
@@ -27,15 +26,7 @@ public class Crystallizer extends VirtualizedMekanismRegistry<CrystallizerRecipe
 
     @MethodDescription(type = MethodDescription.Type.ADDITION, example = @Example(value = "gas('cleanGold'), item('minecraft:gold_ingot')", commented = true))
     public CrystallizerRecipe add(GasStack input, ItemStack output) {
-        GroovyLog.Msg msg = GroovyLog.msg("Error adding Mekanism Crystallizer recipe").error();
-        msg.add(Mekanism.isEmpty(input), () -> "input must not be empty");
-        msg.add(IngredientHelper.isEmpty(output), () -> "output must not be empty");
-        if (msg.postIfNotEmpty()) return null;
-
-        CrystallizerRecipe recipe = new CrystallizerRecipe(input, output);
-        recipeRegistry.put(recipe);
-        addScripted(recipe);
-        return recipe;
+        return recipeBuilder().gasInput(input).output(output).register();
     }
 
     @MethodDescription(example = @Example("gas('cleanGold')"))

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/DissolutionChamber.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/DissolutionChamber.java
@@ -29,19 +29,7 @@ public class DissolutionChamber extends VirtualizedMekanismRegistry<DissolutionR
 
     @MethodDescription(type = MethodDescription.Type.ADDITION, example = @Example(value = "item('minecraft:packed_ice'), gas('water')", commented = true))
     public DissolutionRecipe add(IIngredient ingredient, GasStack output) {
-        GroovyLog.Msg msg = GroovyLog.msg("Error adding Mekanism Dissolution Chamber recipe").error();
-        msg.add(IngredientHelper.isEmpty(ingredient), () -> "input must not be empty");
-        msg.add(Mekanism.isEmpty(output), () -> "output must not be empty");
-        if (msg.postIfNotEmpty()) return null;
-
-        DissolutionRecipe recipe1 = null;
-        for (ItemStack itemStack : ingredient.getMatchingStacks()) {
-            DissolutionRecipe recipe = new DissolutionRecipe(itemStack, output);
-            if (recipe1 == null) recipe1 = recipe;
-            recipeRegistry.put(recipe);
-            addScripted(recipe);
-        }
-        return recipe1;
+        return recipeBuilder().gasOutput(output).input(ingredient).register();
     }
 
     @MethodDescription(example = @Example("item('mekanism:oreblock:0')"))

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/ElectrolyticSeparator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/ElectrolyticSeparator.java
@@ -28,16 +28,7 @@ public class ElectrolyticSeparator extends VirtualizedMekanismRegistry<Separator
 
     @MethodDescription(type = MethodDescription.Type.ADDITION, example = @Example(value = "fluid('lava') * 10, gas('cleanGold') * 5, gas('cleanCopper') * 3, 3000", commented = true))
     public SeparatorRecipe add(FluidStack input, GasStack leftOutput, GasStack rightOutput, double energy) {
-        GroovyLog.Msg msg = GroovyLog.msg("Error adding Mekanism Electrolytic Separator recipe").error();
-        msg.add(IngredientHelper.isEmpty(input), () -> "input must not be empty");
-        msg.add(Mekanism.isEmpty(leftOutput), () -> "left gas output must not be empty");
-        msg.add(Mekanism.isEmpty(rightOutput), () -> "right gas output must not be empty");
-        if (msg.postIfNotEmpty()) return null;
-
-        SeparatorRecipe recipe = new SeparatorRecipe(input, energy, leftOutput, rightOutput);
-        addScripted(recipe);
-        recipeRegistry.put(recipe);
-        return recipe;
+        return recipeBuilder().energy(energy).gasOutput(leftOutput, rightOutput).fluidInput(input).register();
     }
 
     @MethodDescription(example = @Example("fluid('water')"))

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/EnrichmentChamber.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/EnrichmentChamber.java
@@ -28,19 +28,7 @@ public class EnrichmentChamber extends VirtualizedMekanismRegistry<EnrichmentRec
 
     @MethodDescription(type = MethodDescription.Type.ADDITION, example = @Example(value = "item('minecraft:clay_ball'), item('minecraft:nether_star')", commented = true))
     public EnrichmentRecipe add(IIngredient ingredient, ItemStack output) {
-        GroovyLog.Msg msg = GroovyLog.msg("Error adding Mekanism Enrichment Chamber recipe").error();
-        msg.add(IngredientHelper.isEmpty(ingredient), () -> "input must not be empty");
-        msg.add(IngredientHelper.isEmpty(output), () -> "output must not be empty");
-        if (msg.postIfNotEmpty()) return null;
-
-        EnrichmentRecipe recipe1 = null;
-        for (ItemStack itemStack : ingredient.getMatchingStacks()) {
-            EnrichmentRecipe recipe = new EnrichmentRecipe(itemStack, output);
-            if (recipe1 == null) recipe1 = recipe;
-            recipeRegistry.put(recipe);
-            addScripted(recipe);
-        }
-        return recipe1;
+        return recipeBuilder().output(output).input(ingredient).register();
     }
 
     @MethodDescription(example = @Example("item('minecraft:diamond')"))

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/InjectionChamber.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/InjectionChamber.java
@@ -29,20 +29,7 @@ public class InjectionChamber extends VirtualizedMekanismRegistry<InjectionRecip
 
     @MethodDescription(type = MethodDescription.Type.ADDITION, example = @Example(value = "item('minecraft:diamond'), gas('water'), item('minecraft:nether_star')", commented = true))
     public InjectionRecipe add(IIngredient ingredient, GasStack gasInput, ItemStack output) {
-        GroovyLog.Msg msg = GroovyLog.msg("Error adding Mekanism Injection Chamber recipe").error();
-        msg.add(IngredientHelper.isEmpty(ingredient), () -> "input must not be empty");
-        msg.add(Mekanism.isEmpty(gasInput), () -> "gas input must not be empty");
-        msg.add(IngredientHelper.isEmpty(output), () -> "output must not be empty");
-        if (msg.postIfNotEmpty()) return null;
-
-        InjectionRecipe recipe1 = null;
-        for (ItemStack itemStack : ingredient.getMatchingStacks()) {
-            InjectionRecipe recipe = new InjectionRecipe(itemStack, gasInput.getGas(), output);
-            if (recipe1 == null) recipe1 = recipe;
-            recipeRegistry.put(recipe);
-            addScripted(recipe);
-        }
-        return recipe1;
+        return recipeBuilder().gasInput(gasInput).output(output).input(ingredient).register();
     }
 
     @MethodDescription(example = @Example("item('minecraft:hardened_clay'), gas('water')"))

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/MetallurgicInfuser.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/MetallurgicInfuser.java
@@ -29,26 +29,12 @@ public class MetallurgicInfuser extends VirtualizedMekanismRegistry<MetallurgicI
 
     @MethodDescription(description = "groovyscript.wiki.mekanism.metallurgic_infuser.add0", type = MethodDescription.Type.ADDITION, example = @Example(value = "item('minecraft:nether_star'), infusionType('groovy_example'), 50, item('minecraft:clay')", commented = true))
     public MetallurgicInfuserRecipe add(IIngredient ingredient, InfuseType infuseType, int infuseAmount, ItemStack output) {
-        GroovyLog.Msg msg = GroovyLog.msg("Error adding Mekanism Metallurgic Infuser recipe").error();
-        msg.add(IngredientHelper.isEmpty(ingredient), () -> "input must not be empty");
-        msg.add(IngredientHelper.isEmpty(output), () -> "output must not be empty");
-        msg.add(infuseType == null, () -> "invalid infusion type");
-        if (infuseAmount <= 0) infuseAmount = 40;
-        if (msg.postIfNotEmpty()) return null;
-
-        MetallurgicInfuserRecipe recipe1 = null;
-        for (ItemStack itemStack : ingredient.getMatchingStacks()) {
-            MetallurgicInfuserRecipe recipe = new MetallurgicInfuserRecipe(new InfusionInput(infuseType, infuseAmount, itemStack), output);
-            if (recipe1 == null) recipe1 = recipe;
-            recipeRegistry.put(recipe);
-            addScripted(recipe);
-        }
-        return recipe1;
+        return recipeBuilder().infuse(infuseType).amount(infuseAmount).output(output).input(ingredient).register();
     }
 
     @MethodDescription(description = "groovyscript.wiki.mekanism.metallurgic_infuser.add1")
     public MetallurgicInfuserRecipe add(IIngredient ingredient, String infuseType, int infuseAmount, ItemStack output) {
-        return add(ingredient, InfuseRegistry.get(infuseType), infuseAmount, output);
+        return recipeBuilder().infuse(infuseType).amount(infuseAmount).output(output).input(ingredient).register();
     }
 
     @MethodDescription(example = @Example("ore('dustObsidian'), 'DIAMOND'"))

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/OsmiumCompressor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/OsmiumCompressor.java
@@ -31,19 +31,7 @@ public class OsmiumCompressor extends VirtualizedMekanismRegistry<OsmiumCompress
 
     @MethodDescription(type = MethodDescription.Type.ADDITION, example = @Example(value = "item('minecraft:diamond'), gas('hydrogen'), item('minecraft:nether_star')", commented = true))
     public OsmiumCompressorRecipe add(IIngredient ingredient, GasStack gasInput, ItemStack output) {
-        GroovyLog.Msg msg = GroovyLog.msg("Error adding Mekanism Osmium Compressor recipe").error();
-        msg.add(IngredientHelper.isEmpty(ingredient), () -> "input must not be empty");
-        msg.add(IngredientHelper.isEmpty(output), () -> "output must not be empty");
-        if (msg.postIfNotEmpty()) return null;
-
-        OsmiumCompressorRecipe recipe1 = null;
-        for (ItemStack itemStack : ingredient.getMatchingStacks()) {
-            OsmiumCompressorRecipe recipe = new OsmiumCompressorRecipe(new AdvancedMachineInput(itemStack, gasInput.getGas()), new ItemStackOutput(output));
-            if (recipe1 == null) recipe1 = recipe;
-            recipeRegistry.put(recipe);
-            addScripted(recipe);
-        }
-        return recipe1;
+        return recipeBuilder().gasInput(gasInput).output(output).input(ingredient).register();
     }
 
     @MethodDescription(example = @Example("ore('dustRefinedObsidian'), gas('liquidosmium')"))

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/PressurizedReactionChamber.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/PressurizedReactionChamber.java
@@ -31,14 +31,7 @@ public class PressurizedReactionChamber extends VirtualizedMekanismRegistry<Pres
 
     @MethodDescription
     public PressurizedRecipe add(IIngredient inputSolid, FluidStack inputFluid, GasStack inputGas, ItemStack outputSolid, GasStack outputGas, double energy, int duration) {
-        PressurizedRecipe r = null;
-        for (ItemStack item : inputSolid.getMatchingStacks()) {
-            PressurizedRecipe recipe = new PressurizedRecipe(item, inputFluid, inputGas, outputSolid, outputGas, energy, duration);
-            if (r == null) r = recipe;
-            recipeRegistry.put(recipe);
-            addScripted(recipe);
-        }
-        return r;
+        return recipeBuilder().duration(duration).energy(energy).gasOutput(outputGas).gasInput(inputGas).fluidInput(inputFluid).output(outputSolid).input(inputSolid).register();
     }
 
     @MethodDescription(example = @Example("ore('logWood'), fluid('water'), gas('oxygen')"))

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/PurificationChamber.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/PurificationChamber.java
@@ -30,19 +30,7 @@ public class PurificationChamber extends VirtualizedMekanismRegistry<Purificatio
 
     @MethodDescription(type = MethodDescription.Type.ADDITION, example = @Example(value = "item('minecraft:diamond'), gas('oxygen'), item('minecraft:nether_star')", commented = true))
     public PurificationRecipe add(IIngredient ingredient, GasStack gasInput, ItemStack output) {
-        GroovyLog.Msg msg = GroovyLog.msg("Error adding Mekanism Purification Chamber recipe").error();
-        msg.add(IngredientHelper.isEmpty(ingredient), () -> "input must not be empty");
-        msg.add(IngredientHelper.isEmpty(output), () -> "output must not be empty");
-        if (msg.postIfNotEmpty()) return null;
-
-        PurificationRecipe recipe1 = null;
-        for (ItemStack itemStack : ingredient.getMatchingStacks()) {
-            PurificationRecipe recipe = new PurificationRecipe(new AdvancedMachineInput(itemStack, gasInput.getGas()), new ItemStackOutput(output));
-            if (recipe1 == null) recipe1 = recipe;
-            recipeRegistry.put(recipe);
-            addScripted(recipe);
-        }
-        return recipe1;
+        return recipeBuilder().gasInput(gasInput).output(output).input(ingredient).register();
     }
 
     @MethodDescription(example = @Example("item('mekanism:oreblock:0'), gas('oxygen')"))

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Sawmill.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Sawmill.java
@@ -38,26 +38,7 @@ public class Sawmill extends VirtualizedMekanismRegistry<SawmillRecipe> {
 
     @MethodDescription(description = "groovyscript.wiki.mekanism.sawmill.add2", type = MethodDescription.Type.ADDITION, example = @Example(value = "item('minecraft:diamond_block'), item('minecraft:diamond') * 9, item('minecraft:clay_ball'), 0.7", commented = true))
     public SawmillRecipe add(IIngredient ingredient, ItemStack output, ItemStack secondary, double chance) {
-        GroovyLog.Msg msg = GroovyLog.msg("Error adding Mekanism Sawmill recipe").error();
-        msg.add(IngredientHelper.isEmpty(ingredient), () -> "input must not be empty");
-        msg.add(IngredientHelper.isEmpty(output), () -> "output must not be empty");
-        if (msg.postIfNotEmpty()) return null;
-
-        boolean withSecondary = !IngredientHelper.isEmpty(secondary);
-        if (withSecondary) {
-            if (chance <= 0) chance = 1;
-        }
-
-        SawmillRecipe recipe1 = null;
-        for (ItemStack itemStack : ingredient.getMatchingStacks()) {
-            SawmillRecipe recipe;
-            ChanceOutput chanceOutput = withSecondary ? new ChanceOutput(output, secondary, chance) : new ChanceOutput(output);
-            recipe = new SawmillRecipe(new ItemStackInput(itemStack), chanceOutput);
-            if (recipe1 == null) recipe1 = recipe;
-            recipeRegistry.put(recipe);
-            addScripted(recipe);
-        }
-        return recipe1;
+        return recipeBuilder().extra(secondary).chance(chance).output(output).input(ingredient).register();
     }
 
     @MethodDescription(example = @Example("item('minecraft:ladder')"))

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Smelting.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Smelting.java
@@ -11,7 +11,6 @@ import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
 import mekanism.common.recipe.RecipeHandler;
 import mekanism.common.recipe.inputs.ItemStackInput;
 import mekanism.common.recipe.machines.SmeltingRecipe;
-import mekanism.common.recipe.outputs.ItemStackOutput;
 import net.minecraft.item.ItemStack;
 import org.jetbrains.annotations.Nullable;
 
@@ -33,19 +32,7 @@ public class Smelting extends VirtualizedMekanismRegistry<SmeltingRecipe> {
 
     @MethodDescription(type = MethodDescription.Type.ADDITION, example = @Example(value = "item('minecraft:diamond_block'), item('minecraft:clay')", commented = true))
     public SmeltingRecipe add(IIngredient ingredient, ItemStack output) {
-        GroovyLog.Msg msg = GroovyLog.msg("Error adding Mekanism Smelter recipe").error();
-        msg.add(IngredientHelper.isEmpty(ingredient), () -> "input must not be empty");
-        msg.add(IngredientHelper.isEmpty(output), () -> "output must not be empty");
-        if (msg.postIfNotEmpty()) return null;
-
-        SmeltingRecipe recipe1 = null;
-        for (ItemStack itemStack : ingredient.getMatchingStacks()) {
-            SmeltingRecipe recipe = new SmeltingRecipe(new ItemStackInput(itemStack), new ItemStackOutput(output));
-            if (recipe1 == null) recipe1 = recipe;
-            recipeRegistry.put(recipe);
-            addScripted(recipe);
-        }
-        return recipe1;
+        return recipeBuilder().output(output).input(ingredient).register();
     }
 
     @MethodDescription(example = @Example(value = "item('minecraft:clay')", commented = true))

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/SolarNeutronActivator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/SolarNeutronActivator.java
@@ -26,15 +26,7 @@ public class SolarNeutronActivator extends VirtualizedMekanismRegistry<SolarNeut
 
     @MethodDescription(type = MethodDescription.Type.ADDITION, example = @Example(value = "gas('water'), gas('hydrogen')", commented = true))
     public SolarNeutronRecipe add(GasStack input, GasStack output) {
-        GroovyLog.Msg msg = GroovyLog.msg("Error adding Mekanism Solar Neutron Activator recipe").error();
-        msg.add(Mekanism.isEmpty(input), () -> "input must not be empty");
-        msg.add(Mekanism.isEmpty(output), () -> "output must not be empty");
-        if (msg.postIfNotEmpty()) return null;
-
-        SolarNeutronRecipe recipe = new SolarNeutronRecipe(input, output);
-        recipeRegistry.put(recipe);
-        addScripted(recipe);
-        return recipe;
+        return recipeBuilder().gasOutput(output).gasInput(input).register();
     }
 
     @MethodDescription(example = @Example("gas('lithium')"))

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/ThermalEvaporationPlant.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/ThermalEvaporationPlant.java
@@ -27,15 +27,7 @@ public class ThermalEvaporationPlant extends VirtualizedMekanismRegistry<Thermal
 
     @MethodDescription(type = MethodDescription.Type.ADDITION, example = @Example(value = "fluid('water'), fluid('steam')", commented = true))
     public ThermalEvaporationRecipe add(FluidStack input, FluidStack output) {
-        GroovyLog.Msg msg = GroovyLog.msg("Error adding Mekanism Solar Neutron Activator recipe").error();
-        msg.add(IngredientHelper.isEmpty(input), () -> "input must not be empty");
-        msg.add(IngredientHelper.isEmpty(output), () -> "output must not be empty");
-        if (msg.postIfNotEmpty()) return null;
-
-        ThermalEvaporationRecipe recipe = new ThermalEvaporationRecipe(input, output);
-        recipeRegistry.put(recipe);
-        addScripted(recipe);
-        return recipe;
+        return recipeBuilder().fluidInput(input).fluidOutput(output).register();
     }
 
     @MethodDescription(example = @Example("fluid('water')"))

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Washer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Washer.java
@@ -26,15 +26,7 @@ public class Washer extends VirtualizedMekanismRegistry<WasherRecipe> {
 
     @MethodDescription(type = MethodDescription.Type.ADDITION, example = @Example(value = "gas('water'), gas('hydrogen')", commented = true))
     public WasherRecipe add(GasStack input, GasStack output) {
-        GroovyLog.Msg msg = GroovyLog.msg("Error adding Mekanism Washer recipe").error();
-        msg.add(Mekanism.isEmpty(input), () -> "input must not be empty");
-        msg.add(Mekanism.isEmpty(output), () -> "output must not be empty");
-        if (msg.postIfNotEmpty()) return null;
-
-        WasherRecipe recipe = new WasherRecipe(input, output);
-        recipeRegistry.put(recipe);
-        addScripted(recipe);
-        return recipe;
+        return recipeBuilder().gasOutput(output).gasInput(input).register();
     }
 
     @MethodDescription(example = @Example("gas('iron')"))

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/Crucible.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/Crucible.java
@@ -54,9 +54,7 @@ public class Crucible extends VirtualizedRegistry<CrucibleRecipe> {
 
     @MethodDescription(type = MethodDescription.Type.ADDITION)
     public CrucibleRecipe add(String researchKey, ItemStack result, IIngredient catalyst, AspectList tags) {
-        CrucibleRecipe recipe = new CrucibleRecipe(researchKey, result, catalyst.toMcIngredient(), tags);
-        add(recipe);
-        return recipe;
+        return recipeBuilder().researchKey(researchKey).catalyst(catalyst).aspect(tags).output(result).register();
     }
 
     public boolean remove(CrucibleRecipe recipe) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/Crucible.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/Crucible.java
@@ -194,7 +194,9 @@ public class Crucible extends VirtualizedRegistry<CrucibleRecipe> {
         @RecipeBuilderRegistrationMethod
         public @Nullable CrucibleRecipe register() {
             if (!validate()) return null;
-            return ModSupport.THAUMCRAFT.get().crucible.add(researchKey, this.output.get(0), catalyst, aspects);
+            CrucibleRecipe recipe = new CrucibleRecipe(researchKey, this.output.get(0), catalyst.toMcIngredient(), aspects);
+            ModSupport.THAUMCRAFT.get().crucible.add(recipe);
+            return recipe;
         }
     }
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/Crucible.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/Crucible.java
@@ -21,10 +21,7 @@ import thaumcraft.api.crafting.CrucibleRecipe;
 import thaumcraft.api.crafting.IThaumcraftRecipe;
 import thaumcraft.common.config.ConfigRecipes;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @RegistryDescription
@@ -144,6 +141,28 @@ public class Crucible extends VirtualizedRegistry<CrucibleRecipe> {
         @RecipeBuilderMethodDescription(field = "aspects")
         public RecipeBuilder aspect(AspectStack aspectIn) {
             this.aspects.add(aspectIn.getAspect(), aspectIn.getAmount());
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription(field = "aspects")
+        public RecipeBuilder aspect(AspectStack... aspects) {
+            for (AspectStack aspect : aspects) {
+                aspect(aspect);
+            }
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription(field = "aspects")
+        public RecipeBuilder aspect(Collection<AspectStack> aspects) {
+            for (AspectStack aspect : aspects) {
+                aspect(aspect);
+            }
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription(field = "aspects")
+        public RecipeBuilder aspect(AspectList aspectList) {
+            this.aspects.merge(aspectList);
             return this;
         }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/InfusionCrafting.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/InfusionCrafting.java
@@ -6,14 +6,12 @@ import com.cleanroommc.groovyscript.api.IIngredient;
 import com.cleanroommc.groovyscript.api.documentation.annotations.*;
 import com.cleanroommc.groovyscript.compat.mods.ModSupport;
 import com.cleanroommc.groovyscript.compat.mods.thaumcraft.aspect.AspectStack;
-import com.cleanroommc.groovyscript.helper.ArrayUtils;
 import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
 import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
 import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
 import com.cleanroommc.groovyscript.helper.recipe.RecipeName;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.crafting.Ingredient;
 import net.minecraft.util.ResourceLocation;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.ApiStatus;
@@ -59,10 +57,7 @@ public class InfusionCrafting extends VirtualizedRegistry<Pair<ResourceLocation,
 
     @MethodDescription(type = MethodDescription.Type.ADDITION)
     public InfusionRecipe add(String research, ItemStack outputResult, int inst, Collection<AspectStack> aspects, IIngredient centralItem, IIngredient... input) {
-        Object[] inputs = ArrayUtils.map(input, IIngredient::toMcIngredient, new Ingredient[0]);
-        InfusionRecipe infusionRecipe = new InfusionRecipe(research, outputResult, inst, Thaumcraft.makeAspectList(aspects), centralItem.toMcIngredient(), inputs);
-        add(RecipeName.generateRl("infusion_matrix_recipe"), infusionRecipe);
-        return infusionRecipe;
+        return recipeBuilder().researchKey(research).mainInput(centralItem).instability(inst).aspect(aspects).input(input).output(outputResult).register();
     }
 
     public boolean remove(InfusionRecipe recipe) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/InfusionCrafting.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/InfusionCrafting.java
@@ -162,6 +162,28 @@ public class InfusionCrafting extends VirtualizedRegistry<Pair<ResourceLocation,
         }
 
         @RecipeBuilderMethodDescription(field = "aspects")
+        public RecipeBuilder aspect(AspectStack... aspects) {
+            for (AspectStack aspect : aspects) {
+                aspect(aspect);
+            }
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription(field = "aspects")
+        public RecipeBuilder aspect(Collection<AspectStack> aspects) {
+            for (AspectStack aspect : aspects) {
+                aspect(aspect);
+            }
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription(field = "aspects")
+        public RecipeBuilder aspect(AspectList aspectList) {
+            this.aspects.merge(aspectList);
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription(field = "aspects")
         public RecipeBuilder aspect(String tag, int amount) {
             Aspect a = Thaumcraft.validateAspect(tag);
             if (a != null) this.aspects.add(a, amount);


### PR DESCRIPTION
changes in this PR:
- add more ability to add Aspects to Thaumcraft Infusion and Crucible Recipe Builders.
- make the Thaumcraft Crucible Recipe Builder create the `CrucibleRecipe` in the register method, instead of calling a different method. 
- add a lens field and validation to Actually Additions Atomic Reconstructor.
- convert (most) cases of adding recipes via shorthand to refer to the relevant Recipe Builder. the benefits of this include:
	- improved error logging due to using the more robust validation methods in every situation
	- reduced code duplication
	- revealing several errors with some of the current add methods
- fixes several add methods using Minecraft's Ingredient instead of GroovyScript's IIngredient or otherwise using types that are harder for GroovyScript to obtain.
