### PR TITLE
Convert a handful of javax annotations to jetbrains

### DIFF
--- a/src/main/java/com/cleanroommc/groovyscript/command/BaseInfoCommand.java
+++ b/src/main/java/com/cleanroommc/groovyscript/command/BaseInfoCommand.java
@@ -20,8 +20,8 @@ import net.minecraft.util.text.TextComponentString;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.common.MinecraftForge;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;

--- a/src/main/java/com/cleanroommc/groovyscript/command/GSCommand.java
+++ b/src/main/java/com/cleanroommc/groovyscript/command/GSCommand.java
@@ -21,7 +21,6 @@ import net.minecraft.util.text.event.HoverEvent;
 import net.minecraftforge.server.command.CommandTreeBase;
 import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.io.File;
 import java.util.Arrays;
 import java.util.List;
@@ -120,19 +119,19 @@ public class GSCommand extends CommandTreeBase {
     }
 
     @Override
-    @Nonnull
+    @NotNull
     public String getName() {
         return "groovyscript";
     }
 
     @Override
-    @Nonnull
+    @NotNull
     public List<String> getAliases() {
         return Arrays.asList("grs", "GroovyScript", "gs");
     }
 
     @Override
-    @Nonnull
+    @NotNull
     public String getUsage(@NotNull ICommandSender sender) {
         return "/grs []";
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/advancedrocketry/BaseRegistry.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/advancedrocketry/BaseRegistry.java
@@ -10,12 +10,12 @@ import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
 import com.cleanroommc.groovyscript.registry.StandardListRegistry;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import zmaster587.libVulpes.interfaces.IRecipe;
 import zmaster587.libVulpes.recipe.RecipesMachine;
 import zmaster587.libVulpes.tile.multiblock.TileMultiblockMachine;
 
-import javax.annotation.Nonnull;
 import java.util.*;
 
 public abstract class BaseRegistry extends StandardListRegistry<IRecipe> {
@@ -23,7 +23,7 @@ public abstract class BaseRegistry extends StandardListRegistry<IRecipe> {
     protected abstract Class<?> getMachineClass();
 
     @Override
-    @Nonnull
+    @NotNull
     @SuppressWarnings("unchecked")
     public Collection<IRecipe> getRecipes() {
         Class<?> clazz = getMachineClass();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/LightTransmutation.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/LightTransmutation.java
@@ -11,8 +11,8 @@ import hellfirepvp.astralsorcery.common.constellation.IWeakConstellation;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.item.ItemStack;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.Collection;
 
 @RegistryDescription
@@ -34,7 +34,7 @@ public class LightTransmutation extends StandardListRegistry<LightOreTransmutati
     }
 
     public LightOreTransmutations.Transmutation add(Block input, IBlockState output,
-                                                    @Nonnull ItemStack inputDisplay, @Nonnull ItemStack outputDisplay, double cost) {
+                                                    @NotNull ItemStack inputDisplay, @NotNull ItemStack outputDisplay, double cost) {
         LightOreTransmutations.Transmutation recipe = new LightOreTransmutations.Transmutation(input, output, inputDisplay, outputDisplay, cost);
         addScripted(recipe);
         getRecipes().add(recipe);
@@ -42,7 +42,7 @@ public class LightTransmutation extends StandardListRegistry<LightOreTransmutati
     }
 
     public LightOreTransmutations.Transmutation add(IBlockState input, IBlockState output,
-                                                    @Nonnull ItemStack inputDisplay, @Nonnull ItemStack outputDisplay, double cost) {
+                                                    @NotNull ItemStack inputDisplay, @NotNull ItemStack outputDisplay, double cost) {
         LightOreTransmutations.Transmutation recipe = new LightOreTransmutations.Transmutation(input, output, inputDisplay, outputDisplay, cost);
         addScripted(recipe);
         getRecipes().add(recipe);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/Knowledge.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/Knowledge.java
@@ -6,10 +6,9 @@ import com.cleanroommc.groovyscript.api.documentation.annotations.RegistryDescri
 import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
 import net.minecraft.util.text.TextFormatting;
+import org.jetbrains.annotations.Nullable;
 import vazkii.botania.api.BotaniaAPI;
 import vazkii.botania.api.lexicon.KnowledgeType;
-
-import javax.annotation.Nullable;
 
 @RegistryDescription(
         category = RegistryDescription.Category.ENTRIES,

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/recipe/CustomEnchanterRecipe.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/recipe/CustomEnchanterRecipe.java
@@ -11,8 +11,6 @@ import net.minecraft.enchantment.Enchantment;
 import net.minecraft.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
-
 public class CustomEnchanterRecipe extends EnchanterRecipe {
 
     private final Things lapis;
@@ -37,7 +35,7 @@ public class CustomEnchanterRecipe extends EnchanterRecipe {
     }
 
     @Override
-    public boolean isRecipe(@Nonnull RecipeLevel machineLevel, @Nonnull NNList<MachineRecipeInput> inputs) {
+    public boolean isRecipe(@NotNull RecipeLevel machineLevel, @NotNull NNList<MachineRecipeInput> inputs) {
         ItemStack slot0 = MachineRecipeInput.getInputForSlot(0, inputs);
         ItemStack slot1 = MachineRecipeInput.getInputForSlot(1, inputs);
         ItemStack slot2 = MachineRecipeInput.getInputForSlot(2, inputs);
@@ -59,7 +57,7 @@ public class CustomEnchanterRecipe extends EnchanterRecipe {
     }
 
     @Override
-    public boolean isValidInput(@Nonnull RecipeLevel machineLevel, @Nonnull MachineRecipeInput inputs) {
+    public boolean isValidInput(@NotNull RecipeLevel machineLevel, @NotNull MachineRecipeInput inputs) {
         ItemStack slot0 = MachineRecipeInput.getInputForSlot(0, inputs);
         ItemStack slot1 = MachineRecipeInput.getInputForSlot(1, inputs);
         ItemStack slot2 = MachineRecipeInput.getInputForSlot(2, inputs);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/recipe/RecipeInput.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/recipe/RecipeInput.java
@@ -6,8 +6,7 @@ import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
 import crazypants.enderio.base.recipe.IRecipeInput;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class RecipeInput implements IRecipeInput {
 
@@ -26,7 +25,7 @@ public class RecipeInput implements IRecipeInput {
         }
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public IRecipeInput copy() {
         return new RecipeInput(ing);
@@ -37,7 +36,7 @@ public class RecipeInput implements IRecipeInput {
         return ing instanceof FluidStack;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public ItemStack getInput() {
         return ing.getMatchingStacks().length == 0 ? ItemStack.EMPTY : ing.getMatchingStacks()[0].copy();
@@ -59,7 +58,7 @@ public class RecipeInput implements IRecipeInput {
     }
 
     @Override
-    public boolean isInput(@Nonnull ItemStack test) {
+    public boolean isInput(@NotNull ItemStack test) {
         return ing.test(test);
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/forestry/BeeMutations.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/forestry/BeeMutations.java
@@ -13,8 +13,8 @@ import forestry.api.genetics.IMutationBuilder;
 import forestry.apiculture.genetics.BeeMutation;
 import forestry.apiculture.genetics.alleles.AlleleBeeSpecies;
 import forestry.modules.ForestryModuleUids;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.function.Function;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/ArcFurnace.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/ArcFurnace.java
@@ -10,9 +10,9 @@ import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
 import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
 import com.cleanroommc.groovyscript.registry.StandardListRegistry;
 import net.minecraft.item.ItemStack;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -33,7 +33,7 @@ public class ArcFurnace extends StandardListRegistry<ArcFurnaceRecipe> {
     }
 
     @MethodDescription(type = MethodDescription.Type.ADDITION)
-    public ArcFurnaceRecipe add(ItemStack output, IIngredient input, List<IIngredient> additives, @Nonnull ItemStack slag, int time, int energyPerTick) {
+    public ArcFurnaceRecipe add(ItemStack output, IIngredient input, List<IIngredient> additives, @NotNull ItemStack slag, int time, int energyPerTick) {
         Object[] inputs = ArrayUtils.mapToArray(additives, ImmersiveEngineering::toIngredientStack);
         ArcFurnaceRecipe recipe = ArcFurnaceRecipe.addRecipe(output, ImmersiveEngineering.toIngredientStack(input), slag, time, energyPerTick, inputs);
         addScripted(recipe);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/BlastFurnace.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/BlastFurnace.java
@@ -9,9 +9,9 @@ import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
 import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
 import com.cleanroommc.groovyscript.registry.StandardListRegistry;
 import net.minecraft.item.ItemStack;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.List;
 
@@ -29,7 +29,7 @@ public class BlastFurnace extends StandardListRegistry<BlastFurnaceRecipe> {
     }
 
     @MethodDescription(type = MethodDescription.Type.ADDITION)
-    public BlastFurnaceRecipe add(ItemStack output, IIngredient input, int time, @Nonnull ItemStack slag) {
+    public BlastFurnaceRecipe add(ItemStack output, IIngredient input, int time, @NotNull ItemStack slag) {
         BlastFurnaceRecipe recipe = new BlastFurnaceRecipe(output.copy(), ImmersiveEngineering.toIEInput(input), time, IngredientHelper.copy(slag));
         add(recipe);
         return recipe;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/Fermenter.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/Fermenter.java
@@ -10,9 +10,9 @@ import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
 import com.cleanroommc.groovyscript.registry.StandardListRegistry;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
 import java.util.Collection;
 
 @RegistryDescription
@@ -29,7 +29,7 @@ public class Fermenter extends StandardListRegistry<FermenterRecipe> {
     }
 
     @MethodDescription(type = MethodDescription.Type.ADDITION)
-    public FermenterRecipe add(FluidStack fluidOutput, @Nonnull ItemStack itemOutput, IIngredient input, int energy) {
+    public FermenterRecipe add(FluidStack fluidOutput, @NotNull ItemStack itemOutput, IIngredient input, int energy) {
         FermenterRecipe recipe = new FermenterRecipe(fluidOutput.copy(), itemOutput.copy(), ImmersiveEngineering.toIngredientStack(input), energy);
         add(recipe);
         return recipe;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/Squeezer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/Squeezer.java
@@ -10,9 +10,9 @@ import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
 import com.cleanroommc.groovyscript.registry.StandardListRegistry;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -35,7 +35,7 @@ public class Squeezer extends StandardListRegistry<SqueezerRecipe> {
     }
 
     @MethodDescription(type = MethodDescription.Type.ADDITION)
-    public SqueezerRecipe add(FluidStack fluidOutput, @Nonnull ItemStack itemOutput, IIngredient input, int energy) {
+    public SqueezerRecipe add(FluidStack fluidOutput, @NotNull ItemStack itemOutput, IIngredient input, int energy) {
         SqueezerRecipe recipe = new SqueezerRecipe(fluidOutput, itemOutput, ImmersiveEngineering.toIngredientStack(input), energy);
         add(recipe);
         return recipe;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/rustic/CondenserRecipe.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/rustic/CondenserRecipe.java
@@ -6,9 +6,9 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
+import org.jetbrains.annotations.NotNull;
 import rustic.common.crafting.ICondenserRecipe;
 
-import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -27,29 +27,29 @@ public class CondenserRecipe implements ICondenserRecipe {
     private final IIngredient modifier;
     private final List<IIngredient> inputs;
 
-    public CondenserRecipe(@Nonnull ItemStack output, List<IIngredient> inputs) {
+    public CondenserRecipe(@NotNull ItemStack output, List<IIngredient> inputs) {
         this(output, inputs, null);
     }
 
-    public CondenserRecipe(@Nonnull ItemStack output, List<IIngredient> inputs, IIngredient modifier) {
+    public CondenserRecipe(@NotNull ItemStack output, List<IIngredient> inputs, IIngredient modifier) {
         this(output, inputs, modifier, (IIngredient) (Object) new ItemStack(Items.GLASS_BOTTLE));
     }
 
-    public CondenserRecipe(@Nonnull ItemStack output, List<IIngredient> inputs, IIngredient modifier, IIngredient bottle) {
+    public CondenserRecipe(@NotNull ItemStack output, List<IIngredient> inputs, IIngredient modifier, IIngredient bottle) {
         this(output, inputs, modifier, bottle, new FluidStack(FluidRegistry.WATER, 125));
     }
 
-    public CondenserRecipe(@Nonnull ItemStack output, List<IIngredient> inputs, IIngredient modifier, IIngredient bottle, @Nonnull FluidStack fluid) {
+    public CondenserRecipe(@NotNull ItemStack output, List<IIngredient> inputs, IIngredient modifier, IIngredient bottle, @NotNull FluidStack fluid) {
         this(output, inputs, modifier, bottle, fluid, 400);
     }
 
-    public CondenserRecipe(@Nonnull ItemStack output, List<IIngredient> inputs, IIngredient modifier, IIngredient bottle, @Nonnull FluidStack fluid, int time) {
+    public CondenserRecipe(@NotNull ItemStack output, List<IIngredient> inputs, IIngredient modifier, IIngredient bottle, @NotNull FluidStack fluid, int time) {
         this(output, inputs, modifier, bottle, fluid, time, modifier == null && inputs.size() <= 2);
     }
 
     public CondenserRecipe(
-            @Nonnull ItemStack output, List<IIngredient> inputs, IIngredient modifier, IIngredient bottle,
-            @Nonnull FluidStack fluid, int time, boolean advanced) {
+            @NotNull ItemStack output, List<IIngredient> inputs, IIngredient modifier, IIngredient bottle,
+            @NotNull FluidStack fluid, int time, boolean advanced) {
         this.output = output;
         this.fluid = fluid;
         this.bottle = bottle;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/tinkersconstruct/material/ToolMaterialBuilder.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/tinkersconstruct/material/ToolMaterialBuilder.java
@@ -9,11 +9,11 @@ import com.cleanroommc.groovyscript.api.IIngredient;
 import com.cleanroommc.groovyscript.helper.ingredient.OreDictIngredient;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fml.common.Loader;
+import org.jetbrains.annotations.Nullable;
 import slimeknights.tconstruct.library.TinkerRegistry;
 import slimeknights.tconstruct.library.materials.*;
 import slimeknights.tconstruct.library.traits.ITrait;
 
-import javax.annotation.Nullable;
 import java.awt.*;
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/src/main/java/com/cleanroommc/groovyscript/core/GroovyScriptCore.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/GroovyScriptCore.java
@@ -3,9 +3,9 @@ package com.cleanroommc.groovyscript.core;
 import com.google.common.collect.ImmutableList;
 import net.minecraftforge.common.ForgeVersion;
 import net.minecraftforge.fml.relauncher.IFMLLoadingPlugin;
+import org.jetbrains.annotations.Nullable;
 import zone.rong.mixinbooter.IEarlyMixinLoader;
 
-import javax.annotation.Nullable;
 import java.io.File;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/thermalexpansion/CentrifugeRecipeAccessor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/thermalexpansion/CentrifugeRecipeAccessor.java
@@ -3,10 +3,10 @@ package com.cleanroommc.groovyscript.core.mixin.thermalexpansion;
 import cofh.thermalexpansion.util.managers.machine.CentrifugeManager;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Invoker;
 
-import javax.annotation.Nullable;
 import java.util.List;
 
 @Mixin(value = CentrifugeManager.CentrifugeRecipe.class, remap = false)

--- a/src/main/java/com/cleanroommc/groovyscript/registry/DummyRecipe.java
+++ b/src/main/java/com/cleanroommc/groovyscript/registry/DummyRecipe.java
@@ -5,19 +5,18 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.world.World;
 import net.minecraftforge.registries.IForgeRegistryEntry;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class DummyRecipe extends IForgeRegistryEntry.Impl<IRecipe> implements IRecipe {
 
     @Override
-    public boolean matches(@Nonnull final InventoryCrafting inv, @Nonnull final World worldIn) {
+    public boolean matches(@NotNull final InventoryCrafting inv, @NotNull final World worldIn) {
         return false;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public ItemStack getCraftingResult(@Nonnull final InventoryCrafting inv) {
+    public ItemStack getCraftingResult(@NotNull final InventoryCrafting inv) {
         return ItemStack.EMPTY;
     }
 
@@ -26,7 +25,7 @@ public class DummyRecipe extends IForgeRegistryEntry.Impl<IRecipe> implements IR
         return false;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public ItemStack getRecipeOutput() {
         return ItemStack.EMPTY;


### PR DESCRIPTION
changes in this PR:
- convert the locations in which `javax.annotation.Nullable` or `javax.annotation.Nonnull` are used instead of `org.jetbrains.annotations.Nullable` or `org.jetbrains.annotations.NotNull` to be the jetbrains version.