### PR TITLE
Astral Sorcery Starmetal Conversion

### DIFF
--- a/examples/postInit/astralsorcery.groovy
+++ b/examples/postInit/astralsorcery.groovy
@@ -151,6 +151,8 @@ mods.astralsorcery.light_transmutation.recipeBuilder()
     .register()
 
 
+mods.astralsorcery.light_transmutation.setStarmetalReplacementState(blockstate('minecraft:clay'))
+
 // Lightwell:
 // Converts an input item into fluid, with a chance at breaking every time fluid is produced. The amount of fluid produced
 // per interval can be increased via starlight.

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/LightTransmutation.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/LightTransmutation.java
@@ -1,5 +1,6 @@
 package com.cleanroommc.groovyscript.compat.mods.astralsorcery;
 
+import com.cleanroommc.groovyscript.api.GroovyBlacklist;
 import com.cleanroommc.groovyscript.api.GroovyLog;
 import com.cleanroommc.groovyscript.api.documentation.annotations.*;
 import com.cleanroommc.groovyscript.compat.mods.ModSupport;
@@ -11,6 +12,7 @@ import hellfirepvp.astralsorcery.common.constellation.IWeakConstellation;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.item.ItemStack;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
@@ -18,12 +20,27 @@ import java.util.Collection;
 @RegistryDescription
 public class LightTransmutation extends StandardListRegistry<LightOreTransmutations.Transmutation> {
 
+    private IBlockState replacementState;
+
+    @GroovyBlacklist
+    public IBlockState getReplacementState() {
+        return replacementState;
+    }
+
     @Override
     public Collection<LightOreTransmutations.Transmutation> getRecipes() {
         if (LightOreTransmutationsAccessor.getRegisteredTransmutations() == null) {
             throw new IllegalStateException("Astral Sorcery Light Transmutation getRegisteredTransmutations() is not yet initialized!");
         }
         return LightOreTransmutationsAccessor.getRegisteredTransmutations();
+    }
+
+    @Override
+    @GroovyBlacklist
+    @ApiStatus.Internal
+    public void onReload() {
+        super.onReload();
+        replacementState = null;
     }
 
     @RecipeBuilderDescription(example = {
@@ -79,6 +96,11 @@ public class LightTransmutation extends StandardListRegistry<LightOreTransmutati
     @MethodDescription(example = @Example("block('minecraft:lapis_block')"))
     public void removeByOutput(Block block) {
         removeByOutput(block.getDefaultState());
+    }
+
+    @MethodDescription(type = MethodDescription.Type.VALUE, example = @Example("blockstate('minecraft:clay')"))
+    public void setStarmetalReplacementState(IBlockState state) {
+        replacementState = state;
     }
 
     public static class RecipeBuilder extends AbstractRecipeBuilder<LightOreTransmutations.Transmutation> {

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/astralsorcery/TileCelestialCrystalsMixin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/astralsorcery/TileCelestialCrystalsMixin.java
@@ -1,0 +1,22 @@
+package com.cleanroommc.groovyscript.core.mixin.astralsorcery;
+
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import hellfirepvp.astralsorcery.common.tile.TileCelestialCrystals;
+import net.minecraft.block.Block;
+import net.minecraft.block.state.IBlockState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(value = TileCelestialCrystals.class, remap = false)
+public abstract class TileCelestialCrystalsMixin {
+
+    @WrapOperation(method = "update", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/Block;getDefaultState()Lnet/minecraft/block/state/IBlockState;"))
+    public IBlockState replaceIronOreDowngrade(Block instance, Operation<IBlockState> original) {
+        var replacementState = ModSupport.ASTRAL_SORCERY.get().lightTransmutation.getReplacementState();
+        if (replacementState == null) return original.call(instance);
+        return replacementState;
+    }
+
+}

--- a/src/main/resources/assets/groovyscript/lang/en_us.lang
+++ b/src/main/resources/assets/groovyscript/lang/en_us.lang
@@ -397,6 +397,7 @@ groovyscript.wiki.astralsorcery.light_transmutation.cost.value=Sets the amount o
 groovyscript.wiki.astralsorcery.light_transmutation.constellation.value=Sets the required Constellation the starlight must be collected from. Must be either a Major or Weak Constellation
 groovyscript.wiki.astralsorcery.light_transmutation.inStack.value=Sets the item representing the input Block or IBlockState in JEI
 groovyscript.wiki.astralsorcery.light_transmutation.outStack.value=Sets the item representing the output IBlockState in JEI
+groovyscript.wiki.astralsorcery.light_transmutation.setStarmetalReplacementState=Sets the IBlockState that Starmetal Ore is converted into when placed beneath a Celestial Crystal Cluster. Useful when the Light Transmutation recipe converting Iron Ore into Starmetal Ore has changed.
 
 groovyscript.wiki.astralsorcery.lightwell.title=Lightwell
 groovyscript.wiki.astralsorcery.lightwell.description=Converts an input item into fluid, with a chance at breaking every time fluid is produced. The amount of fluid produced per interval can be increased via starlight.

--- a/src/main/resources/mixin.groovyscript.astralsorcery.json
+++ b/src/main/resources/mixin.groovyscript.astralsorcery.json
@@ -17,6 +17,7 @@
     "PerkLevelManagerMixin",
     "PerkTreeAccessor",
     "ResearchNodeAccessor",
+    "TileCelestialCrystalsMixin",
     "TraitRecipeAccessor",
     "WellLiquefactionAccessor"
   ]


### PR DESCRIPTION
changes in this PR:
- adds the ability to configure what IBlockState Starmetal Ore converts into while beneath a Celestial Crystal Cluster. adds an example and an i18n key for it.
- this feature requires a mixin, and it uses a `WrapOperation` of the specific IBlockState