### PR TITLE
Convert all Records to Classes

### DIFF
--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/Category.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/Category.java
@@ -124,9 +124,9 @@ public class Category extends VirtualizedRegistry<String> {
         private final List<? extends IRecipeWrapper> wrappers;
 
         public CustomCategory(String id,
-                       Function<IGuiHelper, ? extends IRecipeCategory<? extends IRecipeWrapper>> category,
-                       List<?> catalysts,
-                       List<? extends IRecipeWrapper> wrappers) {
+                              Function<IGuiHelper, ? extends IRecipeCategory<? extends IRecipeWrapper>> category,
+                              List<?> catalysts,
+                              List<? extends IRecipeWrapper> wrappers) {
             this.id = id;
             this.category = category;
             this.catalysts = catalysts;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/Category.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/Category.java
@@ -19,6 +19,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Function;
 
 @RegistryDescription(category = RegistryDescription.Category.ENTRIES,
@@ -115,11 +116,64 @@ public class Category extends VirtualizedRegistry<String> {
         hideAllCategories = true;
     }
 
-    @Desugar
-    record CustomCategory(String id,
-                          Function<IGuiHelper, ? extends IRecipeCategory<? extends IRecipeWrapper>> category,
-                          List<?> catalysts,
-                          List<? extends IRecipeWrapper> wrappers) {
+    @SuppressWarnings({"unused", "ClassCanBeRecord"})
+    public static class CustomCategory {
+        
+        private final String id;
+        private final Function<IGuiHelper, ? extends IRecipeCategory<? extends IRecipeWrapper>> category;
+        private final List<?> catalysts;
+        private final List<? extends IRecipeWrapper> wrappers;
+
+        public CustomCategory(String id,
+                       Function<IGuiHelper, ? extends IRecipeCategory<? extends IRecipeWrapper>> category,
+                       List<?> catalysts,
+                       List<? extends IRecipeWrapper> wrappers) {
+            this.id = id;
+            this.category = category;
+            this.catalysts = catalysts;
+            this.wrappers = wrappers;
+        }
+
+        public String id() {
+            return id;
+        }
+
+        public Function<IGuiHelper, ? extends IRecipeCategory<? extends IRecipeWrapper>> category() {
+            return category;
+        }
+
+        public List<?> catalysts() {
+            return catalysts;
+        }
+
+        public List<? extends IRecipeWrapper> wrappers() {
+            return wrappers;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) return true;
+            if (obj == null || obj.getClass() != this.getClass()) return false;
+            var that = (CustomCategory) obj;
+            return Objects.equals(this.id, that.id) &&
+                   Objects.equals(this.category, that.category) &&
+                   Objects.equals(this.catalysts, that.catalysts) &&
+                   Objects.equals(this.wrappers, that.wrappers);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(id, category, catalysts, wrappers);
+        }
+
+        @Override
+        public String toString() {
+            return "CustomCategory[" +
+                   "id=" + id + ", " +
+                   "category=" + category + ", " +
+                   "catalysts=" + catalysts + ", " +
+                   "wrappers=" + wrappers + ']';
+        }
     }
 
     public static class CategoryBuilder implements IRecipeBuilder<CustomCategory> {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/Category.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/Category.java
@@ -116,7 +116,7 @@ public class Category extends VirtualizedRegistry<String> {
     }
 
     @SuppressWarnings("ClassCanBeRecord")
-    public static class CustomCategory {
+    public static final class CustomCategory {
         
         private final String id;
         private final Function<IGuiHelper, ? extends IRecipeCategory<? extends IRecipeWrapper>> category;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/Category.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/Category.java
@@ -116,7 +116,7 @@ public class Category extends VirtualizedRegistry<String> {
         hideAllCategories = true;
     }
 
-    @SuppressWarnings({"unused", "ClassCanBeRecord"})
+    @SuppressWarnings("ClassCanBeRecord")
     public static class CustomCategory {
         
         private final String id;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/Category.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/Category.java
@@ -7,7 +7,6 @@ import com.cleanroommc.groovyscript.compat.mods.ModSupport;
 import com.cleanroommc.groovyscript.helper.recipe.IRecipeBuilder;
 import com.cleanroommc.groovyscript.registry.AbstractReloadableStorage;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
-import com.github.bsideup.jabel.Desugar;
 import mezz.jei.api.IGuiHelper;
 import mezz.jei.api.IModRegistry;
 import mezz.jei.api.IRecipeRegistry;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/prodigytech/ExplosionFurnaceAdditives.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/prodigytech/ExplosionFurnaceAdditives.java
@@ -7,9 +7,10 @@ import com.cleanroommc.groovyscript.api.documentation.annotations.RegistryDescri
 import com.cleanroommc.groovyscript.helper.ingredient.ItemsIngredient;
 import com.cleanroommc.groovyscript.helper.ingredient.OreDictIngredient;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
-import com.github.bsideup.jabel.Desugar;
 import lykrast.prodigytech.common.recipe.ExplosionFurnaceManager;
 import net.minecraft.item.ItemStack;
+
+import java.util.Objects;
 
 @RegistryDescription(category = RegistryDescription.Category.ENTRIES)
 public class ExplosionFurnaceAdditives extends VirtualizedRegistry<ExplosionFurnaceAdditives.EFAdditiveRecipe> {
@@ -87,8 +88,16 @@ public class ExplosionFurnaceAdditives extends VirtualizedRegistry<ExplosionFurn
         void unregister();
     }
 
-    @Desugar
-    public record EFAdditiveExplosive(IIngredient input, int value) implements EFAdditiveRecipe {
+    @SuppressWarnings({"unused", "ClassCanBeRecord"})
+    public static class EFAdditiveExplosive implements EFAdditiveRecipe {
+
+        private final IIngredient input;
+        private final int value;
+
+        public EFAdditiveExplosive(IIngredient input, int value) {
+            this.input = input;
+            this.value = value;
+        }
 
         @Override
         public void register() {
@@ -111,10 +120,47 @@ public class ExplosionFurnaceAdditives extends VirtualizedRegistry<ExplosionFurn
                 }
             }
         }
+
+        public IIngredient input() {
+            return input;
+        }
+
+        public int value() {
+            return value;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) return true;
+            if (obj == null || obj.getClass() != this.getClass()) return false;
+            var that = (EFAdditiveExplosive) obj;
+            return Objects.equals(this.input, that.input) &&
+                   this.value == that.value;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(input, value);
+        }
+
+        @Override
+        public String toString() {
+            return "EFAdditiveExplosive[" +
+                   "input=" + input + ", " +
+                   "value=" + value + ']';
+        }
     }
 
-    @Desugar
-    public record EFAdditiveDampener(IIngredient input, int value) implements EFAdditiveRecipe {
+    @SuppressWarnings({"unused", "ClassCanBeRecord"})
+    public static class EFAdditiveDampener implements EFAdditiveRecipe {
+
+        private final IIngredient input;
+        private final int value;
+
+        public EFAdditiveDampener(IIngredient input, int value) {
+            this.input = input;
+            this.value = value;
+        }
 
         @Override
         public void register() {
@@ -136,6 +182,35 @@ public class ExplosionFurnaceAdditives extends VirtualizedRegistry<ExplosionFurn
                     ExplosionFurnaceManager.removeDampener(it);
                 }
             }
+        }
+
+        public IIngredient input() {
+            return input;
+        }
+
+        public int value() {
+            return value;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) return true;
+            if (obj == null || obj.getClass() != this.getClass()) return false;
+            var that = (EFAdditiveDampener) obj;
+            return Objects.equals(this.input, that.input) &&
+                   this.value == that.value;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(input, value);
+        }
+
+        @Override
+        public String toString() {
+            return "EFAdditiveDampener[" +
+                   "input=" + input + ", " +
+                   "value=" + value + ']';
         }
     }
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/prodigytech/ExplosionFurnaceAdditives.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/prodigytech/ExplosionFurnaceAdditives.java
@@ -88,7 +88,7 @@ public class ExplosionFurnaceAdditives extends VirtualizedRegistry<ExplosionFurn
         void unregister();
     }
 
-    @SuppressWarnings({"unused", "ClassCanBeRecord"})
+    @SuppressWarnings("ClassCanBeRecord")
     public static class EFAdditiveExplosive implements EFAdditiveRecipe {
 
         private final IIngredient input;
@@ -151,7 +151,7 @@ public class ExplosionFurnaceAdditives extends VirtualizedRegistry<ExplosionFurn
         }
     }
 
-    @SuppressWarnings({"unused", "ClassCanBeRecord"})
+    @SuppressWarnings("ClassCanBeRecord")
     public static class EFAdditiveDampener implements EFAdditiveRecipe {
 
         private final IIngredient input;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/prodigytech/ExplosionFurnaceAdditives.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/prodigytech/ExplosionFurnaceAdditives.java
@@ -89,7 +89,7 @@ public class ExplosionFurnaceAdditives extends VirtualizedRegistry<ExplosionFurn
     }
 
     @SuppressWarnings("ClassCanBeRecord")
-    public static class EFAdditiveExplosive implements EFAdditiveRecipe {
+    public static final class EFAdditiveExplosive implements EFAdditiveRecipe {
 
         private final IIngredient input;
         private final int value;
@@ -152,7 +152,7 @@ public class ExplosionFurnaceAdditives extends VirtualizedRegistry<ExplosionFurn
     }
 
     @SuppressWarnings("ClassCanBeRecord")
-    public static class EFAdditiveDampener implements EFAdditiveRecipe {
+    public static final class EFAdditiveDampener implements EFAdditiveRecipe {
 
         private final IIngredient input;
         private final int value;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/prodigytech/ZorraAltar.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/prodigytech/ZorraAltar.java
@@ -5,13 +5,13 @@ import com.cleanroommc.groovyscript.api.documentation.annotations.Example;
 import com.cleanroommc.groovyscript.api.documentation.annotations.MethodDescription;
 import com.cleanroommc.groovyscript.api.documentation.annotations.RegistryDescription;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
-import com.github.bsideup.jabel.Desugar;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import lykrast.prodigytech.common.recipe.ZorraAltarManager;
 import lykrast.prodigytech.common.util.Config;
 import net.minecraft.enchantment.Enchantment;
 
 import java.util.Map;
+import java.util.Objects;
 
 
 @RegistryDescription
@@ -71,6 +71,50 @@ public class ZorraAltar extends VirtualizedRegistry<ZorraAltar.ZorraRecipeData> 
         return managers.get(registry).removeEnchant(enchantment);
     }
 
-    @Desugar
-    public record ZorraRecipeData(String registry, Enchantment enchantment, int maxLevel) {}
+    @SuppressWarnings({"unused", "ClassCanBeRecord"})
+    public static class ZorraRecipeData {
+
+        private final String registry;
+        private final Enchantment enchantment;
+        private final int maxLevel;
+
+        public ZorraRecipeData(String registry, Enchantment enchantment, int maxLevel) {
+            this.registry = registry;
+            this.enchantment = enchantment;
+            this.maxLevel = maxLevel;
+        }
+
+        public String registry() {return registry;}
+
+        public Enchantment enchantment() {
+            return enchantment;
+        }
+
+        public int maxLevel() {
+            return maxLevel;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) return true;
+            if (obj == null || obj.getClass() != this.getClass()) return false;
+            var that = (ZorraRecipeData) obj;
+            return Objects.equals(this.registry, that.registry) &&
+                   Objects.equals(this.enchantment, that.enchantment) &&
+                   this.maxLevel == that.maxLevel;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(registry, enchantment, maxLevel);
+        }
+
+        @Override
+        public String toString() {
+            return "ZorraRecipeData[" +
+                   "registry=" + registry + ", " +
+                   "enchantment=" + enchantment + ", " +
+                   "maxLevel=" + maxLevel + ']';
+        }
+    }
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/prodigytech/ZorraAltar.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/prodigytech/ZorraAltar.java
@@ -71,7 +71,7 @@ public class ZorraAltar extends VirtualizedRegistry<ZorraAltar.ZorraRecipeData> 
         return managers.get(registry).removeEnchant(enchantment);
     }
 
-    @SuppressWarnings({"unused", "ClassCanBeRecord"})
+    @SuppressWarnings("ClassCanBeRecord")
     public static class ZorraRecipeData {
 
         private final String registry;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/prodigytech/ZorraAltar.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/prodigytech/ZorraAltar.java
@@ -72,7 +72,7 @@ public class ZorraAltar extends VirtualizedRegistry<ZorraAltar.ZorraRecipeData> 
     }
 
     @SuppressWarnings("ClassCanBeRecord")
-    public static class ZorraRecipeData {
+    public static final class ZorraRecipeData {
 
         private final String registry;
         private final Enchantment enchantment;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/Coolant.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/Coolant.java
@@ -9,7 +9,6 @@ import com.cleanroommc.groovyscript.api.documentation.annotations.RegistryDescri
 import com.cleanroommc.groovyscript.core.mixin.thermalexpansion.CoolantManagerAccessor;
 import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
-import com.github.bsideup.jabel.Desugar;
 import mezz.jei.api.IGuiHelper;
 import net.minecraftforge.fluids.FluidStack;
 import org.jetbrains.annotations.ApiStatus;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/Coolant.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/Coolant.java
@@ -14,6 +14,8 @@ import mezz.jei.api.IGuiHelper;
 import net.minecraftforge.fluids.FluidStack;
 import org.jetbrains.annotations.ApiStatus;
 
+import java.util.Objects;
+
 @RegistryDescription(category = RegistryDescription.Category.ENTRIES,
                      admonition = @Admonition(value = "groovyscript.wiki.thermalexpansion.coolant.note0", type = Admonition.Type.WARNING))
 public class Coolant extends VirtualizedRegistry<Coolant.CoolantRecipe> {
@@ -85,9 +87,53 @@ public class Coolant extends VirtualizedRegistry<Coolant.CoolantRecipe> {
         CoolantManagerAccessor.getCoolantFactorMap().clear();
     }
 
-    @Desugar
-    public record CoolantRecipe(String fluid, int rf, int factor) {
+    @SuppressWarnings({"unused", "ClassCanBeRecord"})
+    public static class CoolantRecipe {
 
+        private final String fluid;
+        private final int rf;
+        private final int factor;
+
+        public CoolantRecipe(String fluid, int rf, int factor) {
+            this.fluid = fluid;
+            this.rf = rf;
+            this.factor = factor;
+        }
+
+        public String fluid() {
+            return fluid;
+        }
+
+        public int rf() {
+            return rf;
+        }
+
+        public int factor() {
+            return factor;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) return true;
+            if (obj == null || obj.getClass() != this.getClass()) return false;
+            var that = (CoolantRecipe) obj;
+            return Objects.equals(this.fluid, that.fluid) &&
+                   this.rf == that.rf &&
+                   this.factor == that.factor;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(fluid, rf, factor);
+        }
+
+        @Override
+        public String toString() {
+            return "CoolantRecipe[" +
+                   "fluid=" + fluid + ", " +
+                   "rf=" + rf + ", " +
+                   "factor=" + factor + ']';
+        }
     }
 
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/Coolant.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/Coolant.java
@@ -87,7 +87,7 @@ public class Coolant extends VirtualizedRegistry<Coolant.CoolantRecipe> {
         CoolantManagerAccessor.getCoolantFactorMap().clear();
     }
 
-    @SuppressWarnings({"unused", "ClassCanBeRecord"})
+    @SuppressWarnings("ClassCanBeRecord")
     public static class CoolantRecipe {
 
         private final String fluid;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/Coolant.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/Coolant.java
@@ -87,7 +87,7 @@ public class Coolant extends VirtualizedRegistry<Coolant.CoolantRecipe> {
     }
 
     @SuppressWarnings("ClassCanBeRecord")
-    public static class CoolantRecipe {
+    public static final class CoolantRecipe {
 
         private final String fluid;
         private final int rf;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/Diffuser.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/Diffuser.java
@@ -88,7 +88,7 @@ public class Diffuser extends VirtualizedRegistry<Diffuser.DiffuserRecipe> {
         DiffuserManagerAccessor.getReagentDurMap().clear();
     }
 
-    @SuppressWarnings({"unused", "ClassCanBeRecord"})
+    @SuppressWarnings("ClassCanBeRecord")
     public static class DiffuserRecipe {
 
         private final ComparableItemStack stack;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/Diffuser.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/Diffuser.java
@@ -88,7 +88,7 @@ public class Diffuser extends VirtualizedRegistry<Diffuser.DiffuserRecipe> {
     }
 
     @SuppressWarnings("ClassCanBeRecord")
-    public static class DiffuserRecipe {
+    public static final class DiffuserRecipe {
 
         private final ComparableItemStack stack;
         private final int amplifier;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/Diffuser.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/Diffuser.java
@@ -13,6 +13,7 @@ import net.minecraft.item.ItemStack;
 import org.jetbrains.annotations.ApiStatus;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @RegistryDescription(category = RegistryDescription.Category.ENTRIES)
@@ -87,13 +88,57 @@ public class Diffuser extends VirtualizedRegistry<Diffuser.DiffuserRecipe> {
         DiffuserManagerAccessor.getReagentDurMap().clear();
     }
 
-    @Desugar
-    public record DiffuserRecipe(ComparableItemStack stack, int amplifier, int duration) {
+    @SuppressWarnings({"unused", "ClassCanBeRecord"})
+    public static class DiffuserRecipe {
+
+        private final ComparableItemStack stack;
+        private final int amplifier;
+        private final int duration;
+
+        public DiffuserRecipe(ComparableItemStack stack, int amplifier, int duration) {
+            this.stack = stack;
+            this.amplifier = amplifier;
+            this.duration = duration;
+        }
 
         public DiffuserRecipe(ComparableItemStack stack) {
             this(stack, DiffuserManagerAccessor.getReagentAmpMap().get(stack), DiffuserManagerAccessor.getReagentDurMap().get(stack));
         }
 
+        public ComparableItemStack stack() {
+            return stack;
+        }
+
+        public int amplifier() {
+            return amplifier;
+        }
+
+        public int duration() {
+            return duration;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) return true;
+            if (obj == null || obj.getClass() != this.getClass()) return false;
+            var that = (DiffuserRecipe) obj;
+            return Objects.equals(this.stack, that.stack) &&
+                   this.amplifier == that.amplifier &&
+                   this.duration == that.duration;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(stack, amplifier, duration);
+        }
+
+        @Override
+        public String toString() {
+            return "DiffuserRecipe[" +
+                   "stack=" + stack + ", " +
+                   "amplifier=" + amplifier + ", " +
+                   "duration=" + duration + ']';
+        }
     }
 
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/Diffuser.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/Diffuser.java
@@ -8,7 +8,6 @@ import com.cleanroommc.groovyscript.api.documentation.annotations.RegistryDescri
 import com.cleanroommc.groovyscript.core.mixin.thermalexpansion.DiffuserManagerAccessor;
 import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
-import com.github.bsideup.jabel.Desugar;
 import net.minecraft.item.ItemStack;
 import org.jetbrains.annotations.ApiStatus;
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/Fisher.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/Fisher.java
@@ -92,7 +92,7 @@ public class Fisher extends VirtualizedRegistry<Fisher.FisherRecipe> {
         FisherManagerAccessor.setTotalWeight(0);
     }
 
-    @SuppressWarnings({"unused", "ClassCanBeRecord"})
+    @SuppressWarnings("ClassCanBeRecord")
     public static class FisherRecipe {
 
         private final ItemStack fish;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/Fisher.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/Fisher.java
@@ -12,6 +12,8 @@ import com.github.bsideup.jabel.Desugar;
 import net.minecraft.item.ItemStack;
 import org.jetbrains.annotations.ApiStatus;
 
+import java.util.Objects;
+
 @RegistryDescription(category = RegistryDescription.Category.ENTRIES)
 public class Fisher extends VirtualizedRegistry<Fisher.FisherRecipe> {
 
@@ -90,9 +92,45 @@ public class Fisher extends VirtualizedRegistry<Fisher.FisherRecipe> {
         FisherManagerAccessor.setTotalWeight(0);
     }
 
-    @Desugar
-    public record FisherRecipe(ItemStack fish, int weight) {
+    @SuppressWarnings({"unused", "ClassCanBeRecord"})
+    public static class FisherRecipe {
 
+        private final ItemStack fish;
+        private final int weight;
+
+        public FisherRecipe(ItemStack fish, int weight) {
+            this.fish = fish;
+            this.weight = weight;
+        }
+
+        public ItemStack fish() {
+            return fish;
+        }
+
+        public int weight() {
+            return weight;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) return true;
+            if (obj == null || obj.getClass() != this.getClass()) return false;
+            var that = (FisherRecipe) obj;
+            return Objects.equals(this.fish, that.fish) &&
+                   this.weight == that.weight;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(fish, weight);
+        }
+
+        @Override
+        public String toString() {
+            return "FisherRecipe[" +
+                   "fish=" + fish + ", " +
+                   "weight=" + weight + ']';
+        }
     }
 
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/Fisher.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/Fisher.java
@@ -92,7 +92,7 @@ public class Fisher extends VirtualizedRegistry<Fisher.FisherRecipe> {
     }
 
     @SuppressWarnings("ClassCanBeRecord")
-    public static class FisherRecipe {
+    public static final class FisherRecipe {
 
         private final ItemStack fish;
         private final int weight;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/Fisher.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/Fisher.java
@@ -8,7 +8,6 @@ import com.cleanroommc.groovyscript.api.documentation.annotations.RegistryDescri
 import com.cleanroommc.groovyscript.core.mixin.thermalexpansion.FisherManagerAccessor;
 import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
-import com.github.bsideup.jabel.Desugar;
 import net.minecraft.item.ItemStack;
 import org.jetbrains.annotations.ApiStatus;
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/FisherBait.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/FisherBait.java
@@ -9,7 +9,6 @@ import com.cleanroommc.groovyscript.api.documentation.annotations.RegistryDescri
 import com.cleanroommc.groovyscript.core.mixin.thermalexpansion.FisherManagerAccessor;
 import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
-import com.github.bsideup.jabel.Desugar;
 import net.minecraft.item.ItemStack;
 import org.jetbrains.annotations.ApiStatus;
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/FisherBait.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/FisherBait.java
@@ -69,7 +69,7 @@ public class FisherBait extends VirtualizedRegistry<FisherBait.FisherRecipe> {
         FisherManagerAccessor.getBaitMap().clear();
     }
 
-    @SuppressWarnings({"unused", "ClassCanBeRecord"})
+    @SuppressWarnings("ClassCanBeRecord")
     public static class FisherRecipe {
 
         private final ComparableItemStack bait;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/FisherBait.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/FisherBait.java
@@ -13,6 +13,8 @@ import com.github.bsideup.jabel.Desugar;
 import net.minecraft.item.ItemStack;
 import org.jetbrains.annotations.ApiStatus;
 
+import java.util.Objects;
+
 @RegistryDescription(category = RegistryDescription.Category.ENTRIES)
 public class FisherBait extends VirtualizedRegistry<FisherBait.FisherRecipe> {
 
@@ -67,9 +69,45 @@ public class FisherBait extends VirtualizedRegistry<FisherBait.FisherRecipe> {
         FisherManagerAccessor.getBaitMap().clear();
     }
 
-    @Desugar
-    public record FisherRecipe(ComparableItemStack bait, int multiplier) {
+    @SuppressWarnings({"unused", "ClassCanBeRecord"})
+    public static class FisherRecipe {
 
+        private final ComparableItemStack bait;
+        private final int multiplier;
+
+        public FisherRecipe(ComparableItemStack bait, int multiplier) {
+            this.bait = bait;
+            this.multiplier = multiplier;
+        }
+
+        public ComparableItemStack bait() {
+            return bait;
+        }
+
+        public int multiplier() {
+            return multiplier;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) return true;
+            if (obj == null || obj.getClass() != this.getClass()) return false;
+            var that = (FisherRecipe) obj;
+            return Objects.equals(this.bait, that.bait) &&
+                   this.multiplier == that.multiplier;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(bait, multiplier);
+        }
+
+        @Override
+        public String toString() {
+            return "FisherRecipe[" +
+                   "bait=" + bait + ", " +
+                   "multiplier=" + multiplier + ']';
+        }
     }
 
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/FisherBait.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/FisherBait.java
@@ -69,7 +69,7 @@ public class FisherBait extends VirtualizedRegistry<FisherBait.FisherRecipe> {
     }
 
     @SuppressWarnings("ClassCanBeRecord")
-    public static class FisherRecipe {
+    public static final class FisherRecipe {
 
         private final ComparableItemStack bait;
         private final int multiplier;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/Tapper.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/Tapper.java
@@ -156,7 +156,7 @@ public class Tapper extends VirtualizedRegistry<Tapper.TapperItemRecipe> {
     }
 
     @SuppressWarnings("ClassCanBeRecord")
-    public static class TapperItemRecipe {
+    public static final class TapperItemRecipe {
 
         private final ItemWrapper itemWrapper;
         private final FluidStack fluidStack;
@@ -197,7 +197,7 @@ public class Tapper extends VirtualizedRegistry<Tapper.TapperItemRecipe> {
     }
 
     @SuppressWarnings("ClassCanBeRecord")
-    public static class TapperBlockRecipe {
+    public static final class TapperBlockRecipe {
 
         private final BlockWrapper blockWrapper;
         private final FluidStack fluidStack;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/Tapper.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/Tapper.java
@@ -13,7 +13,6 @@ import com.cleanroommc.groovyscript.core.mixin.thermalexpansion.TapperManagerAcc
 import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
 import com.cleanroommc.groovyscript.registry.AbstractReloadableStorage;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
-import com.github.bsideup.jabel.Desugar;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/Tapper.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/Tapper.java
@@ -156,7 +156,7 @@ public class Tapper extends VirtualizedRegistry<Tapper.TapperItemRecipe> {
         TapperManagerAccessor.getBlockMap().clear();
     }
 
-    @SuppressWarnings({"unused", "ClassCanBeRecord"})
+    @SuppressWarnings("ClassCanBeRecord")
     public static class TapperItemRecipe {
 
         private final ItemWrapper itemWrapper;
@@ -197,7 +197,7 @@ public class Tapper extends VirtualizedRegistry<Tapper.TapperItemRecipe> {
         }
     }
 
-    @SuppressWarnings({"unused", "ClassCanBeRecord"})
+    @SuppressWarnings("ClassCanBeRecord")
     public static class TapperBlockRecipe {
 
         private final BlockWrapper blockWrapper;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/Tapper.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/Tapper.java
@@ -20,6 +20,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 import org.jetbrains.annotations.ApiStatus;
 
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @RegistryDescription(
@@ -155,14 +156,86 @@ public class Tapper extends VirtualizedRegistry<Tapper.TapperItemRecipe> {
         TapperManagerAccessor.getBlockMap().clear();
     }
 
-    @Desugar
-    public record TapperItemRecipe(ItemWrapper itemWrapper, FluidStack fluidStack) {
+    @SuppressWarnings({"unused", "ClassCanBeRecord"})
+    public static class TapperItemRecipe {
 
+        private final ItemWrapper itemWrapper;
+        private final FluidStack fluidStack;
+
+        public TapperItemRecipe(ItemWrapper itemWrapper, FluidStack fluidStack) {
+            this.itemWrapper = itemWrapper;
+            this.fluidStack = fluidStack;
+        }
+
+        public ItemWrapper itemWrapper() {
+            return itemWrapper;
+        }
+
+        public FluidStack fluidStack() {
+            return fluidStack;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) return true;
+            if (obj == null || obj.getClass() != this.getClass()) return false;
+            var that = (TapperItemRecipe) obj;
+            return Objects.equals(this.itemWrapper, that.itemWrapper) &&
+                   Objects.equals(this.fluidStack, that.fluidStack);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(itemWrapper, fluidStack);
+        }
+
+        @Override
+        public String toString() {
+            return "TapperItemRecipe[" +
+                   "itemWrapper=" + itemWrapper + ", " +
+                   "fluidStack=" + fluidStack + ']';
+        }
     }
 
-    @Desugar
-    public record TapperBlockRecipe(BlockWrapper blockWrapper, FluidStack fluidStack) {
+    @SuppressWarnings({"unused", "ClassCanBeRecord"})
+    public static class TapperBlockRecipe {
 
+        private final BlockWrapper blockWrapper;
+        private final FluidStack fluidStack;
+
+        public TapperBlockRecipe(BlockWrapper blockWrapper, FluidStack fluidStack) {
+            this.blockWrapper = blockWrapper;
+            this.fluidStack = fluidStack;
+        }
+
+        public BlockWrapper blockWrapper() {
+            return blockWrapper;
+        }
+
+        public FluidStack fluidStack() {
+            return fluidStack;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) return true;
+            if (obj == null || obj.getClass() != this.getClass()) return false;
+            var that = (TapperBlockRecipe) obj;
+            return Objects.equals(this.blockWrapper, that.blockWrapper) &&
+                   Objects.equals(this.fluidStack, that.fluidStack);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(blockWrapper, fluidStack);
+        }
+
+        @Override
+        public String toString() {
+            return "TapperBlockRecipe[" +
+                   "blockWrapper=" + blockWrapper + ", " +
+                   "fluidStack=" + fluidStack + ']';
+        }
     }
 
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/TapperFertilizer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/TapperFertilizer.java
@@ -69,7 +69,7 @@ public class TapperFertilizer extends VirtualizedRegistry<TapperFertilizer.Tappe
     }
 
     @SuppressWarnings("ClassCanBeRecord")
-    public static class TapperRecipe {
+    public static final class TapperRecipe {
 
         private final ComparableItemStack bait;
         private final int multiplier;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/TapperFertilizer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/TapperFertilizer.java
@@ -13,6 +13,8 @@ import com.github.bsideup.jabel.Desugar;
 import net.minecraft.item.ItemStack;
 import org.jetbrains.annotations.ApiStatus;
 
+import java.util.Objects;
+
 @RegistryDescription(category = RegistryDescription.Category.ENTRIES)
 public class TapperFertilizer extends VirtualizedRegistry<TapperFertilizer.TapperRecipe> {
 
@@ -67,9 +69,45 @@ public class TapperFertilizer extends VirtualizedRegistry<TapperFertilizer.Tappe
         TapperManagerAccessor.getFertilizerMap().clear();
     }
 
-    @Desugar
-    public record TapperRecipe(ComparableItemStack bait, int multiplier) {
+    @SuppressWarnings({"unused", "ClassCanBeRecord"})
+    public static class TapperRecipe {
 
+        private final ComparableItemStack bait;
+        private final int multiplier;
+
+        public TapperRecipe(ComparableItemStack bait, int multiplier) {
+            this.bait = bait;
+            this.multiplier = multiplier;
+        }
+
+        public ComparableItemStack bait() {
+            return bait;
+        }
+
+        public int multiplier() {
+            return multiplier;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) return true;
+            if (obj == null || obj.getClass() != this.getClass()) return false;
+            var that = (TapperRecipe) obj;
+            return Objects.equals(this.bait, that.bait) &&
+                   this.multiplier == that.multiplier;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(bait, multiplier);
+        }
+
+        @Override
+        public String toString() {
+            return "TapperRecipe[" +
+                   "bait=" + bait + ", " +
+                   "multiplier=" + multiplier + ']';
+        }
     }
 
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/TapperFertilizer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/TapperFertilizer.java
@@ -69,7 +69,7 @@ public class TapperFertilizer extends VirtualizedRegistry<TapperFertilizer.Tappe
         TapperManagerAccessor.getFertilizerMap().clear();
     }
 
-    @SuppressWarnings({"unused", "ClassCanBeRecord"})
+    @SuppressWarnings("ClassCanBeRecord")
     public static class TapperRecipe {
 
         private final ComparableItemStack bait;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/TapperFertilizer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/TapperFertilizer.java
@@ -9,7 +9,6 @@ import com.cleanroommc.groovyscript.api.documentation.annotations.RegistryDescri
 import com.cleanroommc.groovyscript.core.mixin.thermalexpansion.TapperManagerAccessor;
 import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
-import com.github.bsideup.jabel.Desugar;
 import net.minecraft.item.ItemStack;
 import org.jetbrains.annotations.ApiStatus;
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/TapperTree.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/TapperTree.java
@@ -8,7 +8,6 @@ import com.cleanroommc.groovyscript.api.documentation.annotations.RegistryDescri
 import com.cleanroommc.groovyscript.core.mixin.thermalexpansion.TapperManagerAccessor;
 import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
-import com.github.bsideup.jabel.Desugar;
 import net.minecraft.block.state.IBlockState;
 import org.jetbrains.annotations.ApiStatus;
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/TapperTree.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/TapperTree.java
@@ -94,7 +94,7 @@ public class TapperTree extends VirtualizedRegistry<TapperTree.TapperTreeEntry> 
     }
 
     @SuppressWarnings("ClassCanBeRecord")
-    public static class TapperTreeEntry {
+    public static final class TapperTreeEntry {
 
         private final BlockWrapper log;
         private final BlockWrapper leaf;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/TapperTree.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/TapperTree.java
@@ -94,7 +94,7 @@ public class TapperTree extends VirtualizedRegistry<TapperTree.TapperTreeEntry> 
         TapperManagerAccessor.getLeafMap().clear();
     }
 
-    @SuppressWarnings({"unused", "ClassCanBeRecord"})
+    @SuppressWarnings("ClassCanBeRecord")
     public static class TapperTreeEntry {
 
         private final BlockWrapper log;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/TapperTree.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/TapperTree.java
@@ -13,6 +13,7 @@ import net.minecraft.block.state.IBlockState;
 import org.jetbrains.annotations.ApiStatus;
 
 import java.util.Map;
+import java.util.Objects;
 
 @RegistryDescription(category = RegistryDescription.Category.ENTRIES)
 public class TapperTree extends VirtualizedRegistry<TapperTree.TapperTreeEntry> {
@@ -93,9 +94,45 @@ public class TapperTree extends VirtualizedRegistry<TapperTree.TapperTreeEntry> 
         TapperManagerAccessor.getLeafMap().clear();
     }
 
-    @Desugar
-    public record TapperTreeEntry(BlockWrapper log, BlockWrapper leaf) {
+    @SuppressWarnings({"unused", "ClassCanBeRecord"})
+    public static class TapperTreeEntry {
 
+        private final BlockWrapper log;
+        private final BlockWrapper leaf;
+
+        public TapperTreeEntry(BlockWrapper log, BlockWrapper leaf) {
+            this.log = log;
+            this.leaf = leaf;
+        }
+
+        public BlockWrapper log() {
+            return log;
+        }
+
+        public BlockWrapper leaf() {
+            return leaf;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) return true;
+            if (obj == null || obj.getClass() != this.getClass()) return false;
+            var that = (TapperTreeEntry) obj;
+            return Objects.equals(this.log, that.log) &&
+                   Objects.equals(this.leaf, that.leaf);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(log, leaf);
+        }
+
+        @Override
+        public String toString() {
+            return "TapperTreeEntry[" +
+                   "log=" + log + ", " +
+                   "leaf=" + leaf + ']';
+        }
     }
 
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/XpCollector.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/XpCollector.java
@@ -84,7 +84,7 @@ public class XpCollector extends VirtualizedRegistry<XpCollector.XpCollectorReci
         XpCollectorManagerAccessor.getCatalystFactorMap().clear();
     }
 
-    @SuppressWarnings({"unused", "ClassCanBeRecord"})
+    @SuppressWarnings("ClassCanBeRecord")
     public static class XpCollectorRecipe {
 
         private final ItemStack catalyst;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/XpCollector.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/XpCollector.java
@@ -12,6 +12,8 @@ import com.github.bsideup.jabel.Desugar;
 import net.minecraft.item.ItemStack;
 import org.jetbrains.annotations.ApiStatus;
 
+import java.util.Objects;
+
 @RegistryDescription(category = RegistryDescription.Category.ENTRIES)
 public class XpCollector extends VirtualizedRegistry<XpCollector.XpCollectorRecipe> {
 
@@ -82,13 +84,57 @@ public class XpCollector extends VirtualizedRegistry<XpCollector.XpCollectorReci
         XpCollectorManagerAccessor.getCatalystFactorMap().clear();
     }
 
-    @Desugar
-    public record XpCollectorRecipe(ItemStack catalyst, int xp, int factor) {
+    @SuppressWarnings({"unused", "ClassCanBeRecord"})
+    public static class XpCollectorRecipe {
+
+        private final ItemStack catalyst;
+        private final int xp;
+        private final int factor;
+
+        public XpCollectorRecipe(ItemStack catalyst, int xp, int factor) {
+            this.catalyst = catalyst;
+            this.xp = xp;
+            this.factor = factor;
+        }
 
         public ComparableItemStack getComparableStack() {
             return new ComparableItemStack(catalyst());
         }
 
+        public ItemStack catalyst() {
+            return catalyst;
+        }
+
+        public int xp() {
+            return xp;
+        }
+
+        public int factor() {
+            return factor;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) return true;
+            if (obj == null || obj.getClass() != this.getClass()) return false;
+            var that = (XpCollectorRecipe) obj;
+            return Objects.equals(this.catalyst, that.catalyst) &&
+                   this.xp == that.xp &&
+                   this.factor == that.factor;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(catalyst, xp, factor);
+        }
+
+        @Override
+        public String toString() {
+            return "XpCollectorRecipe[" +
+                   "catalyst=" + catalyst + ", " +
+                   "xp=" + xp + ", " +
+                   "factor=" + factor + ']';
+        }
     }
 
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/XpCollector.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/XpCollector.java
@@ -8,7 +8,6 @@ import com.cleanroommc.groovyscript.api.documentation.annotations.RegistryDescri
 import com.cleanroommc.groovyscript.core.mixin.thermalexpansion.XpCollectorManagerAccessor;
 import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
-import com.github.bsideup.jabel.Desugar;
 import net.minecraft.item.ItemStack;
 import org.jetbrains.annotations.ApiStatus;
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/XpCollector.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/XpCollector.java
@@ -84,7 +84,7 @@ public class XpCollector extends VirtualizedRegistry<XpCollector.XpCollectorReci
     }
 
     @SuppressWarnings("ClassCanBeRecord")
-    public static class XpCollectorRecipe {
+    public static final class XpCollectorRecipe {
 
         private final ItemStack catalyst;
         private final int xp;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Compression.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Compression.java
@@ -11,6 +11,8 @@ import com.github.bsideup.jabel.Desugar;
 import net.minecraftforge.fluids.FluidStack;
 import org.jetbrains.annotations.ApiStatus;
 
+import java.util.Objects;
+
 @RegistryDescription
 public class Compression extends VirtualizedRegistry<Compression.CompressionRecipe> {
 
@@ -79,9 +81,45 @@ public class Compression extends VirtualizedRegistry<Compression.CompressionReci
         CompressionManagerAccessor.getFuelMap().clear();
     }
 
-    @Desugar
-    public record CompressionRecipe(String fluid, int energy) {
+    @SuppressWarnings({"unused", "ClassCanBeRecord"})
+    public static class CompressionRecipe {
 
+        private final String fluid;
+        private final int energy;
+
+        public CompressionRecipe(String fluid, int energy) {
+            this.fluid = fluid;
+            this.energy = energy;
+        }
+
+        public String fluid() {
+            return fluid;
+        }
+
+        public int energy() {
+            return energy;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) return true;
+            if (obj == null || obj.getClass() != this.getClass()) return false;
+            var that = (CompressionRecipe) obj;
+            return Objects.equals(this.fluid, that.fluid) &&
+                   this.energy == that.energy;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(fluid, energy);
+        }
+
+        @Override
+        public String toString() {
+            return "CompressionRecipe[" +
+                   "fluid=" + fluid + ", " +
+                   "energy=" + energy + ']';
+        }
     }
 
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Compression.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Compression.java
@@ -81,7 +81,7 @@ public class Compression extends VirtualizedRegistry<Compression.CompressionReci
         CompressionManagerAccessor.getFuelMap().clear();
     }
 
-    @SuppressWarnings({"unused", "ClassCanBeRecord"})
+    @SuppressWarnings("ClassCanBeRecord")
     public static class CompressionRecipe {
 
         private final String fluid;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Compression.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Compression.java
@@ -81,7 +81,7 @@ public class Compression extends VirtualizedRegistry<Compression.CompressionReci
     }
 
     @SuppressWarnings("ClassCanBeRecord")
-    public static class CompressionRecipe {
+    public static final class CompressionRecipe {
 
         private final String fluid;
         private final int energy;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Compression.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Compression.java
@@ -7,7 +7,6 @@ import com.cleanroommc.groovyscript.api.documentation.annotations.RegistryDescri
 import com.cleanroommc.groovyscript.core.mixin.thermalexpansion.CompressionManagerAccessor;
 import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
-import com.github.bsideup.jabel.Desugar;
 import net.minecraftforge.fluids.FluidStack;
 import org.jetbrains.annotations.ApiStatus;
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Enervation.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Enervation.java
@@ -9,9 +9,10 @@ import com.cleanroommc.groovyscript.api.documentation.annotations.RegistryDescri
 import com.cleanroommc.groovyscript.core.mixin.thermalexpansion.EnervationManagerAccessor;
 import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
-import com.github.bsideup.jabel.Desugar;
 import net.minecraft.item.ItemStack;
 import org.jetbrains.annotations.ApiStatus;
+
+import java.util.Objects;
 
 @RegistryDescription
 public class Enervation extends VirtualizedRegistry<Enervation.EnervationRecipe> {
@@ -76,9 +77,45 @@ public class Enervation extends VirtualizedRegistry<Enervation.EnervationRecipe>
         EnervationManagerAccessor.getFuelMap().clear();
     }
 
-    @Desugar
-    public record EnervationRecipe(ComparableItemStack comparableItemStack, int energy) {
+    @SuppressWarnings({"unused", "ClassCanBeRecord"})
+    public static class EnervationRecipe {
 
+        private final ComparableItemStack comparableItemStack;
+        private final int energy;
+
+        public EnervationRecipe(ComparableItemStack comparableItemStack, int energy) {
+            this.comparableItemStack = comparableItemStack;
+            this.energy = energy;
+        }
+
+        public ComparableItemStack comparableItemStack() {
+            return comparableItemStack;
+        }
+
+        public int energy() {
+            return energy;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) return true;
+            if (obj == null || obj.getClass() != this.getClass()) return false;
+            var that = (EnervationRecipe) obj;
+            return Objects.equals(this.comparableItemStack, that.comparableItemStack) &&
+                   this.energy == that.energy;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(comparableItemStack, energy);
+        }
+
+        @Override
+        public String toString() {
+            return "EnervationRecipe[" +
+                   "comparableItemStack=" + comparableItemStack + ", " +
+                   "energy=" + energy + ']';
+        }
     }
 
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Enervation.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Enervation.java
@@ -78,7 +78,7 @@ public class Enervation extends VirtualizedRegistry<Enervation.EnervationRecipe>
     }
 
     @SuppressWarnings("ClassCanBeRecord")
-    public static class EnervationRecipe {
+    public static final class EnervationRecipe {
 
         private final ComparableItemStack comparableItemStack;
         private final int energy;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Enervation.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Enervation.java
@@ -77,7 +77,7 @@ public class Enervation extends VirtualizedRegistry<Enervation.EnervationRecipe>
         EnervationManagerAccessor.getFuelMap().clear();
     }
 
-    @SuppressWarnings({"unused", "ClassCanBeRecord"})
+    @SuppressWarnings("ClassCanBeRecord")
     public static class EnervationRecipe {
 
         private final ComparableItemStack comparableItemStack;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Lapidary.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Lapidary.java
@@ -13,6 +13,8 @@ import com.github.bsideup.jabel.Desugar;
 import net.minecraft.item.ItemStack;
 import org.jetbrains.annotations.ApiStatus;
 
+import java.util.Objects;
+
 @RegistryDescription
 public class Lapidary extends VirtualizedRegistry<Lapidary.LapidaryRecipe> {
 
@@ -76,9 +78,45 @@ public class Lapidary extends VirtualizedRegistry<Lapidary.LapidaryRecipe> {
         NumismaticManagerAccessor.getGemFuelMap().clear();
     }
 
-    @Desugar
-    public record LapidaryRecipe(ComparableItemStack comparableItemStack, int energy) {
+    @SuppressWarnings({"unused", "ClassCanBeRecord"})
+    public static class LapidaryRecipe {
 
+        private final ComparableItemStack comparableItemStack;
+        private final int energy;
+
+        public LapidaryRecipe(ComparableItemStack comparableItemStack, int energy) {
+            this.comparableItemStack = comparableItemStack;
+            this.energy = energy;
+        }
+
+        public ComparableItemStack comparableItemStack() {
+            return comparableItemStack;
+        }
+
+        public int energy() {
+            return energy;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) return true;
+            if (obj == null || obj.getClass() != this.getClass()) return false;
+            var that = (LapidaryRecipe) obj;
+            return Objects.equals(this.comparableItemStack, that.comparableItemStack) &&
+                   this.energy == that.energy;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(comparableItemStack, energy);
+        }
+
+        @Override
+        public String toString() {
+            return "LapidaryRecipe[" +
+                   "comparableItemStack=" + comparableItemStack + ", " +
+                   "energy=" + energy + ']';
+        }
     }
 
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Lapidary.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Lapidary.java
@@ -78,7 +78,7 @@ public class Lapidary extends VirtualizedRegistry<Lapidary.LapidaryRecipe> {
     }
 
     @SuppressWarnings("ClassCanBeRecord")
-    public static class LapidaryRecipe {
+    public static final class LapidaryRecipe {
 
         private final ComparableItemStack comparableItemStack;
         private final int energy;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Lapidary.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Lapidary.java
@@ -9,7 +9,6 @@ import com.cleanroommc.groovyscript.api.documentation.annotations.RegistryDescri
 import com.cleanroommc.groovyscript.core.mixin.thermalexpansion.NumismaticManagerAccessor;
 import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
-import com.github.bsideup.jabel.Desugar;
 import net.minecraft.item.ItemStack;
 import org.jetbrains.annotations.ApiStatus;
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Lapidary.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Lapidary.java
@@ -78,7 +78,7 @@ public class Lapidary extends VirtualizedRegistry<Lapidary.LapidaryRecipe> {
         NumismaticManagerAccessor.getGemFuelMap().clear();
     }
 
-    @SuppressWarnings({"unused", "ClassCanBeRecord"})
+    @SuppressWarnings("ClassCanBeRecord")
     public static class LapidaryRecipe {
 
         private final ComparableItemStack comparableItemStack;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Magmatic.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Magmatic.java
@@ -11,6 +11,8 @@ import com.github.bsideup.jabel.Desugar;
 import net.minecraftforge.fluids.FluidStack;
 import org.jetbrains.annotations.ApiStatus;
 
+import java.util.Objects;
+
 @RegistryDescription
 public class Magmatic extends VirtualizedRegistry<Magmatic.MagmaticRecipe> {
 
@@ -79,9 +81,45 @@ public class Magmatic extends VirtualizedRegistry<Magmatic.MagmaticRecipe> {
         MagmaticManagerAccessor.getFuelMap().clear();
     }
 
-    @Desugar
-    public record MagmaticRecipe(String fluid, int energy) {
+    @SuppressWarnings({"unused", "ClassCanBeRecord"})
+    public static class MagmaticRecipe {
 
+        private final String fluid;
+        private final int energy;
+
+        public MagmaticRecipe(String fluid, int energy) {
+            this.fluid = fluid;
+            this.energy = energy;
+        }
+
+        public String fluid() {
+            return fluid;
+        }
+
+        public int energy() {
+            return energy;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) return true;
+            if (obj == null || obj.getClass() != this.getClass()) return false;
+            var that = (MagmaticRecipe) obj;
+            return Objects.equals(this.fluid, that.fluid) &&
+                   this.energy == that.energy;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(fluid, energy);
+        }
+
+        @Override
+        public String toString() {
+            return "MagmaticRecipe[" +
+                   "fluid=" + fluid + ", " +
+                   "energy=" + energy + ']';
+        }
     }
 
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Magmatic.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Magmatic.java
@@ -81,7 +81,7 @@ public class Magmatic extends VirtualizedRegistry<Magmatic.MagmaticRecipe> {
     }
 
     @SuppressWarnings("ClassCanBeRecord")
-    public static class MagmaticRecipe {
+    public static final class MagmaticRecipe {
 
         private final String fluid;
         private final int energy;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Magmatic.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Magmatic.java
@@ -81,7 +81,7 @@ public class Magmatic extends VirtualizedRegistry<Magmatic.MagmaticRecipe> {
         MagmaticManagerAccessor.getFuelMap().clear();
     }
 
-    @SuppressWarnings({"unused", "ClassCanBeRecord"})
+    @SuppressWarnings("ClassCanBeRecord")
     public static class MagmaticRecipe {
 
         private final String fluid;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Magmatic.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Magmatic.java
@@ -7,7 +7,6 @@ import com.cleanroommc.groovyscript.api.documentation.annotations.RegistryDescri
 import com.cleanroommc.groovyscript.core.mixin.thermalexpansion.MagmaticManagerAccessor;
 import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
-import com.github.bsideup.jabel.Desugar;
 import net.minecraftforge.fluids.FluidStack;
 import org.jetbrains.annotations.ApiStatus;
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Numismatic.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Numismatic.java
@@ -13,6 +13,8 @@ import com.github.bsideup.jabel.Desugar;
 import net.minecraft.item.ItemStack;
 import org.jetbrains.annotations.ApiStatus;
 
+import java.util.Objects;
+
 @RegistryDescription
 public class Numismatic extends VirtualizedRegistry<Numismatic.NumismaticRecipe> {
 
@@ -76,9 +78,45 @@ public class Numismatic extends VirtualizedRegistry<Numismatic.NumismaticRecipe>
         NumismaticManagerAccessor.getFuelMap().clear();
     }
 
-    @Desugar
-    public record NumismaticRecipe(ComparableItemStack comparableItemStack, int energy) {
+    @SuppressWarnings({"unused", "ClassCanBeRecord"})
+    public static class NumismaticRecipe {
 
+        private final ComparableItemStack comparableItemStack;
+        private final int energy;
+
+        public NumismaticRecipe(ComparableItemStack comparableItemStack, int energy) {
+            this.comparableItemStack = comparableItemStack;
+            this.energy = energy;
+        }
+
+        public ComparableItemStack comparableItemStack() {
+            return comparableItemStack;
+        }
+
+        public int energy() {
+            return energy;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) return true;
+            if (obj == null || obj.getClass() != this.getClass()) return false;
+            var that = (NumismaticRecipe) obj;
+            return Objects.equals(this.comparableItemStack, that.comparableItemStack) &&
+                   this.energy == that.energy;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(comparableItemStack, energy);
+        }
+
+        @Override
+        public String toString() {
+            return "NumismaticRecipe[" +
+                   "comparableItemStack=" + comparableItemStack + ", " +
+                   "energy=" + energy + ']';
+        }
     }
 
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Numismatic.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Numismatic.java
@@ -9,7 +9,6 @@ import com.cleanroommc.groovyscript.api.documentation.annotations.RegistryDescri
 import com.cleanroommc.groovyscript.core.mixin.thermalexpansion.NumismaticManagerAccessor;
 import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
-import com.github.bsideup.jabel.Desugar;
 import net.minecraft.item.ItemStack;
 import org.jetbrains.annotations.ApiStatus;
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Numismatic.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Numismatic.java
@@ -78,7 +78,7 @@ public class Numismatic extends VirtualizedRegistry<Numismatic.NumismaticRecipe>
         NumismaticManagerAccessor.getFuelMap().clear();
     }
 
-    @SuppressWarnings({"unused", "ClassCanBeRecord"})
+    @SuppressWarnings("ClassCanBeRecord")
     public static class NumismaticRecipe {
 
         private final ComparableItemStack comparableItemStack;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Numismatic.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Numismatic.java
@@ -78,7 +78,7 @@ public class Numismatic extends VirtualizedRegistry<Numismatic.NumismaticRecipe>
     }
 
     @SuppressWarnings("ClassCanBeRecord")
-    public static class NumismaticRecipe {
+    public static final class NumismaticRecipe {
 
         private final ComparableItemStack comparableItemStack;
         private final int energy;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Steam.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Steam.java
@@ -78,7 +78,7 @@ public class Steam extends VirtualizedRegistry<Steam.SteamRecipe> {
     }
 
     @SuppressWarnings("ClassCanBeRecord")
-    public static class SteamRecipe {
+    public static final class SteamRecipe {
 
         private final ComparableItemStack comparableItemStack;
         private final int energy;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Steam.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Steam.java
@@ -13,6 +13,8 @@ import com.github.bsideup.jabel.Desugar;
 import net.minecraft.item.ItemStack;
 import org.jetbrains.annotations.ApiStatus;
 
+import java.util.Objects;
+
 @RegistryDescription
 public class Steam extends VirtualizedRegistry<Steam.SteamRecipe> {
 
@@ -76,9 +78,45 @@ public class Steam extends VirtualizedRegistry<Steam.SteamRecipe> {
         SteamManagerAccessor.getFuelMap().clear();
     }
 
-    @Desugar
-    public record SteamRecipe(ComparableItemStack comparableItemStack, int energy) {
+    @SuppressWarnings({"unused", "ClassCanBeRecord"})
+    public static class SteamRecipe {
 
+        private final ComparableItemStack comparableItemStack;
+        private final int energy;
+
+        public SteamRecipe(ComparableItemStack comparableItemStack, int energy) {
+            this.comparableItemStack = comparableItemStack;
+            this.energy = energy;
+        }
+
+        public ComparableItemStack comparableItemStack() {
+            return comparableItemStack;
+        }
+
+        public int energy() {
+            return energy;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) return true;
+            if (obj == null || obj.getClass() != this.getClass()) return false;
+            var that = (SteamRecipe) obj;
+            return Objects.equals(this.comparableItemStack, that.comparableItemStack) &&
+                   this.energy == that.energy;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(comparableItemStack, energy);
+        }
+
+        @Override
+        public String toString() {
+            return "SteamRecipe[" +
+                   "comparableItemStack=" + comparableItemStack + ", " +
+                   "energy=" + energy + ']';
+        }
     }
 
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Steam.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Steam.java
@@ -9,7 +9,6 @@ import com.cleanroommc.groovyscript.api.documentation.annotations.RegistryDescri
 import com.cleanroommc.groovyscript.core.mixin.thermalexpansion.SteamManagerAccessor;
 import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
-import com.github.bsideup.jabel.Desugar;
 import net.minecraft.item.ItemStack;
 import org.jetbrains.annotations.ApiStatus;
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Steam.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Steam.java
@@ -78,7 +78,7 @@ public class Steam extends VirtualizedRegistry<Steam.SteamRecipe> {
         SteamManagerAccessor.getFuelMap().clear();
     }
 
-    @SuppressWarnings({"unused", "ClassCanBeRecord"})
+    @SuppressWarnings("ClassCanBeRecord")
     public static class SteamRecipe {
 
         private final ComparableItemStack comparableItemStack;


### PR DESCRIPTION
This PR converts all usages of Records in GroovyScript to use Classes instead, preserving the same functions as before.

This is because these records were not compiled correctly, causing occasional GrS errors on some machines in some environments.