### PR TITLE
Unblacklist GrS registry

### DIFF
--- a/src/main/java/com/cleanroommc/groovyscript/sandbox/security/GroovySecurityManager.java
+++ b/src/main/java/com/cleanroommc/groovyscript/sandbox/security/GroovySecurityManager.java
@@ -67,7 +67,6 @@ public class GroovySecurityManager {
         // mod specific
         banPackage("com.cleanroommc.groovyscript.command");
         banPackage("com.cleanroommc.groovyscript.core");
-        banPackage("com.cleanroommc.groovyscript.registry");
         banPackage("com.cleanroommc.groovyscript.sandbox");
         banPackage("com.cleanroommc.groovyscript.server");
     }


### PR DESCRIPTION
changes in this PR:
- remove the package `com.cleanroommc.groovyscript.registry` from the blacklist

`DummyRecipe` cannot be blacklisted to properly iterate through recipes, and the other classes are just registry classes/wrappers. dont see anything in there that requires being blocked and having it be accessible makes adding things like custom reloadable compat much easier.