### PR TITLE
More defaultValues for Object Mappers

### DIFF
--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/appliedenergistics2/AppliedEnergistics2.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/appliedenergistics2/AppliedEnergistics2.java
@@ -27,6 +27,7 @@ public class AppliedEnergistics2 extends GroovyPropertyContainer {
         container.objectMapperBuilder("tunnel", TunnelType.class)
                 .parser(IObjectParser.wrapEnum(TunnelType.class, false))
                 .completerOfNamed(() -> Arrays.asList(TunnelType.values()), v -> v.name().toUpperCase(Locale.ROOT))
+                .defaultValue(() -> TunnelType.ME)
                 .docOfType("P2P tunnel type")
                 .register();
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/ThermalExpansion.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/ThermalExpansion.java
@@ -1,5 +1,6 @@
 package com.cleanroommc.groovyscript.compat.mods.thermalexpansion;
 
+import appeng.api.config.TunnelType;
 import com.cleanroommc.groovyscript.compat.mods.GroovyPropertyContainer;
 import cofh.thermalexpansion.util.managers.machine.CompactorManager;
 import com.cleanroommc.groovyscript.api.IObjectParser;
@@ -51,9 +52,8 @@ public class ThermalExpansion extends GroovyPropertyContainer {
     public final XpCollector xpCollector = new XpCollector();
 
     @Override
-    public void initialize(GroovyContainer<?> owner) {
-        ObjectMapper.builder("compactorMode", CompactorManager.Mode.class)
-                .mod("thermalexpansion")
+    public void initialize(GroovyContainer<?> container) {
+        container.objectMapperBuilder("compactorMode", CompactorManager.Mode.class)
                 .parser(IObjectParser.wrapEnum(CompactorManager.Mode.class, false))
                 .completerOfNamed(() -> Arrays.asList(CompactorManager.Mode.values()), v -> v.name().toUpperCase(Locale.ROOT))
                 .defaultValue(() -> CompactorManager.Mode.ALL)

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/ThermalExpansion.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/ThermalExpansion.java
@@ -56,6 +56,7 @@ public class ThermalExpansion extends GroovyPropertyContainer {
                 .mod("thermalexpansion")
                 .parser(IObjectParser.wrapEnum(CompactorManager.Mode.class, false))
                 .completerOfNamed(() -> Arrays.asList(CompactorManager.Mode.values()), v -> v.name().toUpperCase(Locale.ROOT))
+                .defaultValue(() -> CompactorManager.Mode.ALL)
                 .register();
     }
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/ThermalExpansion.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/ThermalExpansion.java
@@ -1,14 +1,12 @@
 package com.cleanroommc.groovyscript.compat.mods.thermalexpansion;
 
-import appeng.api.config.TunnelType;
-import com.cleanroommc.groovyscript.compat.mods.GroovyPropertyContainer;
 import cofh.thermalexpansion.util.managers.machine.CompactorManager;
 import com.cleanroommc.groovyscript.api.IObjectParser;
 import com.cleanroommc.groovyscript.compat.mods.GroovyContainer;
+import com.cleanroommc.groovyscript.compat.mods.GroovyPropertyContainer;
 import com.cleanroommc.groovyscript.compat.mods.thermalexpansion.device.*;
 import com.cleanroommc.groovyscript.compat.mods.thermalexpansion.dynamo.*;
 import com.cleanroommc.groovyscript.compat.mods.thermalexpansion.machine.*;
-import com.cleanroommc.groovyscript.mapper.ObjectMapper;
 
 import java.util.Arrays;
 import java.util.Locale;

--- a/src/main/java/com/cleanroommc/groovyscript/mapper/ObjectMapperManager.java
+++ b/src/main/java/com/cleanroommc/groovyscript/mapper/ObjectMapperManager.java
@@ -18,6 +18,7 @@ import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.enchantment.Enchantment;
+import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.potion.Potion;
@@ -105,6 +106,7 @@ public class ObjectMapperManager {
         ObjectMapper.builder("block", Block.class)
                 .parser(IObjectParser.wrapForgeRegistry(ForgeRegistries.BLOCKS))
                 .completer(ForgeRegistries.BLOCKS)
+                .defaultValue(() -> Blocks.AIR)
                 .docOfType("block")
                 .register();
         ObjectMapper.builder("blockstate", IBlockState.class)
@@ -113,6 +115,7 @@ public class ObjectMapperManager {
                 .addSignature(String.class, int.class)
                 .addSignature(String.class, String[].class)
                 .completer(ForgeRegistries.BLOCKS)
+                .defaultValue(() -> Blocks.AIR.getBlockState().getBaseState())
                 .docOfType("block state")
                 .register();
         ObjectMapper.builder("enchantment", Enchantment.class)
@@ -174,15 +177,18 @@ public class ObjectMapperManager {
         ObjectMapper.builder("creativeTab", CreativeTabs.class)
                 .parser(ObjectMappers::parseCreativeTab)
                 .completerOfNamed(() -> Arrays.asList(CreativeTabs.CREATIVE_TAB_ARRAY), v -> ((CreativeTabsAccessor) v).getTabLabel2())
+                .defaultValue(() -> CreativeTabs.SEARCH)
                 .docOfType("creative tab")
                 .register();
         ObjectMapper.builder("textformat", TextFormatting.class)
                 .parser(ObjectMappers::parseTextFormatting)
                 .completerOfNamed(() -> Arrays.asList(TextFormatting.values()), format -> format.name().toLowerCase(Locale.ROOT).replaceAll("[^a-z]", ""))
+                .defaultValue(() -> TextFormatting.RESET)
                 .docOfType("text format")
                 .register();
         ObjectMapper.builder("nbt", NBTTagCompound.class)
                 .parser(ObjectMappers::parseNBT)
+                .defaultValue(NBTTagCompound::new)
                 .docOfType("nbt tag")
                 .register();
     }


### PR DESCRIPTION
changes in this PR:
- add more default values to Object Mappers, specifically Thermal Expansion `compactorMode`, Applied Energistics 2 `tunnel`, and Vanilla `block`, `blockstate`, `creativeTab`, `textformat`, and `nbt`.
- convert Thermal Expansion `compactorMode` Object Mapper to use the `GroovyContainer<?>` argument passed in, as all other mods do.