### PR TITLE
fix multiple punctuation marks

### DIFF
--- a/examples/postInit/aether_legacy.groovy
+++ b/examples/postInit/aether_legacy.groovy
@@ -32,7 +32,7 @@ mods.aether_legacy.enchanter.recipeBuilder()
 
 
 // Enchanter Fuel:
-// By default, the Enchantar (Altar) takes Ambrosium Shards as fuel. Using GroovyScript, custom fuels can be added.
+// By default, the Enchanter (Altar) takes Ambrosium Shards as fuel. Using GroovyScript, custom fuels can be added.
 
 mods.aether_legacy.enchanter_fuel.removeByItem(item('aether_legacy:ambrosium_shard'))
 // mods.aether_legacy.enchanter_fuel.removeAll()
@@ -53,7 +53,7 @@ mods.aether_legacy.freezer.recipeBuilder()
 
 
 
-// Freezer:
+// Freezer Fuel:
 // By default, the Freezer takes Icestone as fuel. Using GroovyScript, custom fuels can be added.
 
 mods.aether_legacy.freezer_fuel.removeByItem(item('aether_legacy:icestone'))

--- a/examples/postInit/atum.groovy
+++ b/examples/postInit/atum.groovy
@@ -2,7 +2,7 @@
 // Auto generated groovyscript example file
 // MODS_LOADED: atum
 
-println 'mod \'atum\' detected, running script'
+log.info 'mod \'atum\' detected, running script'
 
 // Kiln:
 // Smelts an input item into an output itemstack and giving experience similar to a Furnace, but can process up to 4 stacks

--- a/examples/postInit/botania.groovy
+++ b/examples/postInit/botania.groovy
@@ -129,8 +129,8 @@ mods.botania.pure_daisy.recipeBuilder()
 
 
 // Rune Altar:
-// Converts a items inputs into an item ouput at the cost of mana when a Livingrock item is thrown atop the altar and right
-// clicked with a Wand of the Forest.
+// Converts a items inputs into an item output at the cost of mana when a Livingrock item is thrown atop the altar and
+// right clicked with a Wand of the Forest.
 
 mods.botania.rune_altar.removeByInput(ore('runeEarthB'))
 mods.botania.rune_altar.removeByInputs(ore('feather'), ore('string'))

--- a/examples/postInit/botanicadds.groovy
+++ b/examples/postInit/botanicadds.groovy
@@ -2,7 +2,7 @@
 // Auto generated groovyscript example file
 // MODS_LOADED: botanicadds
 
-println 'mod \'botanicadds\' detected, running script'
+log.info 'mod \'botanicadds\' detected, running script'
 
 // Gaia Plate:
 // Converts an number of input items into an output itemstack, consuming a given amount of mana when dropped in-world atop

--- a/examples/postInit/cyclicmagic.groovy
+++ b/examples/postInit/cyclicmagic.groovy
@@ -2,7 +2,7 @@
 // Auto generated groovyscript example file
 // MODS_LOADED: cyclicmagic
 
-println 'mod \'cyclicmagic\' detected, running script'
+log.info 'mod \'cyclicmagic\' detected, running script'
 
 // DeHydrator:
 // Converts an input itemstack into an output itemstack.

--- a/examples/postInit/extrabotany.groovy
+++ b/examples/postInit/extrabotany.groovy
@@ -2,10 +2,11 @@
 // Auto generated groovyscript example file
 // MODS_LOADED: extrabotany
 
-println 'mod \'extrabotany\' detected, running script'
+log.info 'mod \'extrabotany\' detected, running script'
 
-// groovyscript.wiki.extrabotany.pedestal.title:
-// groovyscript.wiki.extrabotany.pedestal.description
+// Livingrock Pedestal:
+// Converts an input item into an output itemstack when placed inside a Livingrock Pedestal and interacted with by an Extra
+// Botany Hammer.
 
 mods.extrabotany.pedestal.removeByInput(item('minecraft:cobblestone'))
 mods.extrabotany.pedestal.removeByOutput(item('minecraft:flint'))

--- a/examples/postInit/mekanism.groovy
+++ b/examples/postInit/mekanism.groovy
@@ -148,7 +148,7 @@ mods.mekanism.injection_chamber.recipeBuilder()
 // mods.mekanism.injection_chamber.add(item('minecraft:diamond'), gas('water'), item('minecraft:nether_star'))
 
 // Metallurgic Infuser:
-// Converts and input itemstack and a varible amount of an infusion type into an output itemstack.
+// Converts and input itemstack and a variable amount of an infusion type into an output itemstack.
 
 mods.mekanism.metallurgic_infuser.removeByInput(ore('dustObsidian'), 'DIAMOND')
 // mods.mekanism.metallurgic_infuser.removeAll()

--- a/examples/postInit/mysticalagriculture.groovy
+++ b/examples/postInit/mysticalagriculture.groovy
@@ -2,7 +2,7 @@
 // Auto generated groovyscript example file
 // MODS_LOADED: mysticalagriculture
 
-println 'mod \'mysticalagriculture\' detected, running script'
+log.info 'mod \'mysticalagriculture\' detected, running script'
 
 // Seed Reprocessor:
 // Converts an input itemstack into an output itemstack, taking a set amount of time based on the machine and consuming

--- a/examples/postInit/primal_tech.groovy
+++ b/examples/postInit/primal_tech.groovy
@@ -2,7 +2,7 @@
 // Auto generated groovyscript example file
 // MODS_LOADED: primal_tech
 
-println 'mod \'primal_tech\' detected, running script'
+log.info 'mod \'primal_tech\' detected, running script'
 
 // Clay Kiln:
 // Converts an input item into an output itemstack after a given amount of time. Requires the block below to be Minecraft

--- a/examples/postInit/projecte.groovy
+++ b/examples/postInit/projecte.groovy
@@ -18,8 +18,8 @@ mods.projecte.entity_randomizer.addMob(entity('minecraft:pig'))
 mods.projecte.entity_randomizer.addPeaceful(entity('minecraft:zombie'))
 
 // World Transmutation:
-// Converts an input blockstate into an output blockstate when right-clicked with by a Philosopher's Stone, with the abity
-// to be converted into a different output blockstate when holding shift.
+// Converts an input blockstate into an output blockstate when right-clicked with by a Philosopher's Stone, with the
+// ability to be converted into a different output blockstate when holding shift.
 
 mods.projecte.transmutation.removeByInput(blockstate('minecraft:wool'))
 mods.projecte.transmutation.removeByOutput(blockstate('minecraft:dirt'))

--- a/examples/postInit/roots.groovy
+++ b/examples/postInit/roots.groovy
@@ -237,7 +237,7 @@ mods.roots.predicates.stateBuilder()
 
 
 // Pyre:
-// Converts 5 input items into the ouput after a period of time when the Pyre is lit on fire.
+// Converts 5 input items into the output after a period of time when the Pyre is lit on fire.
 
 mods.roots.pyre.removeByName(resource('roots:infernal_bulb'))
 mods.roots.pyre.removeByOutput(item('minecraft:gravel'))

--- a/examples/postInit/theaurorian.groovy
+++ b/examples/postInit/theaurorian.groovy
@@ -2,7 +2,7 @@
 // Auto generated groovyscript example file
 // MODS_LOADED: theaurorian
 
-println 'mod \'theaurorian\' detected, running script'
+log.info 'mod \'theaurorian\' detected, running script'
 
 // Moonlight Forge:
 // Combines two items to get a third item. Only works at night, and works faster the higher it is placed in the world.

--- a/src/main/java/com/cleanroommc/groovyscript/documentation/Documentation.java
+++ b/src/main/java/com/cleanroommc/groovyscript/documentation/Documentation.java
@@ -8,6 +8,7 @@ import com.cleanroommc.groovyscript.compat.mods.ModSupport;
 import com.cleanroommc.groovyscript.documentation.format.IFormat;
 import com.cleanroommc.groovyscript.documentation.format.OutputFormat;
 import com.cleanroommc.groovyscript.sandbox.LoadStage;
+import com.google.common.collect.ImmutableSet;
 import it.unimi.dsi.fastutil.objects.ObjectLinkedOpenHashSet;
 import net.minecraft.client.resources.I18n;
 import net.minecraftforge.fml.common.FMLCommonHandler;
@@ -39,6 +40,7 @@ public class Documentation {
     private static final boolean LOG_MISSING_KEYS = true;
 
     private static final Set<String> missingLangKeys = new ObjectLinkedOpenHashSet<>();
+    private static final Set<Character> PUNCTUATION_CHARACTERS = ImmutableSet.of('.', '!', '?');
 
     public static void generate() {
         if (isGenerateExamples()) generateExamples();
@@ -117,7 +119,7 @@ public class Documentation {
 
     public static String ensurePeriod(String string) {
         if (string.isEmpty()) return "";
-        return string.charAt(string.length() - 1) == '.' ? string : string + ".";
+        return PUNCTUATION_CHARACTERS.contains(string.charAt(string.length() - 1)) ? string : string + ".";
     }
 
 }

--- a/src/main/resources/assets/groovyscript/lang/en_us.lang
+++ b/src/main/resources/assets/groovyscript/lang/en_us.lang
@@ -1543,8 +1543,7 @@ groovyscript.wiki.pyrotech.kiln.title=Kiln
 groovyscript.wiki.pyrotech.kiln.description=Converts an item into a new one by burning it. Has a chance to fail
 groovyscript.wiki.pyrotech.kiln.burnTime.value=Sets the time required for the recipe to complete
 groovyscript.wiki.pyrotech.kiln.failureChance.value=Sets the chance to fail the recipe
-groovyscript.wiki.pyrotech.kiln.failureOutputs.value=Sets the output when the recipe failed
-groovyscript.wiki.pyrotech.kiln.failureOutput.value=
+groovyscript.wiki.pyrotech.kiln.failureOutput.value=Sets the output when the recipe failed
 groovyscript.wiki.pyrotech.kiln.add=Adds recipes in the format `name`, `input`, `output`, `burnTime`, `failureChance`, `failureOutput`
 
 groovyscript.wiki.pyrotech.soaking_pot.title=Soaking Pot

--- a/src/main/resources/assets/groovyscript/lang/en_us.lang
+++ b/src/main/resources/assets/groovyscript/lang/en_us.lang
@@ -199,7 +199,7 @@ groovyscript.wiki.aether_legacy.freezer.description=The Freezer is used to turn 
 groovyscript.wiki.aether_legacy.freezer.add=Adds a Freezer recipe in the format `input`, `output`, `time`.
 groovyscript.wiki.aether_legacy.freezer.time.value=Sets the time the recipe takes to complete
 
-groovyscript.wiki.aether_legacy.freezer_fuel.title=Freezer
+groovyscript.wiki.aether_legacy.freezer_fuel.title=Freezer Fuel
 groovyscript.wiki.aether_legacy.freezer_fuel.description= By default, the Freezer takes Icestone as fuel. Using GroovyScript, custom fuels can be added.
 groovyscript.wiki.aether_legacy.freezer_fuel.add=Adds a Freezer fuel in the format `item`, `timeGiven`.
 


### PR DESCRIPTION
changes in this PR:
- fix punctuation being matched against exclusively period to determine if a period is added, instead of `./!/?`, which currently leads to a few situations of `!.` at the end of a paragraph.
- rename the second instance of Aether Legacy Freezer to Freezer Fuel.
- fix Pyrotech's Kiln having an empty lang key and having a typo'd correct lang key.
- update examples with the new docs.


noticed these while creating this PR: https://github.com/CleanroomMC/cleanroom-website/pull/18