### PR TITLE
Resolve Symbolic Links in Groovy Folder in Debug Mode

### DIFF
--- a/src/main/java/com/cleanroommc/groovyscript/sandbox/RunConfig.java
+++ b/src/main/java/com/cleanroommc/groovyscript/sandbox/RunConfig.java
@@ -320,7 +320,7 @@ public class RunConfig {
                 continue;
             }
             int pathSize = path.split(separator).length;
-            try (Stream<Path> stream = Files.walk(rootFile.toPath(), FileVisitOption.FOLLOW_LINKS)) {
+            try (Stream<Path> stream = Files.walk(rootFile.toPath(), isDebug() ? new FileVisitOption[] { FileVisitOption.FOLLOW_LINKS } : new FileVisitOption[0])) {
                 stream.filter(path1 -> isGroovyFile(path1.toString()))
                         .map(Path::toFile)
                         //.filter(Preprocessor::validatePreprocessors)

--- a/src/main/java/com/cleanroommc/groovyscript/sandbox/RunConfig.java
+++ b/src/main/java/com/cleanroommc/groovyscript/sandbox/RunConfig.java
@@ -21,6 +21,7 @@ import org.jetbrains.annotations.ApiStatus;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.FileVisitOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
@@ -319,7 +320,7 @@ public class RunConfig {
                 continue;
             }
             int pathSize = path.split(separator).length;
-            try (Stream<Path> stream = Files.walk(rootFile.toPath())) {
+            try (Stream<Path> stream = Files.walk(rootFile.toPath(), FileVisitOption.FOLLOW_LINKS)) {
                 stream.filter(path1 -> isGroovyFile(path1.toString()))
                         .map(Path::toFile)
                         //.filter(Preprocessor::validatePreprocessors)


### PR DESCRIPTION
This PR properly resolves Symbolic Links when searching through the `groovy` folder to find scripts. This means that sub folders and individual files of the `groovy` folder can now be symlinked (`postInit` folder or folders inside `postInit`, etc.), rather than having the whole `groovy` folder required to be symlinked beforehand.

This results in potential improvements for developers.

This might introduce cases where recursive symlinks cause an infinite walk, which could be controlled with a limit on directory search, but given the rarity of such a case, and potential issues directory search limits could introduce, this has not been directly added in this PR.