### PR TITLE
fix infusion type info handler being incorrect

### DIFF
--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Mekanism.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/Mekanism.java
@@ -63,7 +63,7 @@ public class Mekanism extends GroovyPropertyContainer {
 
     @Optional.Method(modid = "mekanism")
     public static String asGroovyCode(InfuseType infuseType, boolean colored) {
-        return GroovyScriptCodeConverter.formatGenericHandler("infusionType", infuseType.unlocalizedName, colored);
+        return GroovyScriptCodeConverter.formatGenericHandler("infusionType", infuseType.name, colored);
     }
 
     @Optional.Method(modid = "mekanism")


### PR DESCRIPTION
changes in this PR:
- when converting the Mekanism Infusion Type to the GroovyScript Object Mapper version for information reasons, it uses `unlocalizedName` instead of `name`. this makes it incorrect, it is stored based on the name of the Infusion Type.