### PR TITLE
Don't assume that all scripts come from GroovyScript

### DIFF
--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/groovy/ModuleNodeMixin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/groovy/ModuleNodeMixin.java
@@ -31,7 +31,8 @@ public abstract class ModuleNodeMixin {
             // can happen with traits
             return;
         }
-        try(String rel = FileUtil.relativize(GroovyScript.getScriptPath(), script);){
+        try{
+            String rel = FileUtil.relativize(GroovyScript.getScriptPath(), script);
             int i = rel.lastIndexOf(File.separatorChar);
             if (i >= 0) {
                 // inject correct package declaration into script

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/groovy/ModuleNodeMixin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/groovy/ModuleNodeMixin.java
@@ -31,12 +31,15 @@ public abstract class ModuleNodeMixin {
             // can happen with traits
             return;
         }
-        String rel = FileUtil.relativize(GroovyScript.getScriptPath(), script);
-        int i = rel.lastIndexOf(File.separatorChar);
-        if (i >= 0) {
-            // inject correct package declaration into script
-            String packageName = rel.substring(0, i).replace(File.separatorChar, '.') + '.';
-            this.packageNode = new PackageNode(packageName);
+        try(String rel = FileUtil.relativize(GroovyScript.getScriptPath(), script);){
+            int i = rel.lastIndexOf(File.separatorChar);
+            if (i >= 0) {
+                // inject correct package declaration into script
+                String packageName = rel.substring(0, i).replace(File.separatorChar, '.') + '.';
+                this.packageNode = new PackageNode(packageName);
+            }
+        }catch(Throwable ignored){
+            // Not a groovyscript groovy script
         }
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/groovy/ModuleNodeMixin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/groovy/ModuleNodeMixin.java
@@ -26,21 +26,17 @@ public abstract class ModuleNodeMixin {
     public void init(SourceUnit context, CallbackInfo ci) {
         // auto set package name
         String script = context.getName();
-        if (!RunConfig.isGroovyFile(script)) {
-            // probably not a script file
+        if (!RunConfig.isGroovyFile(script) || !FileUtil.isRelative(GroovyScript.getScriptPath(), script)) {
+            // probably not a script file or not a groovyscript groovy script
             // can happen with traits
             return;
         }
-        try{
-            String rel = FileUtil.relativize(GroovyScript.getScriptPath(), script);
-            int i = rel.lastIndexOf(File.separatorChar);
-            if (i >= 0) {
-                // inject correct package declaration into script
-                String packageName = rel.substring(0, i).replace(File.separatorChar, '.') + '.';
-                this.packageNode = new PackageNode(packageName);
-            }
-        }catch(Throwable ignored){
-            // Not a groovyscript groovy script
+        String rel = FileUtil.relativize(GroovyScript.getScriptPath(), script);
+        int i = rel.lastIndexOf(File.separatorChar);
+        if (i >= 0) {
+            // inject correct package declaration into script
+            String packageName = rel.substring(0, i).replace(File.separatorChar, '.') + '.';
+            this.packageNode = new PackageNode(packageName);
         }
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/sandbox/FileUtil.java
+++ b/src/main/java/com/cleanroommc/groovyscript/sandbox/FileUtil.java
@@ -11,15 +11,17 @@ import java.nio.file.Files;
 
 public class FileUtil {
 
-    public static String relativize(String rootPath, String longerThanRootPath) {
-        try {
-            longerThanRootPath = URLDecoder.decode(longerThanRootPath, "UTF-8");
-        } catch (UnsupportedEncodingException ignored) {
+    public static boolean isRelative(String rootPath, String longerThanRootPath) {
+        longerThanRootPath = fixPathSeparatorChar(longerThanRootPath);
+        int index = longerThanRootPath.indexOf(rootPath);
+        if (index < 0) {
+            return false;
         }
+        return true;
+    }
 
-        if (File.separatorChar != '/') {
-            longerThanRootPath = longerThanRootPath.replace('/', File.separatorChar);
-        }
+    public static String relativize(String rootPath, String longerThanRootPath) {
+        longerThanRootPath = fixPathSeparatorChar(longerThanRootPath);
         return relativizeInternal(fixDriveCase(rootPath), fixDriveCase(longerThanRootPath));
     }
 
@@ -29,6 +31,18 @@ public class FileUtil {
             throw new IllegalArgumentException("The path '" + longerThanRootPath + "' does not contain the root path '" + rootPath + "'");
         }
         return longerThanRootPath.substring(index + rootPath.length() + 1);
+    }
+
+    private static String fixPathSeparatorChar(String path) {
+        try {
+            path = URLDecoder.decode(path, "UTF-8");
+        } catch (UnsupportedEncodingException ignored) {
+        }
+
+        if (File.separatorChar != '/') {
+            path = path.replace('/', File.separatorChar);
+        }
+        return path;
     }
 
     // sometimes the paths passed to relativize() have a lower case drive letter

--- a/src/main/java/com/cleanroommc/groovyscript/sandbox/FileUtil.java
+++ b/src/main/java/com/cleanroommc/groovyscript/sandbox/FileUtil.java
@@ -14,10 +14,7 @@ public class FileUtil {
     public static boolean isRelative(String rootPath, String longerThanRootPath) {
         longerThanRootPath = fixPathSeparatorChar(longerThanRootPath);
         int index = longerThanRootPath.indexOf(rootPath);
-        if (index < 0) {
-            return false;
-        }
-        return true;
+        return index >= 0;
     }
 
     public static String relativize(String rootPath, String longerThanRootPath) {

--- a/src/main/java/com/cleanroommc/groovyscript/sandbox/FileUtil.java
+++ b/src/main/java/com/cleanroommc/groovyscript/sandbox/FileUtil.java
@@ -12,9 +12,7 @@ import java.nio.file.Files;
 public class FileUtil {
 
     public static boolean isRelative(String rootPath, String longerThanRootPath) {
-        longerThanRootPath = fixPathSeparatorChar(longerThanRootPath);
-        int index = longerThanRootPath.indexOf(rootPath);
-        return index >= 0;
+        return fixPathSeparatorChar(longerThanRootPath).indexOf(rootPath) >= 0;
     }
 
     public static String relativize(String rootPath, String longerThanRootPath) {


### PR DESCRIPTION
Don't assume that all scripts come from GroovyScript.
This mixin breaks other mods' use of groovy, and scripts not from the groovyscript path do not work as expected.

The following example does not work in a GroovyScript environment.
```java
GroovyClassLoader groovyClassLoader = new GroovyClassLoader(Launch.classLoader);
Class<?> test = groovyClassLoader.parseClass("println('test load class groovy successfully!')", "demo.groovy");
```

```log
[22:30:18] [CLIENT/ERROR] [placeholdername]: An exception occurred while running scripts. Look at latest.log for a full stacktrace:
	java.lang.IllegalArgumentException: The path 'demo.groovy' does not contain the root path 'F:\other Game\Cleanroom\.minecraft\versions\GroovyScript\groovy'
		at com.cleanroommc.groovyscript.sandbox.FileUtil.relativize(FileUtil.java:25)
		at org.codehaus.groovy.ast.ModuleNode.handler$zzp000$init(ModuleNode.java:1139)
		at org.codehaus.groovy.ast.ModuleNode.<init>(ModuleNode.java:82)
		at org.apache.groovy.parser.antlr4.AstBuilder.<init>(AstBuilder.java:173)
		at org.apache.groovy.parser.antlr4.Antlr4ParserPlugin.buildAST(Antlr4ParserPlugin.java:56)
		at org.codehaus.groovy.control.SourceUnit.buildAST(SourceUnit.java:256)
		at java.util.Iterator.forEachRemaining(Iterator.java:116)
		at java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801)
		at java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:580)
		at org.codehaus.groovy.control.CompilationUnit.compile(CompilationUnit.java:663)
		at groovy.lang.GroovyClassLoader.doParseClass(GroovyClassLoader.java:373)
		at groovy.lang.GroovyClassLoader.lambda$parseClass$2(GroovyClassLoader.java:316)
		at groovy.lang.GroovyClassLoader.parseClass(GroovyClassLoader.java:314)
		at groovy.lang.GroovyClassLoader.parseClass(GroovyClassLoader.java:298)
		at groovy.lang.GroovyClassLoader.parseClass(GroovyClassLoader.java:258)
		at rml.layer.compat.groovyscripts.RMLGroovySandBox.load(RMLGroovySandBox.java:91)
		at com.cleanroommc.groovyscript.sandbox.GroovySandbox.load(GroovySandbox.java)
		at com.cleanroommc.groovyscript.sandbox.GroovySandbox.load(GroovySandbox.java:108)
		at com.cleanroommc.groovyscript.sandbox.GroovyScriptSandbox.run(GroovyScriptSandbox.java:161)
		at com.cleanroommc.groovyscript.GroovyScript.runGroovyScriptsInLoader(GroovyScript.java:188)
		at com.cleanroommc.groovyscript.GroovyScript.initializeGroovyPreInit(GroovyScript.java:174)
		at net.minecraftforge.fml.common.LoadController.handler$zzg000$preInit(LoadController.java:1018)
		at net.minecraftforge.fml.common.LoadController.distributeStateMessage(LoadController.java)
		at net.minecraftforge.fml.common.Loader.preinitializeMods(Loader.java:629)
		at net.minecraftforge.fml.client.FMLClientHandler.beginMinecraftLoading(FMLClientHandler.java:252)
		at net.minecraft.client.Minecraft.func_71384_a(Minecraft.java:467)
		at net.minecraft.client.Minecraft.func_99999_d(Minecraft.java:378)
		at net.minecraft.client.main.Main.main(SourceFile:123)
		at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
		at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
		at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
		at java.lang.reflect.Method.invoke(Method.java:498)
		at net.minecraft.launchwrapper.Launch.launch(Launch.java:135)
		at net.minecraft.launchwrapper.Launch.main(Launch.java:28)
```