### PR TITLE
Fix Edge Case Running Status of Sandbox

### DIFF
--- a/src/main/java/com/cleanroommc/groovyscript/sandbox/GroovySandbox.java
+++ b/src/main/java/com/cleanroommc/groovyscript/sandbox/GroovySandbox.java
@@ -168,7 +168,8 @@ public abstract class GroovySandbox {
     }
 
     public <T> T runClosure(Closure<T> closure, Object... args) {
-        if (!isRunning()) startRunning();
+        boolean wasRunning = isRunning();
+        if (!wasRunning) startRunning();
         T result = null;
         try {
             result = closure.call(args);
@@ -176,7 +177,7 @@ public abstract class GroovySandbox {
             GroovyScript.LOGGER.error("Caught an exception trying to run a closure:");
             e.printStackTrace();
         } finally {
-            if (!isRunning()) stopRunning();
+            if (!wasRunning) stopRunning();
         }
         return result;
     }

--- a/src/main/java/com/cleanroommc/groovyscript/sandbox/GroovySandbox.java
+++ b/src/main/java/com/cleanroommc/groovyscript/sandbox/GroovySandbox.java
@@ -168,7 +168,7 @@ public abstract class GroovySandbox {
     }
 
     public <T> T runClosure(Closure<T> closure, Object... args) {
-        startRunning();
+        if (!isRunning()) startRunning();
         T result = null;
         try {
             result = closure.call(args);
@@ -176,7 +176,7 @@ public abstract class GroovySandbox {
             GroovyScript.LOGGER.error("Caught an exception trying to run a closure:");
             e.printStackTrace();
         } finally {
-            stopRunning();
+            if (!isRunning()) stopRunning();
         }
         return result;
     }

--- a/src/main/java/com/cleanroommc/groovyscript/sandbox/GroovyScriptSandbox.java
+++ b/src/main/java/com/cleanroommc/groovyscript/sandbox/GroovyScriptSandbox.java
@@ -178,7 +178,7 @@ public class GroovyScriptSandbox extends GroovySandbox {
     @ApiStatus.Internal
     @Override
     public <T> T runClosure(Closure<T> closure, Object... args) {
-        startRunning();
+        if (!isRunning()) startRunning();
         T result = null;
         try {
             result = runClosureInternal(closure, args);
@@ -189,7 +189,7 @@ public class GroovyScriptSandbox extends GroovySandbox {
                 return new AtomicInteger();
             }).addAndGet(1);
         } finally {
-            stopRunning();
+            if (!isRunning()) stopRunning();
         }
         return result;
     }

--- a/src/main/java/com/cleanroommc/groovyscript/sandbox/GroovyScriptSandbox.java
+++ b/src/main/java/com/cleanroommc/groovyscript/sandbox/GroovyScriptSandbox.java
@@ -178,7 +178,8 @@ public class GroovyScriptSandbox extends GroovySandbox {
     @ApiStatus.Internal
     @Override
     public <T> T runClosure(Closure<T> closure, Object... args) {
-        if (!isRunning()) startRunning();
+        boolean wasRunning = isRunning();
+        if (!wasRunning) startRunning();
         T result = null;
         try {
             result = runClosureInternal(closure, args);
@@ -189,7 +190,7 @@ public class GroovyScriptSandbox extends GroovySandbox {
                 return new AtomicInteger();
             }).addAndGet(1);
         } finally {
-            if (!isRunning()) stopRunning();
+            if (!wasRunning) stopRunning();
         }
         return result;
     }


### PR DESCRIPTION
This PR fixes edge cases where the running status of the GroovyScript sandbox is reported, falsely, as not running.

Reproduction Case:
```groovy
import gregtech.integration.groovy.GroovyScriptModule
import net.minecraft.item.ItemStack

println('Hello World!')

println(GroovyScriptModule.isCurrentlyRunning())

var test = { ItemStack stack ->
    println("Hello World (2)! " + stack.toString())
}

test(item('minecraft:apple'))

println(GroovyScriptModule.isCurrentlyRunning())
```

This script uses GT just to report the status of the sandbox, but it should work without gt dependency. This was reproduced in an instance with just GroovyScript and its deps, + GT and its deps.

Output of running the above script:
```
[21:59:45] [SERVER/INFO] [groovyscript]: ========== Reloading Groovy scripts ==========
[21:59:45] [SERVER/INFO] [placeholdername]: Running scripts in loader 'postInit'
[21:59:45] [SERVER/INFO] [placeholdername]:  - running main
Hello World!
true
Hello World (2)! 1xitem.apple@0
false
```