### PR TITLE
Inline icons for Object mappers in vsc

### DIFF
--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -13,16 +13,16 @@
       "devDependencies": {
         "@types/node": "^20.11.17",
         "@types/vscode": "^1.81.0",
-        "esbuild": "^0.20.0"
+        "esbuild": "0.20.2"
       },
       "engines": {
         "vscode": "^1.81.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.0.tgz",
-      "integrity": "sha512-fGFDEctNh0CcSwsiRPxiaqX0P5rq+AqE0SRhYGZ4PX46Lg1FNR6oCxJghf8YgY0WQEgQuh3lErUFE4KxLeRmmw==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz",
+      "integrity": "sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==",
       "cpu": [
         "ppc64"
       ],
@@ -36,9 +36,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.0.tgz",
-      "integrity": "sha512-3bMAfInvByLHfJwYPJRlpTeaQA75n8C/QKpEaiS4HrFWFiJlNI0vzq/zCjBrhAYcPyVPG7Eo9dMrcQXuqmNk5g==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.2.tgz",
+      "integrity": "sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==",
       "cpu": [
         "arm"
       ],
@@ -52,9 +52,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.0.tgz",
-      "integrity": "sha512-aVpnM4lURNkp0D3qPoAzSG92VXStYmoVPOgXveAUoQBWRSuQzt51yvSju29J6AHPmwY1BjH49uR29oyfH1ra8Q==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.2.tgz",
+      "integrity": "sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==",
       "cpu": [
         "arm64"
       ],
@@ -68,9 +68,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.0.tgz",
-      "integrity": "sha512-uK7wAnlRvjkCPzh8jJ+QejFyrP8ObKuR5cBIsQZ+qbMunwR8sbd8krmMbxTLSrDhiPZaJYKQAU5Y3iMDcZPhyQ==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.2.tgz",
+      "integrity": "sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==",
       "cpu": [
         "x64"
       ],
@@ -84,9 +84,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.0.tgz",
-      "integrity": "sha512-AjEcivGAlPs3UAcJedMa9qYg9eSfU6FnGHJjT8s346HSKkrcWlYezGE8VaO2xKfvvlZkgAhyvl06OJOxiMgOYQ==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.2.tgz",
+      "integrity": "sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==",
       "cpu": [
         "arm64"
       ],
@@ -100,9 +100,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.0.tgz",
-      "integrity": "sha512-bsgTPoyYDnPv8ER0HqnJggXK6RyFy4PH4rtsId0V7Efa90u2+EifxytE9pZnsDgExgkARy24WUQGv9irVbTvIw==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.2.tgz",
+      "integrity": "sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==",
       "cpu": [
         "x64"
       ],
@@ -116,9 +116,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.0.tgz",
-      "integrity": "sha512-kQ7jYdlKS335mpGbMW5tEe3IrQFIok9r84EM3PXB8qBFJPSc6dpWfrtsC/y1pyrz82xfUIn5ZrnSHQQsd6jebQ==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.2.tgz",
+      "integrity": "sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==",
       "cpu": [
         "arm64"
       ],
@@ -132,9 +132,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.0.tgz",
-      "integrity": "sha512-uG8B0WSepMRsBNVXAQcHf9+Ko/Tr+XqmK7Ptel9HVmnykupXdS4J7ovSQUIi0tQGIndhbqWLaIL/qO/cWhXKyQ==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.2.tgz",
+      "integrity": "sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==",
       "cpu": [
         "x64"
       ],
@@ -148,9 +148,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.0.tgz",
-      "integrity": "sha512-2ezuhdiZw8vuHf1HKSf4TIk80naTbP9At7sOqZmdVwvvMyuoDiZB49YZKLsLOfKIr77+I40dWpHVeY5JHpIEIg==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.2.tgz",
+      "integrity": "sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==",
       "cpu": [
         "arm"
       ],
@@ -164,9 +164,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.0.tgz",
-      "integrity": "sha512-uTtyYAP5veqi2z9b6Gr0NUoNv9F/rOzI8tOD5jKcCvRUn7T60Bb+42NDBCWNhMjkQzI0qqwXkQGo1SY41G52nw==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.2.tgz",
+      "integrity": "sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==",
       "cpu": [
         "arm64"
       ],
@@ -180,9 +180,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.0.tgz",
-      "integrity": "sha512-c88wwtfs8tTffPaoJ+SQn3y+lKtgTzyjkD8NgsyCtCmtoIC8RDL7PrJU05an/e9VuAke6eJqGkoMhJK1RY6z4w==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.2.tgz",
+      "integrity": "sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==",
       "cpu": [
         "ia32"
       ],
@@ -196,9 +196,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.0.tgz",
-      "integrity": "sha512-lR2rr/128/6svngnVta6JN4gxSXle/yZEZL3o4XZ6esOqhyR4wsKyfu6qXAL04S4S5CgGfG+GYZnjFd4YiG3Aw==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.2.tgz",
+      "integrity": "sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==",
       "cpu": [
         "loong64"
       ],
@@ -212,9 +212,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.0.tgz",
-      "integrity": "sha512-9Sycc+1uUsDnJCelDf6ZNqgZQoK1mJvFtqf2MUz4ujTxGhvCWw+4chYfDLPepMEvVL9PDwn6HrXad5yOrNzIsQ==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.2.tgz",
+      "integrity": "sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==",
       "cpu": [
         "mips64el"
       ],
@@ -228,9 +228,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.0.tgz",
-      "integrity": "sha512-CoWSaaAXOZd+CjbUTdXIJE/t7Oz+4g90A3VBCHLbfuc5yUQU/nFDLOzQsN0cdxgXd97lYW/psIIBdjzQIwTBGw==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.2.tgz",
+      "integrity": "sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==",
       "cpu": [
         "ppc64"
       ],
@@ -244,9 +244,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.0.tgz",
-      "integrity": "sha512-mlb1hg/eYRJUpv8h/x+4ShgoNLL8wgZ64SUr26KwglTYnwAWjkhR2GpoKftDbPOCnodA9t4Y/b68H4J9XmmPzA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.2.tgz",
+      "integrity": "sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==",
       "cpu": [
         "riscv64"
       ],
@@ -260,9 +260,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.0.tgz",
-      "integrity": "sha512-fgf9ubb53xSnOBqyvWEY6ukBNRl1mVX1srPNu06B6mNsNK20JfH6xV6jECzrQ69/VMiTLvHMicQR/PgTOgqJUQ==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.2.tgz",
+      "integrity": "sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==",
       "cpu": [
         "s390x"
       ],
@@ -276,9 +276,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.0.tgz",
-      "integrity": "sha512-H9Eu6MGse++204XZcYsse1yFHmRXEWgadk2N58O/xd50P9EvFMLJTQLg+lB4E1cF2xhLZU5luSWtGTb0l9UeSg==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz",
+      "integrity": "sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==",
       "cpu": [
         "x64"
       ],
@@ -292,9 +292,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.0.tgz",
-      "integrity": "sha512-lCT675rTN1v8Fo+RGrE5KjSnfY0x9Og4RN7t7lVrN3vMSjy34/+3na0q7RIfWDAj0e0rCh0OL+P88lu3Rt21MQ==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz",
+      "integrity": "sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==",
       "cpu": [
         "x64"
       ],
@@ -308,9 +308,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.0.tgz",
-      "integrity": "sha512-HKoUGXz/TOVXKQ+67NhxyHv+aDSZf44QpWLa3I1lLvAwGq8x1k0T+e2HHSRvxWhfJrFxaaqre1+YyzQ99KixoA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz",
+      "integrity": "sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==",
       "cpu": [
         "x64"
       ],
@@ -324,9 +324,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.0.tgz",
-      "integrity": "sha512-GDwAqgHQm1mVoPppGsoq4WJwT3vhnz/2N62CzhvApFD1eJyTroob30FPpOZabN+FgCjhG+AgcZyOPIkR8dfD7g==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.2.tgz",
+      "integrity": "sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==",
       "cpu": [
         "x64"
       ],
@@ -340,9 +340,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.0.tgz",
-      "integrity": "sha512-0vYsP8aC4TvMlOQYozoksiaxjlvUcQrac+muDqj1Fxy6jh9l9CZJzj7zmh8JGfiV49cYLTorFLxg7593pGldwQ==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.2.tgz",
+      "integrity": "sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==",
       "cpu": [
         "arm64"
       ],
@@ -356,9 +356,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.0.tgz",
-      "integrity": "sha512-p98u4rIgfh4gdpV00IqknBD5pC84LCub+4a3MO+zjqvU5MVXOc3hqR2UgT2jI2nh3h8s9EQxmOsVI3tyzv1iFg==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.2.tgz",
+      "integrity": "sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==",
       "cpu": [
         "ia32"
       ],
@@ -372,9 +372,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.0.tgz",
-      "integrity": "sha512-NgJnesu1RtWihtTtXGFMU5YSE6JyyHPMxCwBZK7a6/8d31GuSo9l0Ss7w1Jw5QnKUawG6UEehs883kcXf5fYwg==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.2.tgz",
+      "integrity": "sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==",
       "cpu": [
         "x64"
       ],
@@ -408,9 +408,9 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/esbuild": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.0.tgz",
-      "integrity": "sha512-6iwE3Y2RVYCME1jLpBqq7LQWK3MW6vjV2bZy6gt/WrqkY+WE74Spyc0ThAOYpMtITvnjX09CrC6ym7A/m9mebA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.2.tgz",
+      "integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -420,29 +420,29 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.20.0",
-        "@esbuild/android-arm": "0.20.0",
-        "@esbuild/android-arm64": "0.20.0",
-        "@esbuild/android-x64": "0.20.0",
-        "@esbuild/darwin-arm64": "0.20.0",
-        "@esbuild/darwin-x64": "0.20.0",
-        "@esbuild/freebsd-arm64": "0.20.0",
-        "@esbuild/freebsd-x64": "0.20.0",
-        "@esbuild/linux-arm": "0.20.0",
-        "@esbuild/linux-arm64": "0.20.0",
-        "@esbuild/linux-ia32": "0.20.0",
-        "@esbuild/linux-loong64": "0.20.0",
-        "@esbuild/linux-mips64el": "0.20.0",
-        "@esbuild/linux-ppc64": "0.20.0",
-        "@esbuild/linux-riscv64": "0.20.0",
-        "@esbuild/linux-s390x": "0.20.0",
-        "@esbuild/linux-x64": "0.20.0",
-        "@esbuild/netbsd-x64": "0.20.0",
-        "@esbuild/openbsd-x64": "0.20.0",
-        "@esbuild/sunos-x64": "0.20.0",
-        "@esbuild/win32-arm64": "0.20.0",
-        "@esbuild/win32-ia32": "0.20.0",
-        "@esbuild/win32-x64": "0.20.0"
+        "@esbuild/aix-ppc64": "0.20.2",
+        "@esbuild/android-arm": "0.20.2",
+        "@esbuild/android-arm64": "0.20.2",
+        "@esbuild/android-x64": "0.20.2",
+        "@esbuild/darwin-arm64": "0.20.2",
+        "@esbuild/darwin-x64": "0.20.2",
+        "@esbuild/freebsd-arm64": "0.20.2",
+        "@esbuild/freebsd-x64": "0.20.2",
+        "@esbuild/linux-arm": "0.20.2",
+        "@esbuild/linux-arm64": "0.20.2",
+        "@esbuild/linux-ia32": "0.20.2",
+        "@esbuild/linux-loong64": "0.20.2",
+        "@esbuild/linux-mips64el": "0.20.2",
+        "@esbuild/linux-ppc64": "0.20.2",
+        "@esbuild/linux-riscv64": "0.20.2",
+        "@esbuild/linux-s390x": "0.20.2",
+        "@esbuild/linux-x64": "0.20.2",
+        "@esbuild/netbsd-x64": "0.20.2",
+        "@esbuild/openbsd-x64": "0.20.2",
+        "@esbuild/sunos-x64": "0.20.2",
+        "@esbuild/win32-arm64": "0.20.2",
+        "@esbuild/win32-ia32": "0.20.2",
+        "@esbuild/win32-x64": "0.20.2"
       }
     },
     "node_modules/lru-cache": {

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -62,6 +62,6 @@
   "devDependencies": {
     "@types/node": "^20.11.17",
     "@types/vscode": "^1.81.0",
-    "esbuild": "^0.20.0"
+    "esbuild": "0.20.2"
   }
 }

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -36,6 +36,12 @@
           "default": 25564,
           "title": "Language server port",
           "description": "Port to connect to GroovyScript mod"
+        },
+        "groovyscript.enableIcons": {
+          "type": "boolean",
+          "default": true,
+          "title": "Enable Inline Icons",
+          "description": "Enables preview icons of some global methods like item()"
         }
       }
     },

--- a/editors/vscode/src/features/TextureDecoration.ts
+++ b/editors/vscode/src/features/TextureDecoration.ts
@@ -48,8 +48,7 @@ export class TextureDecorationFeature extends TextDocumentLanguageFeature<boolea
     }
     initialize(capabilities: ServerCapabilities, documentSelector: DocumentSelector): void {
         const [id, options] = this.getRegistration(documentSelector, capabilities.experimental.textureDecorationProvider);
-        if (!id || !options)
-        {
+        if (!id || !options) {
             return;
         }
         this.register({ id: id, registerOptions: options });
@@ -65,18 +64,15 @@ export class TextureDecorationFeature extends TextDocumentLanguageFeature<boolea
                         textDocument: client.code2ProtocolConverter.asTextDocumentIdentifier(document),
                     };
 
-                    return client.sendRequest(TextureDecorationRequest.type, requestParams, token).then((result) =>
-                    {
-                        if (token.isCancellationRequested)
-                        {
+                    return client.sendRequest(TextureDecorationRequest.type, requestParams, token).then((result) => {
+                        if (token.isCancellationRequested) {
                             return null;
                         }
                         return result.map<TextureDecorationInformation>(decoration => ({
                             range: decoration.range,
-                            textureUri: client.protocol2CodeConverter.asUri(decoration.textureUri).toString(),
+                            textureUri: client.protocol2CodeConverter.asUri(decoration.textureUri).toString(true),
                         }));
-                    }, (error) =>
-                    {
+                    }, (error) => {
                         return client.handleFailedRequest(TextureDecorationRequest.type, token, error, null);
                     });
                 };
@@ -89,5 +85,5 @@ export class TextureDecorationFeature extends TextDocumentLanguageFeature<boolea
 
         return [registerTextureDecorationProvider(this._client.protocol2CodeConverter.asDocumentSelector(selector), provider), provider];
     }
-    
+
 }

--- a/editors/vscode/src/features/TextureDecoration.ts
+++ b/editors/vscode/src/features/TextureDecoration.ts
@@ -1,0 +1,93 @@
+import { CancellationToken, Disposable, languages, ProviderResult, TextDocument, Range as VRange } from 'vscode';
+import { ClientCapabilities, DocumentColorOptions, DocumentSelector, DynamicFeature, ensure, FeatureClient, MessageDirection, PartialResultParams, ProtocolRequestType, RequestHandler, ServerCapabilities, StaticRegistrationOptions, TextDocumentIdentifier, TextDocumentLanguageFeature, TextDocumentRegistrationOptions, WorkDoneProgressOptions, WorkDoneProgressParams } from 'vscode-languageclient';
+import { registerTextureDecorationProvider } from '../languageProviders/TextureDecorationLanguageProvider';
+
+export interface TextureDecorationParams extends WorkDoneProgressParams, PartialResultParams {
+    /**
+     * The text document.
+     */
+    textDocument: TextDocumentIdentifier;
+}
+
+export interface TextureDecorationInformation {
+    range: VRange;
+    textureUri: string;
+}
+
+export interface TextureDecorationOptions extends WorkDoneProgressOptions {
+}
+
+export interface TextureDecorationRegistrationOptions extends TextDocumentRegistrationOptions, StaticRegistrationOptions, DocumentColorOptions {
+}
+
+export interface ProvideTextureDecorationsSignature {
+    (document: TextDocument, token: CancellationToken): ProviderResult<TextureDecorationInformation[]>;
+}
+
+export interface TextureDecorationProvider {
+    provideTextureDecoration(document: TextDocument, token: CancellationToken): ProviderResult<TextureDecorationInformation[]>;
+}
+
+export interface TextureDecorationMiddleware {
+    provideTextureDecorations?: (this: void, document: TextDocument, token: CancellationToken, next: ProvideTextureDecorationsSignature) => ProviderResult<TextureDecorationInformation[]>;
+}
+
+export namespace TextureDecorationRequest {
+    export const method: 'groovyScript/textureDecoration' = 'groovyScript/textureDecoration';
+    export const messageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<TextureDecorationParams, TextureDecorationInformation[], TextureDecorationInformation[], void, TextureDecorationRegistrationOptions>(method);
+    export type HandlerSignature = RequestHandler<TextureDecorationParams, TextureDecorationInformation[], void>;
+}
+
+export class TextureDecorationFeature extends TextDocumentLanguageFeature<boolean | TextureDecorationOptions, TextureDecorationRegistrationOptions, TextureDecorationProvider, TextureDecorationMiddleware> {
+    constructor(client: FeatureClient<TextureDecorationMiddleware>) {
+        super(client, TextureDecorationRequest.type);
+    }
+    fillClientCapabilities(capabilities: ClientCapabilities): void {
+        ensure(ensure(capabilities, 'experimental')!, 'textureDecorationProvider')!.dynamicRegistration = true;
+    }
+    initialize(capabilities: ServerCapabilities, documentSelector: DocumentSelector): void {
+        const [id, options] = this.getRegistration(documentSelector, capabilities.experimental.textureDecorationProvider);
+        if (!id || !options)
+        {
+            return;
+        }
+        this.register({ id: id, registerOptions: options });
+    }
+    protected registerLanguageProvider(options: TextureDecorationRegistrationOptions, id: string): [Disposable, TextureDecorationProvider] {
+        const selector = options.documentSelector!;
+
+        const provider: TextureDecorationProvider = {
+            provideTextureDecoration: (document, token) => {
+                const client = this._client;
+                const provideTextureDecorations: ProvideTextureDecorationsSignature = (document, token) => {
+                    const requestParams: TextureDecorationParams = {
+                        textDocument: client.code2ProtocolConverter.asTextDocumentIdentifier(document),
+                    };
+
+                    return client.sendRequest(TextureDecorationRequest.type, requestParams, token).then((result) =>
+                    {
+                        if (token.isCancellationRequested)
+                        {
+                            return null;
+                        }
+                        return result.map<TextureDecorationInformation>(decoration => ({
+                            range: decoration.range,
+                            textureUri: client.protocol2CodeConverter.asUri(decoration.textureUri).toString(),
+                        }));
+                    }, (error) =>
+                    {
+                        return client.handleFailedRequest(TextureDecorationRequest.type, token, error, null);
+                    });
+                };
+                const middleware = client.middleware;
+                return middleware.provideTextureDecorations
+                    ? middleware.provideTextureDecorations(document, token, provideTextureDecorations)
+                    : provideTextureDecorations(document, token);
+            },
+        };
+
+        return [registerTextureDecorationProvider(this._client.protocol2CodeConverter.asDocumentSelector(selector), provider), provider];
+    }
+    
+}

--- a/editors/vscode/src/languageProviders/TextureDecorationLanguageProvider.ts
+++ b/editors/vscode/src/languageProviders/TextureDecorationLanguageProvider.ts
@@ -1,5 +1,5 @@
 import { DocumentSelector, Disposable, window as vWindow, workspace as vWorkspace, CancellationTokenSource, TextEditor, TextDocument, languages, DecorationOptions, Uri } from "vscode";
-import { TextureDecorationInformation, TextureDecorationProvider } from "../features/textureDecoration";
+import { TextureDecorationInformation, TextureDecorationProvider } from "../features/TextureDecoration";
 
 export function registerTextureDecorationProvider(selector: DocumentSelector, provider: TextureDecorationProvider): Disposable {
     let cancellationSource = new CancellationTokenSource();

--- a/editors/vscode/src/languageProviders/TextureDecorationLanguageProvider.ts
+++ b/editors/vscode/src/languageProviders/TextureDecorationLanguageProvider.ts
@@ -1,0 +1,53 @@
+import { DocumentSelector, Disposable, window as vWindow, workspace as vWorkspace, CancellationTokenSource, TextEditor, TextDocument, languages, DecorationOptions } from "vscode";
+import { TextureDecorationInformation, TextureDecorationProvider } from "../features/textureDecoration";
+
+export function registerTextureDecorationProvider(selector: DocumentSelector, provider: TextureDecorationProvider): Disposable {
+    let cancellationSource = new CancellationTokenSource();
+
+    function cancel() {
+        cancellationSource.cancel();
+        cancellationSource.dispose();
+        cancellationSource = new CancellationTokenSource();
+    }
+
+    const changedActiveTextEditor = vWindow.onDidChangeActiveTextEditor(async editor => {
+        if (editor && languages.match(selector, editor.document)) {
+            cancel();
+            const result = await provider.provideTextureDecoration(editor.document, cancellationSource.token);
+
+            if (result) {
+                decorate(editor, result);
+            }
+        }
+    });
+
+    const changedDocumentText = vWorkspace.onDidChangeTextDocument(async event => {
+        if (vWindow.activeTextEditor?.document === event.document && languages.match(selector, event.document)) {
+            cancel();
+            const result = await provider.provideTextureDecoration(event.document, cancellationSource.token);
+            if (result) {
+                decorate(vWindow.activeTextEditor, result);
+            }
+        }
+    })
+
+    return new Disposable(() => {
+        changedActiveTextEditor.dispose();
+        changedDocumentText.dispose();
+    });
+}
+
+function decorate(textEditor: TextEditor, decorations: TextureDecorationInformation[]) {
+    textEditor.setDecorations(decorationStyle, decorations.map<DecorationOptions>(decoration => ({
+        range: decoration.range,
+        renderOptions: {
+            before: {
+                contentIconPath: decoration.textureUri,
+                height: '16px',
+                width: '16px'
+            }
+        }
+    })))
+}
+
+const decorationStyle = vWindow.createTextEditorDecorationType({})

--- a/editors/vscode/src/main.ts
+++ b/editors/vscode/src/main.ts
@@ -2,6 +2,8 @@ import * as net from "net";
 import * as lc from "vscode-languageclient/node";
 import * as vscode from "vscode";
 import { extensionStatusBar } from "./gui/extensionStatusBarProvider";
+import { TextureDecorationFeature, TextureDecorationMiddleware } from "./features/textureDecoration";
+import { FeatureClient } from "vscode-languageclient/node";
 
 let client: lc.LanguageClient;
 let outputChannel = vscode.window.createOutputChannel("GroovyScript Language Server");
@@ -37,7 +39,9 @@ async function startClient() {
 		traceOutputChannel,
 	};
 
-	client = new lc.LanguageClient("groovyscript", "GroovyScript", serverOptions, clientOptions)
+	client = new lc.LanguageClient("groovyscript", "GroovyScript", serverOptions, clientOptions);
+
+	registerFeatures();
 
 	try {
 		await client.start();
@@ -49,6 +53,10 @@ async function startClient() {
 
 	extensionStatusBar.running();
 	outputChannel.appendLine("Connected to GroovyScript Language Server");
+}
+
+function registerFeatures() {
+	client.registerFeature(new TextureDecorationFeature(<FeatureClient<TextureDecorationMiddleware>>client));
 }
 
 async function stopClient() {

--- a/editors/vscode/src/main.ts
+++ b/editors/vscode/src/main.ts
@@ -2,7 +2,7 @@ import * as net from "net";
 import * as lc from "vscode-languageclient/node";
 import * as vscode from "vscode";
 import { extensionStatusBar } from "./gui/extensionStatusBarProvider";
-import { TextureDecorationFeature, TextureDecorationMiddleware } from "./features/textureDecoration";
+import { TextureDecorationFeature, TextureDecorationMiddleware } from "./features/TextureDecoration";
 import { FeatureClient } from "vscode-languageclient/node";
 
 let client: lc.LanguageClient;

--- a/src/main/java/com/cleanroommc/groovyscript/GroovyScript.java
+++ b/src/main/java/com/cleanroommc/groovyscript/GroovyScript.java
@@ -23,7 +23,7 @@ import com.cleanroommc.groovyscript.registry.ReloadableRegistryManager;
 import com.cleanroommc.groovyscript.sandbox.*;
 import com.cleanroommc.groovyscript.sandbox.mapper.GroovyDeobfMapper;
 import com.cleanroommc.groovyscript.sandbox.security.GrSMetaClassCreationHandle;
-import com.cleanroommc.groovyscript.server.GroovyScriptLanguageServer;
+import com.cleanroommc.groovyscript.server.GroovyScriptLanguageServerImpl;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import groovy.lang.GroovySystem;
@@ -327,7 +327,7 @@ public class GroovyScript {
 
     public static boolean runLanguageServer() {
         if (languageServerThread != null) return false;
-        languageServerThread = new Thread(() -> GroovyScriptLanguageServer.listen(getSandbox().getScriptRoot()));
+        languageServerThread = new Thread(() -> GroovyScriptLanguageServerImpl.listen(getSandbox().getScriptRoot()));
         languageServerThread.start();
         return true;
     }

--- a/src/main/java/com/cleanroommc/groovyscript/gameobjects/GameObjectHandlerManager.java
+++ b/src/main/java/com/cleanroommc/groovyscript/gameobjects/GameObjectHandlerManager.java
@@ -20,7 +20,7 @@ public class GameObjectHandlerManager {
 
     @Nullable
     public static Object getGameObject(String name, String mainArg, Object... args) {
-        return ObjectMapperManager.getGameObject(name, mainArg, args);
+        return ObjectMapperManager.getGameObject(false, name, mainArg, args);
     }
 
     public static boolean hasGameObjectHandler(String key) {

--- a/src/main/java/com/cleanroommc/groovyscript/mapper/ObjectMapper.java
+++ b/src/main/java/com/cleanroommc/groovyscript/mapper/ObjectMapper.java
@@ -54,8 +54,9 @@ public class ObjectMapper<T> extends Closure<T> implements INamed, IDocumented {
     private final Completer completer;
     private final String documentation;
     private List<MethodNode> methodNodes;
+    private TextureBinder<T> textureBinder;
 
-    private ObjectMapper(String name, GroovyContainer<?> mod, IObjectParser<T> handler, Supplier<Result<T>> defaultValue, Class<T> returnType, List<Class<?>[]> paramTypes, Completer completer, String documentation) {
+    private ObjectMapper(String name, GroovyContainer<?> mod, IObjectParser<T> handler, Supplier<Result<T>> defaultValue, Class<T> returnType, List<Class<?>[]> paramTypes, Completer completer, String documentation, TextureBinder<T> textureBinder) {
         super(null);
         this.name = name;
         this.mod = mod;
@@ -65,6 +66,7 @@ public class ObjectMapper<T> extends Closure<T> implements INamed, IDocumented {
         this.paramTypes = paramTypes;
         this.completer = completer;
         this.documentation = documentation;
+        this.textureBinder = textureBinder;
     }
 
     T invoke(String s, Object... args) {
@@ -146,6 +148,14 @@ public class ObjectMapper<T> extends Closure<T> implements INamed, IDocumented {
         return methodNodes;
     }
 
+    public TextureBinder<T> getTextureBinder() {
+        return textureBinder;
+    }
+
+    public void setTextureBinder(TextureBinder<T> textureBinder) {
+        this.textureBinder = textureBinder;
+    }
+
     /**
      * A helper class to create {@link ObjectMapper}s.
      *
@@ -161,6 +171,7 @@ public class ObjectMapper<T> extends Closure<T> implements INamed, IDocumented {
         private final List<Class<?>[]> paramTypes = new ArrayList<>();
         private Completer completer;
         private String documentation;
+        private TextureBinder textureBinder;
 
         @ApiStatus.Internal
         public Builder(String name, Class<T> returnType) {
@@ -323,6 +334,11 @@ public class ObjectMapper<T> extends Closure<T> implements INamed, IDocumented {
             return documentation("returns a " + mod + type);
         }
 
+        public Builder<T> textureBinder(TextureBinder<T> textureBinder) {
+            this.textureBinder = textureBinder;
+            return this;
+        }
+
         /**
          * Registers the mapper.
          *
@@ -338,7 +354,7 @@ public class ObjectMapper<T> extends Closure<T> implements INamed, IDocumented {
             if (this.defaultValue == null) this.defaultValue = () -> null;
             this.documentation = IDocumented.toJavaDoc(this.documentation);
             ObjectMapper<T> goh = new ObjectMapper<>(this.name, this.mod, this.handler, this.defaultValue,
-                                                     this.returnType, this.paramTypes, this.completer, this.documentation);
+                                                     this.returnType, this.paramTypes, this.completer, this.documentation, this.textureBinder);
             ObjectMapperManager.registerObjectMapper(this.mod, goh);
         }
     }

--- a/src/main/java/com/cleanroommc/groovyscript/mapper/ObjectMapperManager.java
+++ b/src/main/java/com/cleanroommc/groovyscript/mapper/ObjectMapperManager.java
@@ -205,9 +205,23 @@ public class ObjectMapperManager {
      */
     @Nullable
     public static Object getGameObject(String name, String mainArg, Object... args) {
+        return getGameObject(false, name, mainArg, args);
+    }
+
+    /**
+     * Finds the game object handle and invokes it. Called by injected calls via the groovy script transformer.
+     *
+     * @param name    game object handler name (method name)
+     * @param mainArg main argument
+     * @param args    extra arguments
+     * @param silent if error messages should be logged
+     * @return game object or null
+     */
+    @Nullable
+    public static Object getGameObject(boolean silent, String name, String mainArg, Object... args) {
         ObjectMapper<?> objectMapper = handlers.get(name);
         if (objectMapper != null) {
-            return objectMapper.invoke(mainArg, args);
+            return objectMapper.invokeWithDefault(silent, mainArg, args);
         }
         return null;
     }

--- a/src/main/java/com/cleanroommc/groovyscript/mapper/ObjectMapperManager.java
+++ b/src/main/java/com/cleanroommc/groovyscript/mapper/ObjectMapperManager.java
@@ -16,13 +16,14 @@ import groovy.lang.ExpandoMetaClass;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
-import net.minecraft.client.renderer.tileentity.TileEntityItemStackRenderer;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.enchantment.Enchantment;
+import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionType;
+import net.minecraft.potion.PotionUtils;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.text.TextFormatting;
@@ -85,6 +86,7 @@ public class ObjectMapperManager {
                 .parser((s, args) -> s.contains(WILDCARD) ? Result.some(OreDictWildcardIngredient.of(s)) : Result.some(new OreDictIngredient(s)))
                 .completerOfNames(OreDictionaryAccessor::getIdToName)
                 .docOfType("ore dict entry")
+                .textureBinder(TextureBinder.of(i -> i.getMatchingStacks()[0], TextureBinder.ofItem()))
                 .register();
         ObjectMapper.builder("item", ItemStack.class)
                 .parser(ObjectMappers::parseItemStack)
@@ -93,21 +95,24 @@ public class ObjectMapperManager {
                 .defaultValue(() -> ItemStack.EMPTY)
                 .completer(ForgeRegistries.ITEMS)
                 .docOfType("item stack")
-                .textureBinder(itemStack -> TileEntityItemStackRenderer.instance.renderByItem(itemStack))
+                .textureBinder(TextureBinder.ofItem())
                 .register();
         ObjectMapper.builder("liquid", FluidStack.class)
                 .parser(ObjectMappers::parseFluidStack)
                 .completerOfNames(FluidRegistry.getRegisteredFluids()::keySet)
                 .docOfType("fluid stack")
+                .textureBinder(TextureBinder.ofFluid())
                 .register();
         ObjectMapper.builder("fluid", FluidStack.class)
                 .parser(ObjectMappers::parseFluidStack)
                 .completerOfNames(FluidRegistry.getRegisteredFluids()::keySet)
+                .textureBinder(TextureBinder.ofFluid())
                 .register();
         ObjectMapper.builder("block", Block.class)
                 .parser(IObjectParser.wrapForgeRegistry(ForgeRegistries.BLOCKS))
                 .completer(ForgeRegistries.BLOCKS)
                 .docOfType("block")
+                .textureBinder(TextureBinder.of(ItemStack::new, TextureBinder.ofItem()))
                 .register();
         ObjectMapper.builder("blockstate", IBlockState.class)
                 .parser(ObjectMappers::parseBlockState)
@@ -126,6 +131,7 @@ public class ObjectMapperManager {
                 .parser(IObjectParser.wrapForgeRegistry(ForgeRegistries.POTIONS))
                 .completer(ForgeRegistries.POTIONS)
                 .docOfType("potion")
+                .textureBinder(TextureBinder.of(potion -> PotionUtils.addPotionToItemStack(new ItemStack(Items.POTIONITEM), PotionType.REGISTRY.getObject(potion.getRegistryName())), TextureBinder.ofItem()))
                 .register();
         ObjectMapper.builder("potionType", PotionType.class)
                 .parser(IObjectParser.wrapForgeRegistry(ForgeRegistries.POTION_TYPES))

--- a/src/main/java/com/cleanroommc/groovyscript/mapper/ObjectMapperManager.java
+++ b/src/main/java/com/cleanroommc/groovyscript/mapper/ObjectMapperManager.java
@@ -16,6 +16,7 @@ import groovy.lang.ExpandoMetaClass;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.client.renderer.tileentity.TileEntityItemStackRenderer;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.item.ItemStack;
@@ -92,6 +93,7 @@ public class ObjectMapperManager {
                 .defaultValue(() -> ItemStack.EMPTY)
                 .completer(ForgeRegistries.ITEMS)
                 .docOfType("item stack")
+                .textureBinder(itemStack -> TileEntityItemStackRenderer.instance.renderByItem(itemStack))
                 .register();
         ObjectMapper.builder("liquid", FluidStack.class)
                 .parser(ObjectMappers::parseFluidStack)

--- a/src/main/java/com/cleanroommc/groovyscript/mapper/TextureBinder.java
+++ b/src/main/java/com/cleanroommc/groovyscript/mapper/TextureBinder.java
@@ -1,13 +1,78 @@
 package com.cleanroommc.groovyscript.mapper;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.util.ResourceLocation;
+import net.minecraft.client.renderer.BufferBuilder;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.renderer.RenderHelper;
+import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.client.renderer.texture.TextureMap;
+import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
 
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 public interface TextureBinder<T> extends Consumer<T> {
 
-    static TextureBinder<ResourceLocation> ofResource() {
-        return resource -> Minecraft.getMinecraft().getTextureManager().bindTexture(resource);
+    static <A, T> TextureBinder<A> of(Function<A, T> mapper, TextureBinder<T> binder) {
+        return o -> binder.accept(mapper.apply(o));
+    }
+
+    static TextureBinder<ItemStack> ofItem() {
+        return item -> {
+            GlStateManager.enableDepth();
+            RenderHelper.enableGUIStandardItemLighting();
+            var mc = Minecraft.getMinecraft();
+            var fontRenderer = item.getItem().getFontRenderer(item);
+            if (fontRenderer == null)
+                fontRenderer = mc.fontRenderer;
+            mc.getRenderItem().renderItemAndEffectIntoGUI(null, item, 0, 0);
+            mc.getRenderItem().renderItemOverlayIntoGUI(fontRenderer, item, 0, 0, null);
+            GlStateManager.disableBlend();
+            RenderHelper.disableStandardItemLighting();
+            GlStateManager.enableAlpha();
+            GlStateManager.disableDepth();
+        };
+    }
+
+    static TextureBinder<FluidStack> ofFluid() {
+        return fluid -> {
+            GlStateManager.enableBlend();
+            GlStateManager.enableAlpha();
+
+            Minecraft.getMinecraft().getTextureManager().bindTexture(TextureMap.LOCATION_BLOCKS_TEXTURE);
+
+            var texture = Minecraft.getMinecraft().getTextureMapBlocks().getTextureExtry(fluid.getFluid().getStill(fluid).toString());
+
+            if (texture == null) {
+                texture = Minecraft.getMinecraft().getTextureMapBlocks().getMissingSprite();
+            }
+
+            var color = fluid.getFluid().getColor(fluid);
+            GlStateManager.color((color >> 16 & 0xFF) / 255.0F, (color >> 8 & 0xFF) / 255.0F, (color & 0xFF) / 255.0F, (color >> 24 & 0xFF) / 255.0F);
+
+            drawSprite(texture);
+
+            GlStateManager.disableAlpha();
+            GlStateManager.disableBlend();
+        };
+    }
+
+    static void drawSprite(TextureAtlasSprite textureSprite) {
+        double uMin = textureSprite.getMinU();
+        double uMax = textureSprite.getMaxU();
+        double vMin = textureSprite.getMinV();
+        double vMax = textureSprite.getMaxV();
+
+        Tessellator tessellator = Tessellator.getInstance();
+        BufferBuilder bufferBuilder = tessellator.getBuffer();
+        bufferBuilder.begin(7, DefaultVertexFormats.POSITION_TEX);
+        bufferBuilder.pos(0, 16, 0).tex(uMin, vMax).endVertex();
+        bufferBuilder.pos(16, 16, 0).tex(uMax, vMax).endVertex();
+        bufferBuilder.pos(16, 0, 0).tex(uMax, vMin).endVertex();
+        bufferBuilder.pos(0, 0, 0).tex(uMin, vMin).endVertex();
+        tessellator.draw();
     }
 }

--- a/src/main/java/com/cleanroommc/groovyscript/mapper/TextureBinder.java
+++ b/src/main/java/com/cleanroommc/groovyscript/mapper/TextureBinder.java
@@ -1,0 +1,13 @@
+package com.cleanroommc.groovyscript.mapper;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.util.ResourceLocation;
+
+import java.util.function.Consumer;
+
+public interface TextureBinder<T> extends Consumer<T> {
+
+    static TextureBinder<ResourceLocation> ofResource() {
+        return resource -> Minecraft.getMinecraft().getTextureManager().bindTexture(resource);
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/server/GroovyScriptCapabilities.java
+++ b/src/main/java/com/cleanroommc/groovyscript/server/GroovyScriptCapabilities.java
@@ -1,0 +1,14 @@
+package com.cleanroommc.groovyscript.server;
+
+public class GroovyScriptCapabilities {
+
+    private Boolean textureDecorationProvider;
+
+    public Boolean getTextureDecorationProvider() {
+        return textureDecorationProvider;
+    }
+
+    public void setTextureDecorationProvider(Boolean textureDecorationProvider) {
+        this.textureDecorationProvider = textureDecorationProvider;
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/server/GroovyScriptFeaturesService.java
+++ b/src/main/java/com/cleanroommc/groovyscript/server/GroovyScriptFeaturesService.java
@@ -1,0 +1,18 @@
+package com.cleanroommc.groovyscript.server;
+
+import com.cleanroommc.groovyscript.server.features.textureDecoration.TextureDecorationInformation;
+import com.cleanroommc.groovyscript.server.features.textureDecoration.TextureDecorationParams;
+import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
+import org.eclipse.lsp4j.jsonrpc.services.JsonSegment;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+@JsonSegment("groovyScript")
+public interface GroovyScriptFeaturesService {
+
+    @JsonRequest
+    default CompletableFuture<List<TextureDecorationInformation>> textureDecoration(TextureDecorationParams params) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/server/GroovyScriptLanguageServer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/server/GroovyScriptLanguageServer.java
@@ -4,11 +4,18 @@ import com.cleanroommc.groovyscript.GroovyScript;
 import com.cleanroommc.groovyscript.GroovyScriptConfig;
 import com.cleanroommc.groovyscript.api.GroovyLog;
 import net.prominic.groovyls.GroovyLanguageServer;
+import net.prominic.groovyls.GroovyServices;
+import net.prominic.groovyls.compiler.ILanguageServerContext;
+import net.prominic.groovyls.config.ICompilationUnitFactory;
+import org.eclipse.lsp4j.InitializeParams;
+import org.eclipse.lsp4j.InitializeResult;
 import org.eclipse.lsp4j.jsonrpc.Launcher;
 import org.eclipse.lsp4j.services.LanguageClient;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
 import java.net.ServerSocket;
+import java.util.concurrent.CompletableFuture;
 
 public class GroovyScriptLanguageServer extends GroovyLanguageServer {
 
@@ -36,5 +43,21 @@ public class GroovyScriptLanguageServer extends GroovyLanguageServer {
 
     public GroovyScriptLanguageServer(File root, GroovyScriptLanguageServerContext languageServerContext) {
         super(new GroovyScriptCompilationUnitFactory(root, languageServerContext), languageServerContext);
+    }
+
+    @Override
+    public CompletableFuture<InitializeResult> initialize(InitializeParams params) {
+        return super.initialize(params).thenApply(initializeResult -> {
+            var groovyScriptCapabilities = new GroovyScriptCapabilities();
+            groovyScriptCapabilities.setTextureDecorationProvider(true);
+
+            initializeResult.getCapabilities().setExperimental(groovyScriptCapabilities);
+            return initializeResult;
+        });
+    }
+
+    @Override
+    protected @NotNull GroovyServices createGroovyServices(ICompilationUnitFactory compilationUnitFactory, ILanguageServerContext languageServerContext) {
+        return new GroovyScriptServices(compilationUnitFactory, languageServerContext);
     }
 }

--- a/src/main/java/com/cleanroommc/groovyscript/server/GroovyScriptLanguageServer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/server/GroovyScriptLanguageServer.java
@@ -1,63 +1,12 @@
 package com.cleanroommc.groovyscript.server;
 
-import com.cleanroommc.groovyscript.GroovyScript;
-import com.cleanroommc.groovyscript.GroovyScriptConfig;
-import com.cleanroommc.groovyscript.api.GroovyLog;
-import net.prominic.groovyls.GroovyLanguageServer;
-import net.prominic.groovyls.GroovyServices;
-import net.prominic.groovyls.compiler.ILanguageServerContext;
-import net.prominic.groovyls.config.ICompilationUnitFactory;
-import org.eclipse.lsp4j.InitializeParams;
-import org.eclipse.lsp4j.InitializeResult;
-import org.eclipse.lsp4j.jsonrpc.Launcher;
-import org.eclipse.lsp4j.services.LanguageClient;
-import org.jetbrains.annotations.NotNull;
+import org.eclipse.lsp4j.jsonrpc.services.JsonDelegate;
+import org.eclipse.lsp4j.services.LanguageServer;
 
-import java.io.File;
-import java.net.ServerSocket;
-import java.util.concurrent.CompletableFuture;
+public interface GroovyScriptLanguageServer extends LanguageServer {
 
-public class GroovyScriptLanguageServer extends GroovyLanguageServer {
-
-    @SuppressWarnings("InfiniteLoopStatement")
-    public static void listen(File root) {
-        GroovyLog.get().infoMC("Starting Language server");
-        var languageServerContext = new GroovyScriptLanguageServerContext();
-
-        while (true) {
-            var server = new GroovyScriptLanguageServer(root, languageServerContext);
-            try (var serverSocket = new ServerSocket(GroovyScriptConfig.languageServerPort);
-                 var socket = serverSocket.accept()) {
-
-                GroovyScript.LOGGER.info("Accepted connection from: {}", socket.getInetAddress());
-
-                var launcher = Launcher.createLauncher(server, LanguageClient.class, socket.getInputStream(), socket.getOutputStream());
-                server.connect(launcher.getRemoteProxy());
-
-                launcher.startListening().get();
-            } catch (Exception e) {
-                GroovyScript.LOGGER.error("Connection failed", e);
-            }
-        }
-    }
-
-    public GroovyScriptLanguageServer(File root, GroovyScriptLanguageServerContext languageServerContext) {
-        super(new GroovyScriptCompilationUnitFactory(root, languageServerContext), languageServerContext);
-    }
-
-    @Override
-    public CompletableFuture<InitializeResult> initialize(InitializeParams params) {
-        return super.initialize(params).thenApply(initializeResult -> {
-            var groovyScriptCapabilities = new GroovyScriptCapabilities();
-            groovyScriptCapabilities.setTextureDecorationProvider(true);
-
-            initializeResult.getCapabilities().setExperimental(groovyScriptCapabilities);
-            return initializeResult;
-        });
-    }
-
-    @Override
-    protected @NotNull GroovyServices createGroovyServices(ICompilationUnitFactory compilationUnitFactory, ILanguageServerContext languageServerContext) {
-        return new GroovyScriptServices(compilationUnitFactory, languageServerContext);
+    @JsonDelegate
+    default GroovyScriptFeaturesService getGroovyScriptFeaturesService() {
+        return null;
     }
 }

--- a/src/main/java/com/cleanroommc/groovyscript/server/GroovyScriptLanguageServerImpl.java
+++ b/src/main/java/com/cleanroommc/groovyscript/server/GroovyScriptLanguageServerImpl.java
@@ -1,0 +1,67 @@
+package com.cleanroommc.groovyscript.server;
+
+import com.cleanroommc.groovyscript.GroovyScript;
+import com.cleanroommc.groovyscript.GroovyScriptConfig;
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import net.prominic.groovyls.GroovyLanguageServer;
+import net.prominic.groovyls.compiler.ILanguageServerContext;
+import net.prominic.groovyls.config.ICompilationUnitFactory;
+import org.eclipse.lsp4j.InitializeParams;
+import org.eclipse.lsp4j.InitializeResult;
+import org.eclipse.lsp4j.jsonrpc.Launcher;
+import org.eclipse.lsp4j.services.LanguageClient;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.net.ServerSocket;
+import java.util.concurrent.CompletableFuture;
+
+public class GroovyScriptLanguageServerImpl extends GroovyLanguageServer<GroovyScriptServices> implements GroovyScriptLanguageServer {
+
+    @SuppressWarnings("InfiniteLoopStatement")
+    public static void listen(File root) {
+        GroovyLog.get().infoMC("Starting Language server");
+        var languageServerContext = new GroovyScriptLanguageServerContext();
+
+        while (true) {
+            var server = new GroovyScriptLanguageServerImpl(root, languageServerContext);
+            try (var serverSocket = new ServerSocket(GroovyScriptConfig.languageServerPort);
+                 var socket = serverSocket.accept()) {
+
+                GroovyScript.LOGGER.info("Accepted connection from: {}", socket.getInetAddress());
+
+                var launcher = Launcher.createLauncher(server, LanguageClient.class, socket.getInputStream(), socket.getOutputStream());
+                server.connect(launcher.getRemoteProxy());
+
+                launcher.startListening().get();
+            } catch (Exception e) {
+                GroovyScript.LOGGER.error("Connection failed", e);
+            }
+        }
+    }
+
+    public GroovyScriptLanguageServerImpl(File root, GroovyScriptLanguageServerContext languageServerContext) {
+        super(new GroovyScriptCompilationUnitFactory(root, languageServerContext), languageServerContext);
+    }
+
+    @Override
+    public CompletableFuture<InitializeResult> initialize(InitializeParams params) {
+        return super.initialize(params).thenApply(initializeResult -> {
+            var groovyScriptCapabilities = new GroovyScriptCapabilities();
+            groovyScriptCapabilities.setTextureDecorationProvider(true);
+
+            initializeResult.getCapabilities().setExperimental(groovyScriptCapabilities);
+            return initializeResult;
+        });
+    }
+
+    @Override
+    public GroovyScriptFeaturesService getGroovyScriptFeaturesService() {
+        return groovyServices;
+    }
+
+    @Override
+    protected @NotNull GroovyScriptServices createGroovyServices(ICompilationUnitFactory compilationUnitFactory, ILanguageServerContext languageServerContext) {
+        return new GroovyScriptServices(compilationUnitFactory, languageServerContext);
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/server/GroovyScriptServices.java
+++ b/src/main/java/com/cleanroommc/groovyscript/server/GroovyScriptServices.java
@@ -8,19 +8,18 @@ import net.prominic.groovyls.GroovyServices;
 import net.prominic.groovyls.compiler.ILanguageServerContext;
 import net.prominic.groovyls.compiler.ast.ASTContext;
 import net.prominic.groovyls.config.ICompilationUnitFactory;
-import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
 
 import java.net.URI;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-public class GroovyScriptServices extends GroovyServices {
+public class GroovyScriptServices extends GroovyServices implements GroovyScriptFeaturesService {
 
     public GroovyScriptServices(ICompilationUnitFactory factory, ILanguageServerContext languageServerContext) {
         super(factory, languageServerContext);
     }
 
-    @JsonRequest(value = "groovyScript/textureDecoration", useSegment = false)
+    @Override
     public CompletableFuture<List<TextureDecorationInformation>> textureDecoration(TextureDecorationParams params) {
         URI uri = FileUtil.fixUri(params.getTextDocument().getUri());
         var unit = compilationUnitFactory.create(workspaceRoot, uri);

--- a/src/main/java/com/cleanroommc/groovyscript/server/GroovyScriptServices.java
+++ b/src/main/java/com/cleanroommc/groovyscript/server/GroovyScriptServices.java
@@ -30,7 +30,7 @@ public class GroovyScriptServices extends GroovyServices implements GroovyScript
             return CompletableFuture.completedFuture(null);
         }
 
-        var provider = new TextureDecorationProvider(new ASTContext(visitor, languageServerContext));
-        return provider.provideTextureDecorations(params.getTextDocument());
+        var provider = new TextureDecorationProvider(uri, new ASTContext(visitor, languageServerContext));
+        return provider.provideTextureDecorations();
     }
 }

--- a/src/main/java/com/cleanroommc/groovyscript/server/GroovyScriptServices.java
+++ b/src/main/java/com/cleanroommc/groovyscript/server/GroovyScriptServices.java
@@ -1,0 +1,37 @@
+package com.cleanroommc.groovyscript.server;
+
+import com.cleanroommc.groovyscript.sandbox.FileUtil;
+import com.cleanroommc.groovyscript.server.features.textureDecoration.TextureDecorationInformation;
+import com.cleanroommc.groovyscript.server.features.textureDecoration.TextureDecorationParams;
+import com.cleanroommc.groovyscript.server.features.textureDecoration.TextureDecorationProvider;
+import net.prominic.groovyls.GroovyServices;
+import net.prominic.groovyls.compiler.ILanguageServerContext;
+import net.prominic.groovyls.compiler.ast.ASTContext;
+import net.prominic.groovyls.config.ICompilationUnitFactory;
+import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
+
+import java.net.URI;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+public class GroovyScriptServices extends GroovyServices {
+
+    public GroovyScriptServices(ICompilationUnitFactory factory, ILanguageServerContext languageServerContext) {
+        super(factory, languageServerContext);
+    }
+
+    @JsonRequest(value = "groovyScript/textureDecoration", useSegment = false)
+    public CompletableFuture<List<TextureDecorationInformation>> textureDecoration(TextureDecorationParams params) {
+        URI uri = FileUtil.fixUri(params.getTextDocument().getUri());
+        var unit = compilationUnitFactory.create(workspaceRoot, uri);
+
+        var visitor = compileAndVisitAST(unit, uri);
+
+        if (visitor == null) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        var provider = new TextureDecorationProvider(new ASTContext(visitor, languageServerContext));
+        return provider.provideTextureDecorations(params.getTextDocument());
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/server/features/textureDecoration/TextureDecorationInformation.java
+++ b/src/main/java/com/cleanroommc/groovyscript/server/features/textureDecoration/TextureDecorationInformation.java
@@ -1,0 +1,30 @@
+package com.cleanroommc.groovyscript.server.features.textureDecoration;
+
+import org.eclipse.lsp4j.Range;
+
+public class TextureDecorationInformation {
+
+    private Range range;
+    private String textureUri;
+
+    public TextureDecorationInformation(Range range, String textureUri) {
+        this.range = range;
+        this.textureUri = textureUri;
+    }
+
+    public Range getRange() {
+        return range;
+    }
+
+    public void setRange(Range range) {
+        this.range = range;
+    }
+
+    public String getTextureUri() {
+        return textureUri;
+    }
+
+    public void setTextureUri(String textureUri) {
+        this.textureUri = textureUri;
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/server/features/textureDecoration/TextureDecorationParams.java
+++ b/src/main/java/com/cleanroommc/groovyscript/server/features/textureDecoration/TextureDecorationParams.java
@@ -1,0 +1,48 @@
+package com.cleanroommc.groovyscript.server.features.textureDecoration;
+
+import org.eclipse.lsp4j.PartialResultParams;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.WorkDoneProgressParams;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+
+public class TextureDecorationParams implements WorkDoneProgressParams, PartialResultParams {
+
+    private TextDocumentIdentifier textDocument;
+
+    private Either<String, Integer> partialResultToken;
+    private Either<String, Integer> workDoneToken;
+
+    public TextureDecorationParams(TextDocumentIdentifier textDocument, Either<String, Integer> partialResultToken, Either<String, Integer> workDoneToken) {
+        this.textDocument = textDocument;
+        this.partialResultToken = partialResultToken;
+        this.workDoneToken = workDoneToken;
+    }
+
+    public TextDocumentIdentifier getTextDocument() {
+        return textDocument;
+    }
+
+    public void setTextDocument(TextDocumentIdentifier textDocument) {
+        this.textDocument = textDocument;
+    }
+
+    @Override
+    public Either<String, Integer> getPartialResultToken() {
+        return partialResultToken;
+    }
+
+    @Override
+    public void setPartialResultToken(Either<String, Integer> token) {
+        this.partialResultToken = token;
+    }
+
+    @Override
+    public Either<String, Integer> getWorkDoneToken() {
+        return workDoneToken;
+    }
+
+    @Override
+    public void setWorkDoneToken(Either<String, Integer> token) {
+        this.workDoneToken = token;
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/server/features/textureDecoration/TextureDecorationProvider.java
+++ b/src/main/java/com/cleanroommc/groovyscript/server/features/textureDecoration/TextureDecorationProvider.java
@@ -1,0 +1,177 @@
+package com.cleanroommc.groovyscript.server.features.textureDecoration;
+
+import com.cleanroommc.groovyscript.mapper.TextureBinder;
+import com.cleanroommc.groovyscript.sandbox.FileUtil;
+import net.minecraft.client.Minecraft;
+import net.prominic.groovyls.compiler.ast.ASTContext;
+import net.prominic.groovyls.compiler.util.GroovyASTUtils;
+import net.prominic.groovyls.util.GroovyLSUtils;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.codehaus.groovy.ast.ASTNode;
+import org.codehaus.groovy.ast.expr.ArgumentListExpression;
+import org.codehaus.groovy.ast.expr.ConstantExpression;
+import org.codehaus.groovy.ast.expr.Expression;
+import org.codehaus.groovy.ast.expr.MethodCallExpression;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.jetbrains.annotations.NotNull;
+import org.lwjgl.BufferUtils;
+import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL30;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+public class TextureDecorationProvider {
+
+    private final String cacheRoot = FileUtil.makePath(FileUtil.getMinecraftHome(), "cache", "groovy", "textureDecorations");
+
+    private final ASTContext context;
+
+    private final List<TextureDecoration> decorations = new ArrayList<>();
+    private final List<TextureDecorationInformation> decorationInformations = new ArrayList<>();
+
+    public TextureDecorationProvider(ASTContext context) {
+        this.context = context;
+    }
+
+    public CompletableFuture<List<TextureDecorationInformation>> provideTextureDecorations(TextDocumentIdentifier textDocument) {
+        for (ASTNode node : context.getVisitor().getNodes()) {
+            if (node instanceof MethodCallExpression expression && expression.getArguments() instanceof ArgumentListExpression args && !args.getExpressions().isEmpty()) {
+                var goh = GroovyASTUtils.getGohOfNode(expression, context);
+                if (goh == null) continue;
+
+                if (!args.getExpressions().stream().allMatch(e -> e instanceof ConstantExpression))
+                    continue;
+
+                var binder = goh.getTextureBinder();
+                if (binder == null) continue;
+
+                var additionalArgs = new Object[args.getExpressions().size() - 1];
+                for (int i = 0; i < additionalArgs.length; i++) {
+                    if (args.getExpressions().get(i + 1) instanceof ConstantExpression argExpression)
+                        additionalArgs[i] = argExpression.getValue();
+                }
+
+                var bindable = goh.doCall(args.getExpressions().get(0).getText(), additionalArgs);
+
+                if (bindable == null) continue;
+
+                var textureName = computeTextureName(goh.getName(), args.getExpressions());
+
+                var textureFile = FileUtil.makeFile(cacheRoot, textureName + ".png");
+
+                if (!textureFile.mkdirs() && textureFile.exists()) {
+                    decorationInformations.add(new TextureDecorationInformation(GroovyLSUtils.astNodeToRange(expression), textureFile.toURI().toString()));
+                    continue;
+                }
+
+                decorations.add(new TextureDecoration(textureName, binder, bindable, GroovyLSUtils.astNodeToRange(expression)));
+            }
+        }
+
+        if (decorations.isEmpty())
+            return CompletableFuture.completedFuture(decorationInformations);
+
+        var future = new CompletableFuture<List<TextureDecorationInformation>>();
+
+        Minecraft.getMinecraft()
+                .addScheduledTask(this::render)
+                .addListener(() -> future.complete(decorationInformations), Runnable::run);
+
+        return future;
+    }
+
+    private String computeTextureName(String name, List<Expression> expressions) {
+        var sb = new StringBuilder(name);
+        for (Expression expression : expressions) {
+            sb.append(expression.getText());
+        }
+        return DigestUtils.sha1Hex(sb.toString());
+    }
+
+    private void render() {
+        var framebuffer = GL30.glGenFramebuffers();
+        GL30.glBindFramebuffer(GL30.GL_FRAMEBUFFER, framebuffer);
+
+        var texture = GL11.glGenTextures();
+
+        GL11.glBindTexture(GL11.GL_TEXTURE_2D, texture);
+        GL11.glTexImage2D(GL11.GL_TEXTURE_2D, 0, GL11.GL_RGBA, 16, 16, 0, GL11.GL_RGBA, GL11.GL_UNSIGNED_BYTE, 0);
+
+        GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MIN_FILTER, GL11.GL_NEAREST);
+        GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MAG_FILTER, GL11.GL_NEAREST);
+
+        GL30.glFramebufferTexture2D(GL30.GL_FRAMEBUFFER, GL30.GL_COLOR_ATTACHMENT0, GL11.GL_TEXTURE_2D, texture, 0);
+
+        GL11.glViewport(0, 0, 16, 16);
+
+        var buffer = BufferUtils.createByteBuffer(16 * 16 * 3);
+
+        for (TextureDecoration decoration : decorations) {
+            GL11.glClear(GL11.GL_COLOR_BUFFER_BIT | GL11.GL_DEPTH_BUFFER_BIT);
+
+            decoration.render();
+
+            GL11.glReadPixels(0, 0, 16, 16, GL11.GL_RGB, GL11.GL_UNSIGNED_BYTE, buffer);
+
+            var image = new BufferedImage(16, 16, BufferedImage.TYPE_INT_RGB);
+            for (int y = 0; y < 16; y++) {
+                for (int x = 0; x < 16; x++) {
+                    int r = buffer.get() & 0xFF;
+                    int g = buffer.get() & 0xFF;
+                    int b = buffer.get() & 0xFF;
+                    int color = (r << 16) | (g << 8) | b;
+                    image.setRGB(x, 15 - y, color); // Flip the y-coordinate to correct the image orientation
+                }
+            }
+
+            try {
+                ImageIO.write(image, "PNG", decoration.getFile());
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+
+            decorationInformations.add(new TextureDecorationInformation(decoration.getRange(), decoration.getUri()));
+        }
+
+        GL30.glBindFramebuffer(GL30.GL_FRAMEBUFFER, 0);
+        GL11.glDeleteTextures(texture);
+        GL30.glDeleteFramebuffers(framebuffer);
+    }
+
+    private class TextureDecoration {
+
+        private final String name;
+        private final TextureBinder<?> binder;
+        private final Object bindable;
+        private final Range range;
+
+        private TextureDecoration(String name, TextureBinder<?> binder, Object bindable, Range range) {
+            this.name = name;
+            this.binder = binder;
+            this.bindable = bindable;
+            this.range = range;
+        }
+
+        public String getUri() {
+            return getFile().toURI().toString();
+        }
+
+        private @NotNull File getFile() {
+            return FileUtil.makeFile(cacheRoot, name + ".png");
+        }
+
+        public Range getRange() {
+            return range;
+        }
+
+        public void render() {
+            ((TextureBinder) binder).accept(bindable);
+        }
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/server/features/textureDecoration/TextureDecorationProvider.java
+++ b/src/main/java/com/cleanroommc/groovyscript/server/features/textureDecoration/TextureDecorationProvider.java
@@ -210,7 +210,7 @@ public class TextureDecorationProvider {
         }
 
         public String getUri() {
-            return "file://" + getFile().getAbsolutePath();
+            return getFile().toURI().toString();
         }
 
         private @NotNull File getFile() {

--- a/src/main/java/net/prominic/groovyls/GroovyLanguageServer.java
+++ b/src/main/java/net/prominic/groovyls/GroovyLanguageServer.java
@@ -32,17 +32,17 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 
-public class GroovyLanguageServer implements LanguageServer, LanguageClientAware {
+public class GroovyLanguageServer<T extends GroovyServices> implements LanguageServer, LanguageClientAware {
 
-    private final GroovyServices groovyServices;
+    protected final T groovyServices;
 
     public GroovyLanguageServer(ICompilationUnitFactory compilationUnitFactory, ILanguageServerContext languageServerContext) {
         this.groovyServices = createGroovyServices(compilationUnitFactory, languageServerContext);
     }
 
     @NotNull
-    protected GroovyServices createGroovyServices(ICompilationUnitFactory compilationUnitFactory, ILanguageServerContext languageServerContext) {
-        return new GroovyServices(compilationUnitFactory, languageServerContext);
+    protected T createGroovyServices(ICompilationUnitFactory compilationUnitFactory, ILanguageServerContext languageServerContext) {
+        return (T) new GroovyServices(compilationUnitFactory, languageServerContext);
     }
 
     @Override

--- a/src/main/java/net/prominic/groovyls/GroovyLanguageServer.java
+++ b/src/main/java/net/prominic/groovyls/GroovyLanguageServer.java
@@ -24,6 +24,7 @@ import net.prominic.groovyls.compiler.ILanguageServerContext;
 import net.prominic.groovyls.config.ICompilationUnitFactory;
 import org.eclipse.lsp4j.*;
 import org.eclipse.lsp4j.services.*;
+import org.jetbrains.annotations.NotNull;
 
 import java.net.URI;
 import java.nio.file.Path;
@@ -36,7 +37,12 @@ public class GroovyLanguageServer implements LanguageServer, LanguageClientAware
     private final GroovyServices groovyServices;
 
     public GroovyLanguageServer(ICompilationUnitFactory compilationUnitFactory, ILanguageServerContext languageServerContext) {
-        this.groovyServices = new GroovyServices(compilationUnitFactory, languageServerContext);
+        this.groovyServices = createGroovyServices(compilationUnitFactory, languageServerContext);
+    }
+
+    @NotNull
+    protected GroovyServices createGroovyServices(ICompilationUnitFactory compilationUnitFactory, ILanguageServerContext languageServerContext) {
+        return new GroovyServices(compilationUnitFactory, languageServerContext);
     }
 
     @Override

--- a/src/main/java/net/prominic/groovyls/GroovyServices.java
+++ b/src/main/java/net/prominic/groovyls/GroovyServices.java
@@ -61,9 +61,9 @@ public class GroovyServices implements TextDocumentService, WorkspaceService, La
 
     private LanguageClient languageClient;
 
-    private Path workspaceRoot;
-    private final ICompilationUnitFactory compilationUnitFactory;
-    private final ILanguageServerContext languageServerContext;
+    protected Path workspaceRoot;
+    protected final ICompilationUnitFactory compilationUnitFactory;
+    protected final ILanguageServerContext languageServerContext;
     private Map<URI, PublishDiagnosticsParams> prevDiagnosticsByFile;
 
     public GroovyServices(ICompilationUnitFactory factory, ILanguageServerContext languageServerContext) {
@@ -336,7 +336,8 @@ public class GroovyServices implements TextDocumentService, WorkspaceService, La
         return provider.provideRename(params);
     }
 
-    private @Nullable ASTNodeVisitor compileAndVisitAST(GroovyLSCompilationUnit compilationUnit, URI context) {
+    @Nullable
+    protected ASTNodeVisitor compileAndVisitAST(GroovyLSCompilationUnit compilationUnit, URI context) {
         try {
             return compilationUnit.recompileAndVisitASTIfContextChanged(context);
         } catch (GroovyBugError | Exception e) {

--- a/src/main/java/net/prominic/groovyls/compiler/util/GroovyASTUtils.java
+++ b/src/main/java/net/prominic/groovyls/compiler/util/GroovyASTUtils.java
@@ -268,7 +268,7 @@ public class GroovyASTUtils {
         } else if (node instanceof ConstructorCallExpression expression) {
             return expression.getType();
         } else if (node instanceof MethodCallExpression expression) {
-            ObjectMapper<?> goh = getGohOfNode(expression, context);
+            ObjectMapper<?> goh = getMapperOfNode(expression, context);
             if (goh != null) {
                 return ClassHelper.makeCached(goh.getReturnType());
             }
@@ -450,7 +450,7 @@ public class GroovyASTUtils {
         return method;
     }
 
-    public static ObjectMapper<?> getGohOfNode(MethodCallExpression expr, ASTContext context) {
+    public static ObjectMapper<?> getMapperOfNode(MethodCallExpression expr, ASTContext context) {
         if (expr.isImplicitThis()) {
             return ObjectMapperManager.getObjectMapper(expr.getMethodAsString());
         }

--- a/src/main/java/net/prominic/groovyls/providers/CompletionProvider.java
+++ b/src/main/java/net/prominic/groovyls/providers/CompletionProvider.java
@@ -20,7 +20,6 @@
 package net.prominic.groovyls.providers;
 
 import com.cleanroommc.groovyscript.mapper.ObjectMapper;
-import com.cleanroommc.groovyscript.mapper.ObjectMapperManager;
 import com.cleanroommc.groovyscript.server.Completions;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
@@ -124,7 +123,7 @@ public class CompletionProvider extends DocProvider {
             if (parentParent instanceof MethodCallExpression expr &&
                     expr.getArguments() instanceof ArgumentListExpression args &&
                     !args.getExpressions().isEmpty()) {
-                ObjectMapper<?> goh = GroovyASTUtils.getGohOfNode(expr, astContext);
+                ObjectMapper<?> goh = GroovyASTUtils.getMapperOfNode(expr, astContext);
                 if (goh != null && goh.getCompleter() != null) {
                     int index = -1;
                     for (int i = 0; i < args.getExpressions().size(); i++) {

--- a/src/main/java/net/prominic/groovyls/providers/DocProvider.java
+++ b/src/main/java/net/prominic/groovyls/providers/DocProvider.java
@@ -1,9 +1,11 @@
 package net.prominic.groovyls.providers;
 
 import net.prominic.groovyls.compiler.ast.ASTContext;
+import org.codehaus.groovy.ast.ASTNode;
 import org.codehaus.groovy.ast.ModuleNode;
 
 import java.net.URI;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 public abstract class DocProvider {
@@ -18,6 +20,10 @@ public abstract class DocProvider {
 
     public ModuleNode getModule() {
         return astContext.getVisitor().getModule(doc);
+    }
+
+    public List<ASTNode> getNodes() {
+        return astContext.getVisitor().getNodes(doc);
     }
 
     public <T> CompletableFuture<T> future(T t) {

--- a/src/main/java/net/prominic/groovyls/util/GroovyLSUtils.java
+++ b/src/main/java/net/prominic/groovyls/util/GroovyLSUtils.java
@@ -59,6 +59,10 @@ public class GroovyLSUtils {
         return rangeOf(node.getLineNumber(), node.getColumnNumber(), node.getLastLineNumber(), node.getLastColumnNumber());
     }
 
+    public static Range astNodeToRange(ASTNode start, ASTNode end) {
+        return rangeOf(start.getLineNumber(), start.getColumnNumber(), end.getLastLineNumber(), end.getLastColumnNumber());
+    }
+
     public static CompletionItemKind astNodeToCompletionItemKind(ASTNode node) {
         if (node instanceof ClassNode classNode) {
             if (classNode.isInterface()) {


### PR DESCRIPTION
This pr adds handy inline icons for some of object mappers when editing in vsc with grs extension.

However there is a few limitations:

- only works on client due to dependency on lwjgl
- does not take into account subsequent mutations on object mapper result e.g nbt
- only works with constant values like `item('minecraft:stone')`
- only shows first matched value e.g ore dictionary
- does not work if mod is not installed (obviously)
- won't work with other language clients without modifications to them e.g nvim (feature is implemented through custom capability)
- won't work for all object mappers by default (requires to implement mapper specific texture binder)
- won't update rendered texture if it changes ahead of cached state

 adds a new api to allow future extension of list of supported mappers 

- new interface `TextureBinder` - inheritor of Consumer 
- new object mapper builder method `textureBinder` -  provides support for inline icon per mapper 
- some generic implementations of texture binder for itemstack, texture atlas, map like method to delegate binding functionality to a different type of texture binder implementation