### PR TITLE
fix odd validate calls

### DIFF
--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/Apothecary.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/Apothecary.java
@@ -117,7 +117,7 @@ public class Apothecary extends VirtualizedRegistry<RecipePetals> {
 
         @Override
         public void validate(GroovyLog.Msg msg) {
-            validateFluids(msg, 0, 0, 0, 0);
+            validateFluids(msg);
             validateItems(msg, 1, 20, 1, 1);
         }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/Brew.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/Brew.java
@@ -162,8 +162,8 @@ public class Brew extends VirtualizedRegistry<vazkii.botania.api.brew.Brew> {
 
         @Override
         public void validate(GroovyLog.Msg msg) {
-            validateItems(msg, 0, 0, 0, 0);
-            validateFluids(msg, 0, 0, 0, 0);
+            validateItems(msg);
+            validateFluids(msg);
             msg.add(key == null, "key must be defined");
             msg.add(BotaniaAPI.brewMap.containsKey(key), "must have a unique key for brew, got " + key);
             msg.add(cost < 1, "cost must be at least 1, got " + cost);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/ElvenTrade.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/ElvenTrade.java
@@ -124,7 +124,7 @@ public class ElvenTrade extends VirtualizedRegistry<RecipeElvenTrade> {
 
         @Override
         public void validate(GroovyLog.Msg msg) {
-            validateFluids(msg, 0, 0, 0, 0);
+            validateFluids(msg);
             validateItems(msg, 1, 99, 1, 99);
         }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/Lexicon.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/Lexicon.java
@@ -418,8 +418,8 @@ public class Lexicon {
 
             @Override
             public void validate(GroovyLog.Msg msg) {
-                validateFluids(msg, 0, 0, 0, 0);
-                validateItems(msg, 0, 0, 0, 0);
+                validateFluids(msg);
+                validateItems(msg);
                 msg.add(name == null, "expected a valid name, got " + name);
                 msg.add(pages.size() < 1, "entry must have at least 1 page, got " + pages.size());
                 msg.add(category == null, "expected a valid category, got " + category);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/ManaInfusion.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/ManaInfusion.java
@@ -144,7 +144,7 @@ public class ManaInfusion extends VirtualizedRegistry<RecipeManaInfusion> {
 
         @Override
         public void validate(GroovyLog.Msg msg) {
-            validateFluids(msg, 0, 0, 0, 0);
+            validateFluids(msg);
             validateItems(msg, 1, 1, 1, 1);
             msg.add(mana < 1, "Mana amount must be at least 1, got " + mana);
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/PureDaisy.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/PureDaisy.java
@@ -166,8 +166,8 @@ public class PureDaisy extends VirtualizedRegistry<RecipePureDaisy> {
 
         @Override
         public void validate(GroovyLog.Msg msg) {
-            validateItems(msg, 0, 0, 0, 0);
-            validateFluids(msg, 0, 0, 0, 0);
+            validateItems(msg);
+            validateFluids(msg);
             msg.add(time < 0, "time must be at least 1, got " + time);
             msg.add(output == null, "output must be defined");
             msg.add(input == null || !(input instanceof String || input instanceof IBlockState), "expected IBlockState or String input, got {}", input);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/RuneAltar.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/RuneAltar.java
@@ -121,7 +121,7 @@ public class RuneAltar extends VirtualizedRegistry<RecipeRuneAltar> {
 
         @Override
         public void validate(GroovyLog.Msg msg) {
-            validateFluids(msg, 0, 0, 0, 0);
+            validateFluids(msg);
             validateItems(msg, 1, 20, 1, 1);
             msg.add(input.stream().anyMatch(x -> x.test(new ItemStack(Item.getItemFromBlock(ModBlocks.livingrock), 1, 0))),
                     "input cannot contain a livingrock item");

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/forestry/Centrifuge.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/forestry/Centrifuge.java
@@ -112,7 +112,7 @@ public class Centrifuge extends ForestryRegistry<ICentrifugeRecipe> {
 
         @Override
         public void validate(GroovyLog.Msg msg) {
-            validateFluids(msg, 0, 0, 0, 0);
+            validateFluids(msg);
             validateItems(msg, 1, 1, 0, 0);
             msg.add(outputs.isEmpty() || outputs.size() > 9, "Must have 1 - 9 outputs. got {}.", outputs.size());
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/forestry/Moistener.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/forestry/Moistener.java
@@ -94,7 +94,7 @@ public class Moistener extends ForestryRegistry<IMoistenerRecipe> {
 
         @Override
         public void validate(GroovyLog.Msg msg) {
-            validateFluids(msg, 0, 0, 0, 0);
+            validateFluids(msg);
             validateItems(msg, 1, 1, 1, 1);
         }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/forestry/Still.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/forestry/Still.java
@@ -93,7 +93,7 @@ public class Still extends ForestryRegistry<IStillRecipe> {
 
         @Override
         public void validate(GroovyLog.Msg msg) {
-            validateItems(msg, 0, 0, 0, 0);
+            validateItems(msg);
             validateFluids(msg, 1, 1, 1, 1);
         }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/recipe/GasRecipeBuilder.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/recipe/GasRecipeBuilder.java
@@ -63,8 +63,8 @@ public abstract class GasRecipeBuilder<T> extends AbstractRecipeBuilder<T> {
     public void validateGases(GroovyLog.Msg msg, int minInput, int maxInput, int minOutput, int maxOutput) {
         gasInput.trim();
         gasOutput.trim();
-        msg.add(gasInput.size() < minInput || gasInput.size() > maxInput, () -> getRequiredString(minInput, maxInput, "gas input") + ", but found " + gasInput.size());
-        msg.add(gasOutput.size() < minOutput || gasOutput.size() > maxOutput, () -> getRequiredString(minOutput, maxOutput, "gas output") + ", but found " + gasOutput.size());
+        validateCustom(msg, gasInput, minInput, maxInput, "gas input");
+        validateCustom(msg, gasOutput, minOutput, maxOutput, "gas output");
     }
 
     public void validateGases(GroovyLog.Msg msg) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/recipe/GasRecipeBuilder.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/recipe/GasRecipeBuilder.java
@@ -68,7 +68,7 @@ public abstract class GasRecipeBuilder<T> extends AbstractRecipeBuilder<T> {
     }
 
     public void validateGases(GroovyLog.Msg msg) {
-        validateItems(msg, 0, 0, 0, 0);
+        validateGases(msg, 0, 0, 0, 0);
     }
 
 }


### PR DESCRIPTION
changes in this PR:
- since `validate[x](msg)` calls `validate[x](msg, 0, 0, 0, 0)` there is no reason to explicitly use the latter. converted those references to the former in a handful of places.
- fixes `validateGases(msg)` calling `validateItems(msg, 0, 0, 0, 0)` instead of `validateGases(msg, 0, 0, 0, 0)`. shouldnt impact anything, since `validateGases(msg)` isnt used in the main mod currently.
- makes `validateGases` call `validateCustom` for input and output to unify the method used.