### PR TITLE
cant download, wont use

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -30,10 +30,7 @@ final def mod_dependencies = [
         'actually-additions-228404:3117927'                   : [project.debug_actually_additions],
         'advancedmortars-283777:2780626'                      : [project.debug_adv_mortars],
         'advanced-rocketry-236542:4671856'                    : [project.debug_advanced_rocketry],
-        'advanced-rocketry-2-1024225:5486514'                 : [project.debug_advanced_rocketry_2],
-        // libAR is equivalent to libvulpes
         'libvulpes-236541:3801015'                            : [project.debug_advanced_rocketry],
-        'library-for-ar-reworked-1038780:5446535'             : [project.debug_advanced_rocketry_2],
         'aether-255308:3280119'                               : [project.debug_aether],
         'alchemistry-293425:3186612'                          : [project.debug_alchemistry],
         'alchemylib-293426:2761706'                           : [project.debug_alchemistry],

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,9 +14,7 @@ debug_generate_and_crash = false
 
 debug_actually_additions = false
 debug_adv_mortars = false
-# both versions of advanced rocketry claim to be API compatible, this is included to make testing easier
 debug_advanced_rocketry = false
-debug_advanced_rocketry_2 = false
 debug_aether = false
 debug_alchemistry = false
 debug_applied_energistics_2 = false


### PR DESCRIPTION
changes in this PR:
- since Advanced Rocketry 2 restricts downloads for third parties (a recent change), we cant have it as a dependency. gootbye 