### PR TITLE
Minor Documentation Fixes

### DIFF
--- a/examples/postInit/actuallyadditions.groovy
+++ b/examples/postInit/actuallyadditions.groovy
@@ -2,7 +2,7 @@
 // Auto generated groovyscript example file
 // MODS_LOADED: actuallyadditions
 
-println 'mod \'actuallyadditions\' detected, running script'
+log.info 'mod \'actuallyadditions\' detected, running script'
 
 // Atomic Reconstructor:
 // The Atomic Reconstructor is a block which uses energy to convert a block or item in front of it into other items.

--- a/examples/postInit/advancedmortars.groovy
+++ b/examples/postInit/advancedmortars.groovy
@@ -2,7 +2,7 @@
 // Auto generated groovyscript example file
 // MODS_LOADED: advancedmortars
 
-println 'mod \'advancedmortars\' detected, running script'
+log.info 'mod \'advancedmortars\' detected, running script'
 
 // Mortar:
 // Uses any number of specific types of Mortars to convert multiple items into a single output with a possible chance

--- a/examples/postInit/aether_legacy.groovy
+++ b/examples/postInit/aether_legacy.groovy
@@ -2,7 +2,7 @@
 // Auto generated groovyscript example file
 // MODS_LOADED: aether_legacy
 
-println 'mod \'aether_legacy\' detected, running script'
+log.info 'mod \'aether_legacy\' detected, running script'
 
 // Accessory:
 // The Aether Accessory system.

--- a/examples/postInit/alchemistry.groovy
+++ b/examples/postInit/alchemistry.groovy
@@ -2,7 +2,7 @@
 // Auto generated groovyscript example file
 // MODS_LOADED: alchemistry
 
-println 'mod \'alchemistry\' detected, running script'
+log.info 'mod \'alchemistry\' detected, running script'
 
 // Atomizer:
 // Converts a non-element into its component elements.

--- a/examples/postInit/appliedenergistics2.groovy
+++ b/examples/postInit/appliedenergistics2.groovy
@@ -4,7 +4,7 @@
 
 import appeng.capabilities.Capabilities
 
-println 'mod \'appliedenergistics2\' detected, running script'
+log.info 'mod \'appliedenergistics2\' detected, running script'
 
 // P2P Attunement:
 // Controls using specific items, any items from a mod, or any items with a Capability to convert a P2P into a specific

--- a/examples/postInit/arcanearchives.groovy
+++ b/examples/postInit/arcanearchives.groovy
@@ -2,7 +2,7 @@
 // Auto generated groovyscript example file
 // MODS_LOADED: arcanearchives
 
-println 'mod \'arcanearchives\' detected, running script'
+log.info 'mod \'arcanearchives\' detected, running script'
 
 // Gem Cutting Table:
 // Converts any number of itemstacks into a single output itemstack via selecting the desired output itemstack in the GUI.

--- a/examples/postInit/astralsorcery.groovy
+++ b/examples/postInit/astralsorcery.groovy
@@ -5,7 +5,7 @@
 import hellfirepvp.astralsorcery.common.constellation.MoonPhase
 import net.minecraft.util.math.MathHelper
 
-println 'mod \'astralsorcery\' detected, running script'
+log.info 'mod \'astralsorcery\' detected, running script'
 
 // Chalice Interaction:
 // When two chalices containing different fluids are placed nearby, fluid may be consumed to produce an output itemstack.

--- a/examples/postInit/avaritia.groovy
+++ b/examples/postInit/avaritia.groovy
@@ -2,7 +2,7 @@
 // Auto generated groovyscript example file
 // MODS_LOADED: avaritia
 
-println 'mod \'avaritia\' detected, running script'
+log.info 'mod \'avaritia\' detected, running script'
 
 // Compressor:
 // Converts any number of a single item into an output itemstack.

--- a/examples/postInit/betterwithmods.groovy
+++ b/examples/postInit/betterwithmods.groovy
@@ -2,7 +2,7 @@
 // Auto generated groovyscript example file
 // MODS_LOADED: betterwithmods
 
-println 'mod \'betterwithmods\' detected, running script'
+log.info 'mod \'betterwithmods\' detected, running script'
 
 // Anvil Crafting:
 // Similar to a normal crafting table, but 4x4 instead.

--- a/examples/postInit/bloodmagic.groovy
+++ b/examples/postInit/bloodmagic.groovy
@@ -2,7 +2,7 @@
 // Auto generated groovyscript example file
 // MODS_LOADED: bloodmagic
 
-println 'mod \'bloodmagic\' detected, running script'
+log.info 'mod \'bloodmagic\' detected, running script'
 
 // Alchemy Array:
 // Converts two items into an output itemstack by using Arcane Ashes in-world. Has a configurable texture for the

--- a/examples/postInit/botania.groovy
+++ b/examples/postInit/botania.groovy
@@ -5,7 +5,7 @@
 import net.minecraft.potion.PotionEffect
 import net.minecraft.util.text.TextFormatting
 
-println 'mod \'botania\' detected, running script'
+log.info 'mod \'botania\' detected, running script'
 
 // Petal Apothecary:
 // Converts item inputs into an item output consuming water and a seed.
@@ -68,7 +68,7 @@ mods.botania.elven_trade.recipeBuilder()
 
 
 // Magnet:
-// Add or remove items from the magnet blacklist
+// Add or remove items from the magnet blacklist.
 
 
 mods.botania.magnet.addToBlacklist(item('minecraft:diamond'))

--- a/examples/postInit/calculator.groovy
+++ b/examples/postInit/calculator.groovy
@@ -2,7 +2,7 @@
 // Auto generated groovyscript example file
 // MODS_LOADED: calculator
 
-println 'mod \'calculator\' detected, running script'
+log.info 'mod \'calculator\' detected, running script'
 
 // Algorithm Separator:
 // Converts an input itemstack into two output itemstacks.

--- a/examples/postInit/chisel.groovy
+++ b/examples/postInit/chisel.groovy
@@ -2,10 +2,10 @@
 // Auto generated groovyscript example file
 // MODS_LOADED: chisel
 
-println 'mod \'chisel\' detected, running script'
+log.info 'mod \'chisel\' detected, running script'
 
 // Carving:
-// Sets a group of items any item can be converted between freely, in world and in a GUI
+// Sets a group of items any item can be converted between freely, in world and in a GUI.
 
 // mods.chisel.carving.removeAll()
 mods.chisel.carving.removeGroup('blockDiamond')

--- a/examples/postInit/compactmachines3.groovy
+++ b/examples/postInit/compactmachines3.groovy
@@ -2,7 +2,7 @@
 // Auto generated groovyscript example file
 // MODS_LOADED: compactmachines3
 
-println 'mod \'compactmachines3\' detected, running script'
+log.info 'mod \'compactmachines3\' detected, running script'
 
 // Miniaturization:
 // Consumes a 3d structure in-world based on keys when an item is thrown into the field.

--- a/examples/postInit/draconicevolution.groovy
+++ b/examples/postInit/draconicevolution.groovy
@@ -2,7 +2,7 @@
 // Auto generated groovyscript example file
 // MODS_LOADED: draconicevolution
 
-println 'mod \'draconicevolution\' detected, running script'
+log.info 'mod \'draconicevolution\' detected, running script'
 
 // Energy Core:
 // A multiblock with 8 tiers for storing large amounts of energy.

--- a/examples/postInit/enderio.groovy
+++ b/examples/postInit/enderio.groovy
@@ -2,7 +2,7 @@
 // Auto generated groovyscript example file
 // MODS_LOADED: enderio
 
-println 'mod \'enderio\' detected, running script'
+log.info 'mod \'enderio\' detected, running script'
 
 // Alloy Smelter:
 // Convert up to 3 itemstack inputs into an itemstack output, using energy and giving XP. Can be restricted to require a

--- a/examples/postInit/essentialcraft.groovy
+++ b/examples/postInit/essentialcraft.groovy
@@ -2,7 +2,7 @@
 // Auto generated groovyscript example file
 // MODS_LOADED: essentialcraft
 
-println 'mod \'essentialcraft\' detected, running script'
+log.info 'mod \'essentialcraft\' detected, running script'
 
 // Demon Trade:
 // Adds an item that can be sold to Demons to obtain Ackronite. Note that each demon that spawns has a random item that it

--- a/examples/postInit/evilcraft.groovy
+++ b/examples/postInit/evilcraft.groovy
@@ -2,7 +2,7 @@
 // Auto generated groovyscript example file
 // MODS_LOADED: evilcraft
 
-println 'mod \'evilcraft\' detected, running script'
+log.info 'mod \'evilcraft\' detected, running script'
 
 // Blood Infuser:
 // Consumes an item, some fluid, and requires a given tier of Promise of Tenacity to produce the output and some experience

--- a/examples/postInit/extendedcrafting.groovy
+++ b/examples/postInit/extendedcrafting.groovy
@@ -2,7 +2,7 @@
 // Auto generated groovyscript example file
 // MODS_LOADED: extendedcrafting
 
-println 'mod \'extendedcrafting\' detected, running script'
+log.info 'mod \'extendedcrafting\' detected, running script'
 
 // Combination Crafting:
 // Converts one main item and any number of additional items into an output itemstack, with a configurable rf cost and

--- a/examples/postInit/extrautils2.groovy
+++ b/examples/postInit/extrautils2.groovy
@@ -5,7 +5,7 @@
 import com.rwtema.extrautils2.power.IWorldPowerMultiplier
 import com.rwtema.extrautils2.tile.TilePassiveGenerator
 
-println 'mod \'extrautils2\' detected, running script'
+log.info 'mod \'extrautils2\' detected, running script'
 
 // Crusher:
 // Converts an input itemstack into an output itemstack with a chance of an additional itemstack output, consuming energy.
@@ -98,7 +98,7 @@ mods.extrautils2.generator.recipeBuilder()
 
 
 // Grid Power Generators:
-// Passively produces Grid Power into the Owner's GP network
+// Passively produces Grid Power into the Owner's GP network.
 
 mods.extrautils2.grid_power_passive_generator.setBasePower(resource('generators:creative'), 5f)
 mods.extrautils2.grid_power_passive_generator.setBasePower(resource('generators:player_wind_up'), 100f)

--- a/examples/postInit/immersiveengineering.groovy
+++ b/examples/postInit/immersiveengineering.groovy
@@ -2,7 +2,7 @@
 // Auto generated groovyscript example file
 // MODS_LOADED: immersiveengineering
 
-println 'mod \'immersiveengineering\' detected, running script'
+log.info 'mod \'immersiveengineering\' detected, running script'
 
 // Alloy Kiln:
 // Converts two input itemstacks into an output itemstack, consuming fuel (based on burn time).

--- a/examples/postInit/immersivepetroleum.groovy
+++ b/examples/postInit/immersivepetroleum.groovy
@@ -2,7 +2,7 @@
 // Auto generated groovyscript example file
 // MODS_LOADED: immersivepetroleum
 
-println 'mod \'immersivepetroleum\' detected, running script'
+log.info 'mod \'immersivepetroleum\' detected, running script'
 
 // Distillation Tower:
 // Converts an input fluidstack into any number of output fluidstacks and any number of output itemstacks, with each

--- a/examples/postInit/industrialforegoing.groovy
+++ b/examples/postInit/industrialforegoing.groovy
@@ -4,7 +4,7 @@
 
 import net.minecraft.potion.PotionEffect
 
-println 'mod \'industrialforegoing\' detected, running script'
+log.info 'mod \'industrialforegoing\' detected, running script'
 
 // Bioreactor:
 // Converts an input item into Biofuel, with the amount of Biofuel generated being based on the number of concurrent

--- a/examples/postInit/inspirations.groovy
+++ b/examples/postInit/inspirations.groovy
@@ -2,7 +2,7 @@
 // Auto generated groovyscript example file
 // MODS_LOADED: inspirations
 
-println 'mod \'inspirations\' detected, running script'
+log.info 'mod \'inspirations\' detected, running script'
 
 // Anvil Smashing:
 // Converts a Block or IBlockState into an IBlockState when an anvil falls on top of it (from any height).

--- a/examples/postInit/integrateddynamics.groovy
+++ b/examples/postInit/integrateddynamics.groovy
@@ -2,7 +2,7 @@
 // Auto generated groovyscript example file
 // MODS_LOADED: integrateddynamics
 
-println 'mod \'integrateddynamics\' detected, running script'
+log.info 'mod \'integrateddynamics\' detected, running script'
 
 // Drying Basin:
 // Takes either an item or fluid input and gives either an item or fluid output after a duration.

--- a/examples/postInit/jei.groovy
+++ b/examples/postInit/jei.groovy
@@ -4,10 +4,10 @@
 
 import mezz.jei.api.ingredients.VanillaTypes
 
-println 'mod \'jei\' detected, running script'
+log.info 'mod \'jei\' detected, running script'
 
 // Category Catalysts:
-// Modify the items shown on the left of JEI Categories which indicate where the recipe takes place
+// Modify the items shown on the left of JEI Categories which indicate where the recipe takes place.
 
 mods.jei.catalyst.remove('minecraft.smelting', item('minecraft:furnace'))
 // mods.jei.catalyst.removeByType('minecraft.anvil')

--- a/examples/postInit/mekanism.groovy
+++ b/examples/postInit/mekanism.groovy
@@ -2,7 +2,7 @@
 // Auto generated groovyscript example file
 // MODS_LOADED: mekanism
 
-println 'mod \'mekanism\' detected, running script'
+log.info 'mod \'mekanism\' detected, running script'
 
 // Infusion:
 // Add new infusion types and itemstacks to those types.

--- a/examples/postInit/naturesaura.groovy
+++ b/examples/postInit/naturesaura.groovy
@@ -2,7 +2,7 @@
 // Auto generated groovyscript example file
 // MODS_LOADED: naturesaura
 
-println 'mod \'naturesaura\' detected, running script'
+log.info 'mod \'naturesaura\' detected, running script'
 
 // Natural Altar Infusion:
 // Converts an input itemstack into an itemstack in a multiblock structure, with an optional catalyst block, costing aura

--- a/examples/postInit/pneumaticcraft.groovy
+++ b/examples/postInit/pneumaticcraft.groovy
@@ -2,7 +2,7 @@
 // Auto generated groovyscript example file
 // MODS_LOADED: pneumaticcraft
 
-println 'mod \'pneumaticcraft\' detected, running script'
+log.info 'mod \'pneumaticcraft\' detected, running script'
 
 // Amadron:
 // Uses an Amadron Tablet and linked inventories in world to trade via drones.

--- a/examples/postInit/prodigytech.groovy
+++ b/examples/postInit/prodigytech.groovy
@@ -2,7 +2,7 @@
 // Auto generated groovyscript example file
 // MODS_LOADED: prodigytech
 
-println 'mod \'prodigytech\' detected, running script'
+log.info 'mod \'prodigytech\' detected, running script'
 
 // Atomic Reshaper:
 // Uses Hot Air and Primordium to convert items. Can have a weighted random based output.

--- a/examples/postInit/projecte.groovy
+++ b/examples/postInit/projecte.groovy
@@ -2,7 +2,7 @@
 // Auto generated groovyscript example file
 // MODS_LOADED: projecte
 
-println 'mod \'projecte\' detected, running script'
+log.info 'mod \'projecte\' detected, running script'
 
 // Entity Randomizer:
 // Converts an entity on the list into a random other entity on the list when a projectile fired from the Philosopher's

--- a/examples/postInit/pyrotech.groovy
+++ b/examples/postInit/pyrotech.groovy
@@ -2,10 +2,10 @@
 // Auto generated groovyscript example file
 // MODS_LOADED: pyrotech
 
-println 'mod \'pyrotech\' detected, running script'
+log.info 'mod \'pyrotech\' detected, running script'
 
 // Anvil:
-// When using hammer or pickaxe it can convert items
+// When using hammer or pickaxe it can convert items.
 
 mods.pyrotech.anvil.removeByOutput(item('minecraft:stone_slab', 3))
 // mods.pyrotech.anvil.removeAll()
@@ -41,7 +41,7 @@ mods.pyrotech.anvil.recipeBuilder()
 mods.pyrotech.anvil.add('iron_to_clay', ore('ingotIron') * 5, item('minecraft:clay_ball') * 20, 9, 'granite', 'hammer')
 
 // Barrel:
-// Over time converts a fluid with four items into a new fluid
+// Over time converts a fluid with four items into a new fluid.
 
 mods.pyrotech.barrel.removeByOutput(fluid('freckleberry_wine') * 1000)
 // mods.pyrotech.barrel.removeAll()
@@ -58,7 +58,7 @@ mods.pyrotech.barrel.recipeBuilder()
 mods.pyrotech.barrel.add('iron_dirt_water_to_lava', ore('ingotIron'), ore('ingotIron'), item('minecraft:dirt'), item('minecraft:dirt'), fluid('water'), fluid('lava'), 1000)
 
 // Campfire:
-// Can cook food
+// Can cook food.
 
 mods.pyrotech.campfire.removeByInput(item('minecraft:porkchop'))
 mods.pyrotech.campfire.removeByOutput(item('minecraft:cooked_porkchop'))
@@ -75,7 +75,7 @@ mods.pyrotech.campfire.recipeBuilder()
 mods.pyrotech.campfire.add('apple_to_dirt', item('minecraft:apple'), item('minecraft:dirt'), 1000)
 
 // Chopping Block:
-// When using a axe it can convert items
+// When using a axe it can convert items.
 
 mods.pyrotech.chopping_block.removeByInput(item('minecraft:log2'))
 mods.pyrotech.chopping_block.removeByOutput(item('minecraft:planks', 4))
@@ -93,7 +93,7 @@ mods.pyrotech.chopping_block.recipeBuilder()
 
 
 // Compacting Bin:
-// When using a shovel it can convert items
+// When using a shovel it can convert items.
 
 mods.pyrotech.compacting_bin.removeByInput(item('minecraft:snowball'))
 mods.pyrotech.compacting_bin.removeByOutput(item('minecraft:bone_block'))
@@ -110,7 +110,7 @@ mods.pyrotech.compacting_bin.recipeBuilder()
 mods.pyrotech.compacting_bin.add('iron_to_clay', ore('ingotIron') * 5, item('minecraft:clay_ball') * 20, 9)
 
 // Compost Bin:
-// Can convert multiple items into a new one when its full
+// Can convert multiple items into a new one when its full.
 
 mods.pyrotech.compost_bin.removeByInput(item('minecraft:golden_carrot'))
 // mods.pyrotech.compost_bin.removeAll()
@@ -126,7 +126,7 @@ mods.pyrotech.compost_bin.recipeBuilder()
 mods.pyrotech.compost_bin.add('iron_to_clay2', ore('ingotIron') * 5, item('minecraft:clay_ball') * 20, 2)
 
 // Crude Drying Rack:
-// Converts an item over time into a new one
+// Converts an item over time into a new one.
 
 mods.pyrotech.crude_drying_rack.removeByInput(item('minecraft:wheat'))
 // mods.pyrotech.crude_drying_rack.removeAll()
@@ -142,7 +142,7 @@ mods.pyrotech.crude_drying_rack.recipeBuilder()
 mods.pyrotech.crude_drying_rack.add('apple_to_dirt', item('minecraft:apple'), item('minecraft:dirt'), 1200)
 
 // Drying Rack:
-// Converts an item over time into a new one
+// Converts an item over time into a new one.
 
 mods.pyrotech.drying_rack.removeByInput(item('minecraft:wheat'))
 // mods.pyrotech.drying_rack.removeAll()
@@ -158,7 +158,7 @@ mods.pyrotech.drying_rack.recipeBuilder()
 mods.pyrotech.drying_rack.add('apple_to_dirt', item('minecraft:apple'), item('minecraft:dirt'), 1200)
 
 // Kiln:
-// Converts an item into a new one by burning it. Has a chance to fail
+// Converts an item into a new one by burning it. Has a chance to fail.
 
 mods.pyrotech.kiln.removeByOutput(item('pyrotech:bucket_clay'))
 // mods.pyrotech.kiln.removeAll()
@@ -176,7 +176,7 @@ mods.pyrotech.kiln.recipeBuilder()
 mods.pyrotech.kiln.add('clay_to_iron', item('minecraft:clay_ball') * 5, item('minecraft:iron_ingot'), 1200, 0.5f, [item('minecraft:dirt'), item('minecraft:cobblestone')])
 
 // Soaking Pot:
-// Converts an item into a new one by soaking it in a liquid. Can require a campfire
+// Converts an item into a new one by soaking it in a liquid. Can require a campfire.
 
 mods.pyrotech.soaking_pot.removeByOutput(item('pyrotech:material', 54))
 // mods.pyrotech.soaking_pot.removeAll()
@@ -194,7 +194,7 @@ mods.pyrotech.soaking_pot.recipeBuilder()
 mods.pyrotech.soaking_pot.add('dirt_to_apple', item('minecraft:dirt'), fluid('water'), item('minecraft:apple'), 1200)
 
 // Tanning Rack:
-// Converts an item over time into a new one
+// Converts an item over time into a new one.
 
 mods.pyrotech.tanning_rack.removeByInput(item('minecraft:wheat'))
 // mods.pyrotech.tanning_rack.removeAll()

--- a/examples/postInit/roots.groovy
+++ b/examples/postInit/roots.groovy
@@ -2,7 +2,7 @@
 // Auto generated groovyscript example file
 // MODS_LOADED: roots
 
-println 'mod \'roots\' detected, running script'
+log.info 'mod \'roots\' detected, running script'
 
 // Animal Harvest:
 // Animal Harvest is a ritual that drops items from nearby mob's based on that mobs loottable without harming the mob. Only
@@ -107,8 +107,9 @@ mods.roots.fey_crafter.recipeBuilder()
 
 
 // Flower Generation:
-// When running the Flower Growth Ritual, allowed flowers will generate in the area. Additionally, using the spell Growth
-// Infusion's Floral Reproduction modifier will duplicate the flower.
+// When running the Flower Growth Ritual, allowed flowers will generate in the area if they can be placed on the given soil
+// block. Additionally, using the spell Growth Infusion's Floral Reproduction modifier will duplicate the flower,
+// regardless of the soil block.
 
 mods.roots.flower_generation.removeByFlower(block('minecraft:red_flower'))
 mods.roots.flower_generation.removeByFlower(block('minecraft:red_flower'), 1)

--- a/examples/postInit/rustic.groovy
+++ b/examples/postInit/rustic.groovy
@@ -4,7 +4,7 @@
 
 import net.minecraft.potion.PotionEffect
 
-println 'mod \'rustic\' detected, running script'
+log.info 'mod \'rustic\' detected, running script'
 
 // Alchemy Condenser:
 // Converts some number of input itemstacks and a fluidstack into a single output stack after a time in a small multiblock

--- a/examples/postInit/tconstruct.groovy
+++ b/examples/postInit/tconstruct.groovy
@@ -2,7 +2,7 @@
 // Auto generated groovyscript example file
 // MODS_LOADED: tconstruct
 
-println 'mod \'tconstruct\' detected, running script'
+log.info 'mod \'tconstruct\' detected, running script'
 
 // Alloying:
 // Modifies what fluids can be mixed together in the Smeltery.

--- a/examples/postInit/thaumcraft.groovy
+++ b/examples/postInit/thaumcraft.groovy
@@ -2,7 +2,7 @@
 // Auto generated groovyscript example file
 // MODS_LOADED: thaumcraft
 
-println 'mod \'thaumcraft\' detected, running script'
+log.info 'mod \'thaumcraft\' detected, running script'
 
 // Arcane Workbench:
 // A special crafting table, allowing additional requirements in the form of Vis Crystals, Vis, and having a specific
@@ -195,7 +195,7 @@ mods.thaumcraft.smelting_bonus.recipeBuilder()
 
 
 // Warp:
-// Determines if holding an item or equipping a piece of armor or a bauble gives warp, and how much warp it gives
+// Determines if holding an item or equipping a piece of armor or a bauble gives warp, and how much warp it gives.
 
 mods.thaumcraft.warp.removeWarp(item('thaumcraft:void_hoe'))
 // mods.thaumcraft.warp.removeAll()

--- a/examples/postInit/thermalexpansion.groovy
+++ b/examples/postInit/thermalexpansion.groovy
@@ -4,7 +4,7 @@
 
 import cofh.thermalexpansion.util.managers.machine.InsolatorManager
 
-println 'mod \'thermalexpansion\' detected, running script'
+log.info 'mod \'thermalexpansion\' detected, running script'
 
 // Alchemical Imbuer:
 // Converts an input fluidstack and input itemstack into an output fluidstack, costing power and taking time based on the

--- a/examples/postInit/threng.groovy
+++ b/examples/postInit/threng.groovy
@@ -2,7 +2,7 @@
 // Auto generated groovyscript example file
 // MODS_LOADED: threng
 
-println 'mod \'threng\' detected, running script'
+log.info 'mod \'threng\' detected, running script'
 
 // Fluix Aggregation:
 // Converts up to 3 input itemstacks into an output itemstack.

--- a/examples/postInit/woot.groovy
+++ b/examples/postInit/woot.groovy
@@ -4,7 +4,7 @@
 
 import ipsis.woot.util.WootMobName
 
-println 'mod \'woot\' detected, running script'
+log.info 'mod \'woot\' detected, running script'
 
 // Drops:
 // Controls extra drops given by mobs. Chance and Size are both arrays 4 long, containing the values for levels 0/1/2/3
@@ -29,7 +29,7 @@ mods.woot.drops.recipeBuilder()
 // Mob Config:
 // Control the default values or mob-specific values for a large number of effects, a full list can be found at
 // `ipsis.woot.configuration.EnumConfigKey`. A full list can be viewed on
-// [Github](https://github.com/Ipsis/Woot/blob/55e88f5a15d66cc987e676d665d20f4afbe008b8/src/main/java/ipsis/woot/configuration/EnumConfigKey.java#L14)
+// [Github](https://github.com/Ipsis/Woot/blob/55e88f5a15d66cc987e676d665d20f4afbe008b8/src/main/java/ipsis/woot/configuration/EnumConfigKey.java#L14).
 
 mods.woot.mob_config.remove('minecraft:wither_skeleton', 'spawn_units')
 mods.woot.mob_config.remove('minecraft:wither')

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/machine/Sawmill.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/machine/Sawmill.java
@@ -43,12 +43,12 @@ public class Sawmill extends VirtualizedRegistry<SawmillRecipe> {
     }
 
     @MethodDescription(type = MethodDescription.Type.ADDITION, example = @Example("1000, item('minecraft:obsidian') * 4, item('minecraft:gold_ingot'), item('minecraft:diamond'), 25"))
-    public SawmillRecipe add(int energy, IIngredient input, ItemStack outputItem, ItemStack secondayOutput, int chance) {
+    public SawmillRecipe add(int energy, IIngredient input, ItemStack outputItem, ItemStack secondaryOutput, int chance) {
         return recipeBuilder()
                 .energy(energy)
                 .chance(chance)
                 .input(input)
-                .output(outputItem, secondayOutput)
+                .output(outputItem, secondaryOutput)
                 .register();
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/documentation/Builder.java
+++ b/src/main/java/com/cleanroommc/groovyscript/documentation/Builder.java
@@ -418,7 +418,7 @@ public class Builder {
         }
 
         public String getDescription() {
-            return "- " + getFieldTypeInlineCode() + Documentation.translate(getLangKey()) + ".";
+            return "- " + getFieldTypeInlineCode() + Documentation.ensurePeriod(Documentation.translate(getLangKey()));
         }
 
         @Override

--- a/src/main/java/com/cleanroommc/groovyscript/documentation/Documentation.java
+++ b/src/main/java/com/cleanroommc/groovyscript/documentation/Documentation.java
@@ -116,6 +116,7 @@ public class Documentation {
     }
 
     public static String ensurePeriod(String string) {
+        if (string.isEmpty()) return "";
         return string.charAt(string.length() - 1) == '.' ? string : string + ".";
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/documentation/Documentation.java
+++ b/src/main/java/com/cleanroommc/groovyscript/documentation/Documentation.java
@@ -115,5 +115,9 @@ public class Documentation {
         return I18n.format(translateKey, parameters);
     }
 
+    public static String ensurePeriod(String string) {
+        return string.charAt(string.length() - 1) == '.' ? string : string + ".";
+    }
+
 }
 

--- a/src/main/java/com/cleanroommc/groovyscript/documentation/Exporter.java
+++ b/src/main/java/com/cleanroommc/groovyscript/documentation/Exporter.java
@@ -23,7 +23,7 @@ public class Exporter {
 
     private static final String INDEX_FILE_NAME = "index.md";
     private static final String NAV_FILE_NAME = "!navigation.md";
-    private static final String PRINT_MOD_DETECTED = "println 'mod \\'%s\\' detected, running script'";
+    private static final String PRINT_MOD_DETECTED = "log.info 'mod \\'%s\\' detected, running script'";
     private static final Pattern CLASS_NAME_PATTERN = Pattern.compile("(?>\\b)(?>[a-zA-Z0-9]+\\.)+([a-zA-Z0-9$]+)");
 
     public static String simpleSignature(Method method) {

--- a/src/main/java/com/cleanroommc/groovyscript/documentation/Registry.java
+++ b/src/main/java/com/cleanroommc/groovyscript/documentation/Registry.java
@@ -112,8 +112,8 @@ public class Registry {
     }
 
     public String getDescription() {
-        return Documentation.translate(description.description().isEmpty() ? String.format("%s.description", baseTranslationKey) : description.description())
-                .replace("\"", "\\\"");
+        return Documentation.ensurePeriod(Documentation.translate(description.description().isEmpty() ? String.format("%s.description", baseTranslationKey) : description.description())
+                .replace("\"", "\\\""));
     }
 
     public String exampleBlock() {
@@ -170,7 +170,7 @@ public class Registry {
                                .title(note.title())
                                .hasTitle(note.hasTitle())
                                .format(note.format())
-                               .note(Documentation.translate(note.value()))
+                               .note(Documentation.ensurePeriod(Documentation.translate(note.value())))
                                .generate());
             out.append("\n\n");
         }

--- a/src/main/java/com/cleanroommc/groovyscript/documentation/format/VitePress.java
+++ b/src/main/java/com/cleanroommc/groovyscript/documentation/format/VitePress.java
@@ -12,7 +12,7 @@ public class VitePress implements IFormat {
 
     @Override
     public String linkToBuilder() {
-        return "../../groovy/builder.md";
+        return "../../getting_started/builder.md";
     }
 
     @Override

--- a/src/main/resources/assets/groovyscript/lang/en_us.lang
+++ b/src/main/resources/assets/groovyscript/lang/en_us.lang
@@ -156,16 +156,16 @@ groovyscript.wiki.aether_legacy.accessory.accessoryType.value=Sets the type of a
 groovyscript.wiki.aether_legacy.enchanter.title=Enchanter
 groovyscript.wiki.aether_legacy.enchanter.description=Enchanting is a mechanic used to create new items, as well as repair tools, armor, and weapons, using the Altar block.
 groovyscript.wiki.aether_legacy.enchanter.add=Adds an Enchanting recipe in the format `input`, `output`, `time`.
-groovyscript.wiki.aether_legacy.enchanter.time.value=Sets the time the recipe takes to compelte
+groovyscript.wiki.aether_legacy.enchanter.time.value=Sets the time the recipe takes to complete
 
 groovyscript.wiki.aether_legacy.enchanter_fuel.title=Enchanter Fuel
-groovyscript.wiki.aether_legacy.enchanter_fuel.description=By default, the Enchantar (Altar) takes Ambrosium Shards as fuel. Using GroovyScript, custom fuels can be added.
+groovyscript.wiki.aether_legacy.enchanter_fuel.description=By default, the Enchanter (Altar) takes Ambrosium Shards as fuel. Using GroovyScript, custom fuels can be added.
 groovyscript.wiki.aether_legacy.enchanter_fuel.add=Adds an Enchanting fuel in the format `item`, `timeGiven`.
 
 groovyscript.wiki.aether_legacy.freezer.title=Freezer
 groovyscript.wiki.aether_legacy.freezer.description=The Freezer is used to turn certain items into frozen versions.
 groovyscript.wiki.aether_legacy.freezer.add=Adds a Freezer recipe in the format `input`, `output`, `time`.
-groovyscript.wiki.aether_legacy.freezer.time.value=Sets the time the recipe takes to compelte
+groovyscript.wiki.aether_legacy.freezer.time.value=Sets the time the recipe takes to complete
 
 groovyscript.wiki.aether_legacy.freezer_fuel.title=Freezer
 groovyscript.wiki.aether_legacy.freezer_fuel.description= By default, the Freezer takes Icestone as fuel. Using GroovyScript, custom fuels can be added.
@@ -616,7 +616,7 @@ groovyscript.wiki.botania.pure_daisy.input.required=either an IBlockState or Str
 groovyscript.wiki.botania.pure_daisy.time.value=Sets the duration the recipe takes to complete
 
 groovyscript.wiki.botania.rune_altar.title=Rune Altar
-groovyscript.wiki.botania.rune_altar.description=Converts a items inputs into an item ouput at the cost of mana when a Livingrock item is thrown atop the altar and right clicked with a Wand of the Forest.
+groovyscript.wiki.botania.rune_altar.description=Converts a items inputs into an item output at the cost of mana when a Livingrock item is thrown atop the altar and right clicked with a Wand of the Forest.
 groovyscript.wiki.botania.rune_altar.add=Adds recipes in the format `output`, `mana`, `inputs`
 groovyscript.wiki.botania.rune_altar.input.required=that `input` IIngredients cannot contain Botania's Livingrock Item
 groovyscript.wiki.botania.rune_altar.mana.value=Sets the mana cost of processing the recipe
@@ -923,7 +923,7 @@ groovyscript.wiki.extrautils2.resonator.description=Converts and input itemstack
 groovyscript.wiki.extrautils2.resonator.energy.value=Sets the total Grid Power required for the recipe in 1/100ths of a single GP (int 1000 = 10 GP)
 groovyscript.wiki.extrautils2.resonator.ownerTag.value=Sets if the output itemstack should gain an NBT tag attaching the player who placed the Resonator to the itemstack. Notably used for Red Coal, to determine the bonus burn time from Grid Power
 groovyscript.wiki.extrautils2.resonator.requirementText.value=Sets the text in JEI displaying an additional requirement for the recipe to run
-groovyscript.wiki.extrautils2.resonator.shouldProgress.value=Sets the function used to determine if the recipe should run, with the Closure taking 3 paramenters, `TileEntity resonator`, `int frequency`, `ItemStack input` and returning a `boolean`
+groovyscript.wiki.extrautils2.resonator.shouldProgress.value=Sets the function used to determine if the recipe should run, with the Closure taking 3 parameters, `TileEntity resonator`, `int frequency`, `ItemStack input` and returning a `boolean`
 
 # Immersive Engineering
 groovyscript.wiki.immersiveengineering.alloy_kiln.title=Alloy Kiln
@@ -1117,7 +1117,7 @@ groovyscript.wiki.inspirations.cauldron.dye.value=Sets the dye color fluid requi
 groovyscript.wiki.inspirations.cauldron.type.value=Sets what type of recipe is being processed
 groovyscript.wiki.inspirations.cauldron.sound.value=Sets the sound played when the recipe is crafted
 groovyscript.wiki.inspirations.cauldron.levels.value=Sets the level of fluid in the cauldron, where each bottle is a single level
-groovyscript.wiki.inspirations.cauldron.boiling.value=Sets if the cauldon must be boiling, requiring fire or another heat source beneath
+groovyscript.wiki.inspirations.cauldron.boiling.value=Sets if the cauldron must be boiling, requiring fire or another heat source beneath
 groovyscript.wiki.inspirations.cauldron.inputPotion.value=Sets the input potion type
 groovyscript.wiki.inspirations.cauldron.outputPotion.value=Sets the output potion type
 groovyscript.wiki.inspirations.cauldron.removeByFluidInput=Removes all recipes with the given fluid input
@@ -1245,7 +1245,7 @@ groovyscript.wiki.mekanism.injection_chamber.annotation=Always uses 200 gas
 groovyscript.wiki.mekanism.injection_chamber.add=Adds recipes in the format `ingredient`, `gasInput`, `output`
 
 groovyscript.wiki.mekanism.metallurgic_infuser.title=Metallurgic Infuser
-groovyscript.wiki.mekanism.metallurgic_infuser.description=Converts and input itemstack and a varible amount of an infusion type into an output itemstack.
+groovyscript.wiki.mekanism.metallurgic_infuser.description=Converts and input itemstack and a variable amount of an infusion type into an output itemstack.
 groovyscript.wiki.mekanism.metallurgic_infuser.add0=Adds recipes in the format `ingredient`, `infuseType`, `infuseAmount`, `output`
 groovyscript.wiki.mekanism.metallurgic_infuser.add1=Adds recipes in the format `ingredient`, `infuseType`, `infuseAmount`, `output`
 groovyscript.wiki.mekanism.metallurgic_infuser.infuse.value=Sets the Infusion type the recipe uses
@@ -1517,7 +1517,7 @@ groovyscript.wiki.projecte.entity_randomizer.streamMobs=Iterates through every e
 groovyscript.wiki.projecte.entity_randomizer.streamPeacefuls=Iterates through every entry in the peacefuls list
 
 groovyscript.wiki.projecte.transmutation.title=World Transmutation
-groovyscript.wiki.projecte.transmutation.description=Converts an input blockstate into an output blockstate when right-clicked with by a Philosopher's Stone, with the abity to be converted into a different output blockstate when holding shift.
+groovyscript.wiki.projecte.transmutation.description=Converts an input blockstate into an output blockstate when right-clicked with by a Philosopher's Stone, with the ability to be converted into a different output blockstate when holding shift.
 groovyscript.wiki.projecte.transmutation.input.value=Sets the input blockstate
 groovyscript.wiki.projecte.transmutation.output.value=Sets the normal output blockstate
 groovyscript.wiki.projecte.transmutation.altOutput.value=Sets the shift output blockstate
@@ -1620,7 +1620,7 @@ groovyscript.wiki.roots.predicates.above_or_below.required=that only at most one
 groovyscript.wiki.roots.predicates.properties.required=that each property must be a valid property of the provided `blockstate`
 
 groovyscript.wiki.roots.pyre.title=Pyre
-groovyscript.wiki.roots.pyre.description=Converts 5 input items into the ouput after a period of time when the Pyre is lit on fire.
+groovyscript.wiki.roots.pyre.description=Converts 5 input items into the output after a period of time when the Pyre is lit on fire.
 groovyscript.wiki.roots.pyre.burnTime.value=Sets the time in ticks for the recipe to process
 groovyscript.wiki.roots.pyre.xp.value=Sets the XP given when the recipe finishes in levels
 groovyscript.wiki.roots.pyre.removeByName=Removes the Pyre recipe with the given name
@@ -2002,7 +2002,7 @@ groovyscript.wiki.thermalexpansion.refinery_potion.chance.value=Sets the chance 
 groovyscript.wiki.thermalexpansion.sawmill.title=Sawmill
 groovyscript.wiki.thermalexpansion.sawmill.description=Converts an input itemstack into an output itemstack and optional output itemstack with a chance, costing power and taking time based on the power cost.
 groovyscript.wiki.thermalexpansion.sawmill.note0=The valid items and fluid output while the Resin Funnel Augment is installed is controlled by the Arboreal Extractor device.
-groovyscript.wiki.thermalexpansion.sawmill.add=Adds recipes in the format `energy`, `input`, `outputItem`, `secondayOutput`, `chance`
+groovyscript.wiki.thermalexpansion.sawmill.add=Adds recipes in the format `energy`, `input`, `outputItem`, `secondaryOutput`, `chance`
 groovyscript.wiki.thermalexpansion.sawmill.chance.value=Sets the chance the second output itemstack is created
 
 groovyscript.wiki.thermalexpansion.smelter.title=Induction Smelter
@@ -2075,7 +2075,7 @@ groovyscript.wiki.woot.mob_config.removeByEntity=Removes all configuration for t
 
 groovyscript.wiki.woot.policy.title=Policy
 groovyscript.wiki.woot.policy.description=Controls what entities can be farmed for what items via an entity blacklist, mod blacklist, item output blacklist, item output mod blacklist, and a mob whitelist.
-groovyscript.wiki.woot.policy.note=If the whitelist contains any entities, any entities not in the whitelist are banned (rendering EntityModBlacklist and EntityBlacklist superflous). GenerateOnlyList contains all entities which cannot be captured via shard, meaning the controller would need to be obtained a different way.
+groovyscript.wiki.woot.policy.note=If the whitelist contains any entities, any entities not in the whitelist are banned (rendering EntityModBlacklist and EntityBlacklist superfluous). GenerateOnlyList contains all entities which cannot be captured via shard, meaning the controller would need to be obtained a different way.
 groovyscript.wiki.woot.policy.addToEntityBlacklist=Prevents the given entity from being captured and spawned
 groovyscript.wiki.woot.policy.addToEntityModBlacklist=Prevents entities from the given mod from being captured and spawned
 groovyscript.wiki.woot.policy.addToEntityWhitelist=Prevents all entities not on the list from being spawned, overriding EntityBlacklist and EntityModBlacklist


### PR DESCRIPTION
changes in this PR:
- update the vitepress builder link location, since it has moved.
- change `println` to `log.info` in examples, as it contains more information.
- ensure there is one and only one period in some locations for documentation, fixing some occasional oddities.
- fix a handful of small typos in the lang file (and one related instance of it as a parameter name).