### PR TITLE
Fix "value already present" error on reloading

### DIFF
--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/ForgeRegistryMixin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/ForgeRegistryMixin.java
@@ -208,9 +208,9 @@ public abstract class ForgeRegistryMixin<V extends IForgeRegistryEntry<V>> imple
 
     @Override
     public void groovyScript$forceAdd(V entry, int id, Object owner) {
-        names.put(entry.getRegistryName(), entry);
-        ids.put(id, entry);
-        if (owner != null) owners.put(owner, entry);
+        names.forcePut(entry.getRegistryName(), entry);
+        ids.forcePut(id, entry);
+        if (owner != null) owners.forcePut(owner, entry);
         availabilityMap.set(id);
     }
 


### PR DESCRIPTION
This fixes a rare error when an entry is already present in the registry on reloading.