### PR TITLE
add Factory Tech compat

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -69,6 +69,7 @@ final def mod_dependencies = [
         'extended-crafting-nomifactory-edition-398267:3613140': [project.debug_extended_crafting],
         'extrabotany-299086:3112313'                          : [project.debug_extra_botany],
         'extra-utilities-2-225561:2678374'                    : [project.debug_extra_utilities_2],
+        'factory-tech-278822:3845293'                         : [project.debug_factory_tech],
         'forestry-59751:2918418'                              : [project.debug_forestry],
         'future-mc-310059:5626387'                            : [project.debug_future_mc],
         'horse-power-270466:2705433'                          : [project.debug_horse_power],

--- a/examples/postInit/factorytech.groovy
+++ b/examples/postInit/factorytech.groovy
@@ -1,0 +1,388 @@
+
+// Auto generated groovyscript example file
+// MODS_LOADED: factorytech
+
+log.info 'mod \'factorytech\' detected, running script'
+
+// Fluid Agitator:
+// Converts either one or two input fluidstacks and up to one input itemstack into an output itemstack, output fluidstack,
+// or both.
+
+mods.factorytech.agitator.removeByInput(fluid('lava'))
+mods.factorytech.agitator.removeByInput(fluid('ftglowstone'))
+mods.factorytech.agitator.removeByInput(item('minecraft:sand'))
+mods.factorytech.agitator.removeByOutput(fluid('h2so4'))
+mods.factorytech.agitator.removeByOutput(item('minecraft:stone'))
+// mods.factorytech.agitator.removeAll()
+
+mods.factorytech.agitator.recipeBuilder()
+    .input(item('minecraft:clay'))
+    .fluidInput(fluid('water') * 100)
+    .output(item('minecraft:diamond'))
+    .register()
+
+mods.factorytech.agitator.recipeBuilder()
+    .fluidInput(fluid('ftglowstone') * 100)
+    .output(item('minecraft:clay'))
+    .register()
+
+mods.factorytech.agitator.recipeBuilder()
+    .fluidInput(fluid('lava') * 100, fluid('water') * 100)
+    .output(item('minecraft:clay'))
+    .register()
+
+mods.factorytech.agitator.recipeBuilder()
+    .fluidInput(fluid('lava') * 100, fluid('ftglowstone') * 100)
+    .fluidOutput(fluid('ftglowstone') * 100)
+    .register()
+
+mods.factorytech.agitator.recipeBuilder()
+    .input(item('minecraft:gold_ingot'))
+    .fluidInput(fluid('water') * 100)
+    .output(item('minecraft:diamond') * 5)
+    .register()
+
+
+// Centrifuge:
+// Converts an input itemstack into up to 3 output itemstacks, with the ability to control if stone parts are allowed.
+
+mods.factorytech.centrifuge.removeByInput(item('minecraft:gravel'))
+mods.factorytech.centrifuge.removeByOutput(item('minecraft:iron_nugget'))
+// mods.factorytech.centrifuge.removeAll()
+
+mods.factorytech.centrifuge.recipeBuilder()
+    .input(item('minecraft:clay'))
+    .output(item('minecraft:obsidian'), item('minecraft:gold_ingot') * 2, item('minecraft:diamond'))
+    .register()
+
+mods.factorytech.centrifuge.recipeBuilder()
+    .input(item('minecraft:gold_ingot'))
+    .output(item('minecraft:clay'))
+    .register()
+
+
+// Circuit Scribe:
+// Converts an input itemstack into an output itemstack, with the ability to control if stone parts are allowed.
+
+mods.factorytech.circuit_scribe.removeByInput(item('factorytech:circuit_intermediate:8'))
+// mods.factorytech.circuit_scribe.removeByOutput(item('factorytech:circuit_intermediate:8'))
+// mods.factorytech.circuit_scribe.removeAll()
+
+mods.factorytech.circuit_scribe.recipeBuilder()
+    .input(item('minecraft:clay'))
+    .output(item('minecraft:diamond'))
+    .register()
+
+mods.factorytech.circuit_scribe.recipeBuilder()
+    .input(item('minecraft:gold_ingot'))
+    .output(item('minecraft:clay'))
+    .allowStoneParts()
+    .register()
+
+
+// Compression Chamber:
+// Converts an input itemstack and input fluidstack into an output itemstack.
+
+mods.factorytech.compressor.removeByInput(fluid('water'))
+mods.factorytech.compressor.removeByInput(item('factorytech:machinepart:60'))
+mods.factorytech.compressor.removeByOutput(item('factorytech:machinepart:141'))
+// mods.factorytech.compressor.removeAll()
+
+mods.factorytech.compressor.recipeBuilder()
+    .input(item('minecraft:clay'))
+    .output(item('minecraft:diamond'))
+    .register()
+
+mods.factorytech.compressor.recipeBuilder()
+    .input(item('minecraft:diamond'))
+    .fluidInput(fluid('lava') * 100)
+    .output(item('minecraft:clay'))
+    .register()
+
+mods.factorytech.compressor.recipeBuilder()
+    .input(item('minecraft:gold_ingot'))
+    .fluidInput(fluid('water') * 100)
+    .output(item('minecraft:diamond') * 5)
+    .register()
+
+
+// Crucible:
+// Converts an input itemstack into an output fluidstack.
+
+mods.factorytech.crucible.removeByInput(item('minecraft:ice'))
+mods.factorytech.crucible.removeByOutput(fluid('lava'))
+// mods.factorytech.crucible.removeAll()
+
+mods.factorytech.crucible.recipeBuilder()
+    .input(item('minecraft:clay'))
+    .fluidOutput(fluid('water'))
+    .register()
+
+mods.factorytech.crucible.recipeBuilder()
+    .input(item('minecraft:gold_ingot'))
+    .fluidOutput(fluid('lava') * 30)
+    .register()
+
+
+// Terraneous Extractor:
+// Passively generates resources when placed at or below y 8 and.
+
+mods.factorytech.deep_drill.removeByInput(item('minecraft:gold_ore'))
+// mods.factorytech.deep_drill.removeAll()
+
+mods.factorytech.deep_drill.recipeBuilder()
+    .output(item('minecraft:diamond'))
+    .weight(10)
+    .register()
+
+mods.factorytech.deep_drill.recipeBuilder()
+    .output(item('minecraft:clay'))
+    .weight(30)
+    .register()
+
+
+// Mob Disassembler:
+// Kills an entity in-world, dropping the mob's normal loot in addition to custom loot.
+
+mods.factorytech.disassembler.removeByEntity(entity('minecraft:creeper'))
+mods.factorytech.disassembler.removeByOutput(item('minecraft:rotten_flesh'))
+// mods.factorytech.disassembler.removeAll()
+
+mods.factorytech.disassembler.recipeBuilder()
+    .entity(entity('minecraft:chicken'))
+    .output(item('minecraft:obsidian'), item('minecraft:gold_ingot') * 2, item('minecraft:clay'), item('minecraft:diamond'))
+    .register()
+
+mods.factorytech.disassembler.recipeBuilder()
+    .entity(entity('minecraft:rabbit'))
+    .output(item('minecraft:clay'), item('minecraft:diamond') * 2)
+    .register()
+
+
+// Electroplater:
+// Converts an input itemstack into an output itemstack, with the ability to control if stone parts are allowed.
+
+mods.factorytech.electroplater.removeByInput(item('minecraft:sand'))
+mods.factorytech.electroplater.removeByOutput(item('minecraft:gold_ingot'))
+// mods.factorytech.electroplater.removeAll()
+
+mods.factorytech.electroplater.recipeBuilder()
+    .input(item('minecraft:clay'))
+    .output(item('minecraft:diamond'))
+    .register()
+
+mods.factorytech.electroplater.recipeBuilder()
+    .input(item('minecraft:gold_ingot'))
+    .output(item('minecraft:clay'))
+    .allowStoneParts()
+    .register()
+
+
+// Grindstone:
+// Converts an input itemstack into an output itemstack, with the ability to control if stone parts are allowed.
+
+mods.factorytech.grindstone.removeByInput(item('minecraft:stone'))
+mods.factorytech.grindstone.removeByOutput(item('factorytech:machinepart:1'))
+// mods.factorytech.grindstone.removeAll()
+
+mods.factorytech.grindstone.recipeBuilder()
+    .input(item('minecraft:clay'))
+    .output(item('minecraft:diamond'))
+    .register()
+
+mods.factorytech.grindstone.recipeBuilder()
+    .input(item('minecraft:gold_ingot'))
+    .output(item('minecraft:clay'))
+    .allowStoneParts()
+    .register()
+
+
+// Electric Furnace:
+// Converts an input itemstack into an output itemstack, with the ability to control if stone parts are allowed.
+
+mods.factorytech.high_tech_furnace.removeByInput(item('minecraft:cactus'))
+mods.factorytech.high_tech_furnace.removeByOutput(item('minecraft:iron_ingot'))
+// mods.factorytech.high_tech_furnace.removeAll()
+
+mods.factorytech.high_tech_furnace.recipeBuilder()
+    .input(item('minecraft:clay'))
+    .output(item('minecraft:diamond'))
+    .register()
+
+mods.factorytech.high_tech_furnace.recipeBuilder()
+    .input(item('minecraft:gold_ingot'))
+    .output(item('minecraft:clay'))
+    .allowStoneParts()
+    .register()
+
+
+// Magnet Centrifuge:
+// Converts an input itemstack into up to 3 output itemstacks, with the ability to control if stone parts are allowed.
+
+mods.factorytech.magnet_centrifuge.removeByInput(item('minecraft:gravel'))
+mods.factorytech.magnet_centrifuge.removeByOutput(item('minecraft:redstone'))
+// mods.factorytech.magnet_centrifuge.removeAll()
+
+mods.factorytech.magnet_centrifuge.recipeBuilder()
+    .input(item('minecraft:clay'))
+    .output(item('minecraft:obsidian'), item('minecraft:gold_ingot') * 2, item('minecraft:diamond'))
+    .register()
+
+mods.factorytech.magnet_centrifuge.recipeBuilder()
+    .input(item('minecraft:gold_ingot'))
+    .output(item('minecraft:clay'))
+    .allowStoneParts()
+    .register()
+
+
+// Magnetizer:
+// Converts an input itemstack into an output itemstack, with the ability to control if stone parts are allowed.
+
+mods.factorytech.magnetizer.removeByInput(item('minecraft:iron_ingot'))
+// mods.factorytech.magnetizer.removeByOutput(item('factorytech:machinepart:130'))
+// mods.factorytech.magnetizer.removeAll()
+
+mods.factorytech.magnetizer.recipeBuilder()
+    .input(item('minecraft:clay'))
+    .output(item('minecraft:diamond'))
+    .register()
+
+mods.factorytech.magnetizer.recipeBuilder()
+    .input(item('minecraft:gold_ingot'))
+    .output(item('minecraft:clay'))
+    .allowStoneParts()
+    .register()
+
+
+// Metal Cutter:
+// Converts an input itemstack into an output itemstack, with the ability to control if stone parts are allowed.
+
+mods.factorytech.metal_cutter.removeByInput(item('minecraft:gold_ingot'))
+mods.factorytech.metal_cutter.removeByOutput(item('factorytech:machinepart:20'))
+// mods.factorytech.metal_cutter.removeAll()
+
+mods.factorytech.metal_cutter.recipeBuilder()
+    .input(item('minecraft:clay'))
+    .output(item('minecraft:diamond'))
+    .register()
+
+mods.factorytech.metal_cutter.recipeBuilder()
+    .input(item('minecraft:gold_ingot'))
+    .output(item('minecraft:clay'))
+    .allowStoneParts()
+    .register()
+
+
+// Drill Grinder:
+// Converts an input itemstack into an output itemstack, with the ability to control if stone parts are allowed.
+
+mods.factorytech.ore_drill.removeByInput(item('minecraft:gold_ore'))
+mods.factorytech.ore_drill.removeByOutput(item('minecraft:sand'))
+// mods.factorytech.ore_drill.removeAll()
+
+mods.factorytech.ore_drill.recipeBuilder()
+    .input(item('minecraft:clay'))
+    .output(item('minecraft:diamond'))
+    .register()
+
+mods.factorytech.ore_drill.recipeBuilder()
+    .input(item('minecraft:gold_ingot'))
+    .output(item('minecraft:clay'))
+    .allowStoneParts()
+    .register()
+
+
+// Scrap Furnace:
+// Converts an input itemstack into an output itemstack, with the ability to control if stone parts are allowed.
+
+mods.factorytech.reclaimer.removeByInput(item('factorytech:salvagepart:22'))
+mods.factorytech.reclaimer.removeByOutput(item('minecraft:iron_nugget'))
+// mods.factorytech.reclaimer.removeAll()
+
+mods.factorytech.reclaimer.recipeBuilder()
+    .input(item('minecraft:clay'))
+    .output(item('minecraft:diamond'))
+    .register()
+
+mods.factorytech.reclaimer.recipeBuilder()
+    .input(item('minecraft:gold_ingot'))
+    .output(item('minecraft:clay'))
+    .allowStoneParts()
+    .register()
+
+
+// Refrigerator:
+// Converts an input fluidstack into an output itemstack.
+
+mods.factorytech.refrigerator.removeByInput(fluid('water'))
+mods.factorytech.refrigerator.removeByOutput(item('minecraft:obsidian'))
+// mods.factorytech.refrigerator.removeAll()
+
+mods.factorytech.refrigerator.recipeBuilder()
+    .fluidInput(fluid('water') * 100)
+    .output(item('minecraft:diamond'))
+    .register()
+
+mods.factorytech.refrigerator.recipeBuilder()
+    .fluidInput(fluid('lava') * 30)
+    .output(item('minecraft:clay'))
+    .register()
+
+
+// River Grate:
+// Slowly produces the output entries while in a river biome surrounded by water, and between y 60 and 70.
+
+mods.factorytech.river_grate.removeByOutput(item('minecraft:fish'))
+// mods.factorytech.river_grate.removeAll()
+
+mods.factorytech.river_grate.recipeBuilder()
+    .output(item('minecraft:diamond'))
+    .weight(10)
+    .register()
+
+mods.factorytech.river_grate.recipeBuilder()
+    .output(item('minecraft:clay'))
+    .allowStoneParts()
+    .weight(30)
+    .register()
+
+
+// Chop Saw:
+// Converts an input itemstack into an output itemstack, with the ability to control if stone parts are allowed.
+
+mods.factorytech.saw.removeByInput(item('minecraft:log'))
+mods.factorytech.saw.removeByOutput(item('minecraft:stick'))
+// mods.factorytech.saw.removeAll()
+
+mods.factorytech.saw.recipeBuilder()
+    .input(item('minecraft:clay'))
+    .output(item('minecraft:diamond'))
+    .register()
+
+mods.factorytech.saw.recipeBuilder()
+    .input(item('minecraft:gold_ingot'))
+    .output(item('minecraft:clay'))
+    .allowStoneParts()
+    .register()
+
+
+// Tempering Oven:
+// Converts an input itemstack into an output itemstack, with the ability to control if stone parts are allowed and how
+// long the recipe takes.
+
+mods.factorytech.temperer.removeByInput(item('minecraft:iron_ingot'))
+mods.factorytech.temperer.removeByOutput(item('factorytech:machinepart:4'))
+// mods.factorytech.temperer.removeAll()
+
+mods.factorytech.temperer.recipeBuilder()
+    .input(item('minecraft:clay'))
+    .output(item('minecraft:diamond'))
+    .register()
+
+mods.factorytech.temperer.recipeBuilder()
+    .input(item('minecraft:gold_ingot'))
+    .output(item('minecraft:clay'))
+    .time(30)
+    .register()
+
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -44,6 +44,7 @@ debug_extended_crafting = false
 debug_extra_botany = false
 debug_extra_utilities_2 = false
 
+debug_factory_tech = false
 debug_forestry = false
 debug_future_mc = false
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -44,7 +44,7 @@ debug_extended_crafting = false
 debug_extra_botany = false
 debug_extra_utilities_2 = false
 
-debug_factory_tech = false
+debug_factory_tech = true
 debug_forestry = false
 debug_future_mc = false
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ModSupport.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ModSupport.java
@@ -29,6 +29,7 @@ import com.cleanroommc.groovyscript.compat.mods.evilcraft.EvilCraft;
 import com.cleanroommc.groovyscript.compat.mods.extendedcrafting.ExtendedCrafting;
 import com.cleanroommc.groovyscript.compat.mods.extrabotany.ExtraBotany;
 import com.cleanroommc.groovyscript.compat.mods.extrautils2.ExtraUtils2;
+import com.cleanroommc.groovyscript.compat.mods.factorytech.FactoryTech;
 import com.cleanroommc.groovyscript.compat.mods.forestry.Forestry;
 import com.cleanroommc.groovyscript.compat.mods.futuremc.FutureMC;
 import com.cleanroommc.groovyscript.compat.mods.horsepower.HorsePower;
@@ -107,6 +108,7 @@ public class ModSupport {
     public static final GroovyContainer<ExtendedCrafting> EXTENDED_CRAFTING = new InternalModContainer<>("extendedcrafting", "Extended Crafting", ExtendedCrafting::new);
     public static final GroovyContainer<ExtraBotany> EXTRA_BOTANY = new InternalModContainer<>("extrabotany", "Extra Botany", ExtraBotany::new);
     public static final GroovyContainer<ExtraUtils2> EXTRA_UTILITIES_2 = new InternalModContainer<>("extrautils2", "Extra Utilities 2", ExtraUtils2::new, "extrautilities2");
+    public static final GroovyContainer<FactoryTech> FACTORY_TECH = new InternalModContainer<>("factorytech", "Factory Tech", FactoryTech::new);
     public static final GroovyContainer<Forestry> FORESTRY = new InternalModContainer<>("forestry", "Forestry", Forestry::new);
     public static final GroovyContainer<FutureMC> FUTURE_MC = new InternalModContainer<>("futuremc", "Future MC", FutureMC::new);
     public static final GroovyContainer<HorsePower> HORSE_POWER = new InternalModContainer<>("horsepower", "Horse Power", HorsePower::new);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/Agitator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/Agitator.java
@@ -1,5 +1,6 @@
 package com.cleanroommc.groovyscript.compat.mods.factorytech;
 
+import com.cleanroommc.groovyscript.api.GroovyBlacklist;
 import com.cleanroommc.groovyscript.api.GroovyLog;
 import com.cleanroommc.groovyscript.api.IIngredient;
 import com.cleanroommc.groovyscript.api.documentation.annotations.*;
@@ -54,6 +55,11 @@ public class Agitator extends StandardListRegistry<TileEntityAgitator.AgitatorRe
         @Override
         public String getErrorMsg() {
             return "Error adding Factory Tech Agitator recipe";
+        }
+
+        @Override
+        protected int getMaxItemInput() {
+            return 1;
         }
 
         @Override

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/Agitator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/Agitator.java
@@ -1,0 +1,83 @@
+package com.cleanroommc.groovyscript.compat.mods.factorytech;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import com.cleanroommc.groovyscript.registry.StandardListRegistry;
+import dalapo.factech.auxiliary.MachineRecipes;
+import dalapo.factech.tileentity.specialized.TileEntityAgitator;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+
+@RegistryDescription
+public class Agitator extends StandardListRegistry<TileEntityAgitator.AgitatorRecipe> {
+
+    @Override
+    public Collection<TileEntityAgitator.AgitatorRecipe> getRecipes() {
+        return MachineRecipes.AGITATOR;
+    }
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:clay')).fluidInput(fluid('water') * 100).output(item('minecraft:diamond'))"),
+            @Example(".fluidInput(fluid('ftglowstone') * 100).output(item('minecraft:clay'))"),
+            @Example(".fluidInput(fluid('lava') * 100, fluid('water') * 100).output(item('minecraft:clay'))"),
+            @Example(".fluidInput(fluid('lava') * 100, fluid('ftglowstone') * 100).fluidOutput(fluid('ftglowstone') * 100)"),
+            @Example(".input(item('minecraft:gold_ingot')).fluidInput(fluid('water') * 100).output(item('minecraft:diamond') * 5)")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @MethodDescription(example = {
+            @Example("fluid('lava')"), @Example("fluid('ftglowstone')"), @Example("item('minecraft:sand')")
+    })
+    public void removeByInput(IIngredient input) {
+        getRecipes().removeIf(r -> (input.test(r.getInputItem()) || input.test(r.getInputFluid(0)) || input.test(r.getInputFluid(1))) && doAddBackup(r));
+    }
+
+    @MethodDescription(example = {
+            @Example("fluid('h2so4')"), @Example("item('minecraft:stone')")
+    })
+    public void removeByOutput(IIngredient output) {
+        getRecipes().removeIf(r -> (output.test(r.getOutputStack()) || output.test(r.getOutputFluid())) && doAddBackup(r));
+    }
+
+    @Property(property = "input", comp = @Comp(gte = 0, lte = 1))
+    @Property(property = "fluidInput", comp = @Comp(gte = 1, lte = 2))
+    @Property(property = "output", comp = @Comp(gte = 0, lte = 1))
+    @Property(property = "fluidOutput", comp = @Comp(gte = 0, lte = 1))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<TileEntityAgitator.AgitatorRecipe> {
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Factory Tech Agitator recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 0, 1, 0, 1);
+            validateFluids(msg, 1, 2, 0, 1);
+            msg.add(output.isEmpty() && fluidOutput.isEmpty(), "either output or fluidOutput must have an entry, yet both were empty");
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable TileEntityAgitator.AgitatorRecipe register() {
+            if (!validate()) return null;
+            TileEntityAgitator.AgitatorRecipe recipe = null;
+            if (input.isEmpty()) {
+                recipe = new TileEntityAgitator.AgitatorRecipe(null, output.getOrEmpty(0), fluidOutput.getOrEmpty(0), fluidInput.getOrEmpty(0), fluidInput.getOrEmpty(1));
+                ModSupport.FACTORY_TECH.get().agitator.add(recipe);
+            } else {
+                for (var stack : input.get(0).getMatchingStacks()) {
+                    recipe = new TileEntityAgitator.AgitatorRecipe(stack, output.getOrEmpty(0), fluidOutput.getOrEmpty(0), fluidInput.getOrEmpty(0), fluidInput.getOrEmpty(1));
+                    ModSupport.FACTORY_TECH.get().agitator.add(recipe);
+                }
+            }
+            return recipe;
+        }
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/Centrifuge.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/Centrifuge.java
@@ -64,6 +64,11 @@ public class Centrifuge extends StandardListRegistry<MachineRecipes.MachineRecip
         }
 
         @Override
+        protected int getMaxItemInput() {
+            return 1;
+        }
+
+        @Override
         public void validate(GroovyLog.Msg msg) {
             validateItems(msg, 1, 1, 1, 3);
             validateFluids(msg);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/Centrifuge.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/Centrifuge.java
@@ -1,0 +1,84 @@
+package com.cleanroommc.groovyscript.compat.mods.factorytech;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import com.cleanroommc.groovyscript.registry.StandardListRegistry;
+import dalapo.factech.auxiliary.MachineRecipes;
+import net.minecraft.item.ItemStack;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+@RegistryDescription
+public class Centrifuge extends StandardListRegistry<MachineRecipes.MachineRecipe<ItemStack, ItemStack[]>> {
+
+    @Override
+    public Collection<MachineRecipes.MachineRecipe<ItemStack, ItemStack[]>> getRecipes() {
+        return MachineRecipes.CENTRIFUGE;
+    }
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:clay')).output(item('minecraft:obsidian'), item('minecraft:gold_ingot') * 2, item('minecraft:diamond'))"),
+            @Example(".input(item('minecraft:gold_ingot')).output(item('minecraft:clay'))")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @MethodDescription(example = @Example("item('minecraft:gravel')"))
+    public void removeByInput(IIngredient input) {
+        getRecipes().removeIf(r -> input.test(r.input()) && doAddBackup(r));
+    }
+
+    @MethodDescription(example = @Example("item('minecraft:iron_nugget')"))
+    public void removeByOutput(IIngredient output) {
+        getRecipes().removeIf(r -> Arrays.stream(r.getOutputStack()).anyMatch(output) && doAddBackup(r));
+    }
+
+    @Property(property = "input", comp = @Comp(eq = 1))
+    @Property(property = "output", comp = @Comp(gte = 1, lte = 3))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<MachineRecipes.MachineRecipe<ItemStack, ItemStack[]>> {
+
+        @Property("groovyscript.wiki.factorytech.allowStoneParts.value")
+        private boolean allowStoneParts;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder allowStoneParts(boolean allowStoneParts) {
+            this.allowStoneParts = allowStoneParts;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder allowStoneParts() {
+            this.allowStoneParts = !this.allowStoneParts;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Factory Tech Centrifuge recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 1, 1, 1, 3);
+            validateFluids(msg);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable MachineRecipes.MachineRecipe<ItemStack, ItemStack[]> register() {
+            if (!validate()) return null;
+            MachineRecipes.MachineRecipe<ItemStack, ItemStack[]> recipe = null;
+            for (var stack : input.get(0).getMatchingStacks()) {
+                recipe = new MachineRecipes.MachineRecipe<>(stack, output.toArray(new ItemStack[0]), allowStoneParts);
+                ModSupport.FACTORY_TECH.get().centrifuge.add(recipe);
+            }
+            return recipe;
+        }
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/CircuitScribe.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/CircuitScribe.java
@@ -1,0 +1,83 @@
+package com.cleanroommc.groovyscript.compat.mods.factorytech;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import com.cleanroommc.groovyscript.registry.StandardListRegistry;
+import dalapo.factech.auxiliary.MachineRecipes;
+import net.minecraft.item.ItemStack;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+
+@RegistryDescription
+public class CircuitScribe extends StandardListRegistry<MachineRecipes.MachineRecipe<ItemStack, ItemStack>> {
+
+    @Override
+    public Collection<MachineRecipes.MachineRecipe<ItemStack, ItemStack>> getRecipes() {
+        return MachineRecipes.CIRCUIT_SCRIBE;
+    }
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:clay')).output(item('minecraft:diamond'))"),
+            @Example(".input(item('minecraft:gold_ingot')).output(item('minecraft:clay')).allowStoneParts()")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @MethodDescription(example = @Example("item('factorytech:circuit_intermediate:8')"))
+    public void removeByInput(IIngredient input) {
+        getRecipes().removeIf(r -> input.test(r.input()) && doAddBackup(r));
+    }
+
+    @MethodDescription(example = @Example(value = "item('factorytech:circuit_intermediate:8')", commented = true))
+    public void removeByOutput(IIngredient output) {
+        getRecipes().removeIf(r -> output.test(r.getOutputStack()) && doAddBackup(r));
+    }
+
+    @Property(property = "input", comp = @Comp(eq = 1))
+    @Property(property = "output", comp = @Comp(eq = 1))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<MachineRecipes.MachineRecipe<ItemStack, ItemStack>> {
+
+        @Property("groovyscript.wiki.factorytech.allowStoneParts.value")
+        private boolean allowStoneParts;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder allowStoneParts(boolean allowStoneParts) {
+            this.allowStoneParts = allowStoneParts;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder allowStoneParts() {
+            this.allowStoneParts = !this.allowStoneParts;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Factory Tech Circuit Scribe recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 1, 1, 1, 1);
+            validateFluids(msg);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable MachineRecipes.MachineRecipe<ItemStack, ItemStack> register() {
+            if (!validate()) return null;
+            MachineRecipes.MachineRecipe<ItemStack, ItemStack> recipe = null;
+            for (var stack : input.get(0).getMatchingStacks()) {
+                recipe = new MachineRecipes.MachineRecipe<>(stack, output.get(0), allowStoneParts);
+                ModSupport.FACTORY_TECH.get().circuitScribe.add(recipe);
+            }
+            return recipe;
+        }
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/CircuitScribe.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/CircuitScribe.java
@@ -63,6 +63,11 @@ public class CircuitScribe extends StandardListRegistry<MachineRecipes.MachineRe
         }
 
         @Override
+        protected int getMaxItemInput() {
+            return 1;
+        }
+
+        @Override
         public void validate(GroovyLog.Msg msg) {
             validateItems(msg, 1, 1, 1, 1);
             validateFluids(msg);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/Compressor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/Compressor.java
@@ -52,6 +52,11 @@ public class Compressor extends StandardListRegistry<TileEntityCompressionChambe
         }
 
         @Override
+        protected int getMaxItemInput() {
+            return 1;
+        }
+
+        @Override
         public void validate(GroovyLog.Msg msg) {
             validateItems(msg, 1, 1, 1, 1);
             validateFluids(msg, 0, 1, 0, 0);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/Compressor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/Compressor.java
@@ -1,0 +1,72 @@
+package com.cleanroommc.groovyscript.compat.mods.factorytech;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import com.cleanroommc.groovyscript.registry.StandardListRegistry;
+import dalapo.factech.auxiliary.MachineRecipes;
+import dalapo.factech.tileentity.specialized.TileEntityCompressionChamber;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+
+@RegistryDescription
+public class Compressor extends StandardListRegistry<TileEntityCompressionChamber.CompressorRecipe> {
+
+    @Override
+    public Collection<TileEntityCompressionChamber.CompressorRecipe> getRecipes() {
+        return MachineRecipes.COMPRESSOR;
+    }
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:clay')).output(item('minecraft:diamond'))"),
+            @Example(".input(item('minecraft:diamond')).fluidInput(fluid('lava') * 100).output(item('minecraft:clay'))"),
+            @Example(".input(item('minecraft:gold_ingot')).fluidInput(fluid('water') * 100).output(item('minecraft:diamond') * 5)")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @MethodDescription(example = {
+            @Example("fluid('water')"), @Example("item('factorytech:machinepart:60')")
+    })
+    public void removeByInput(IIngredient input) {
+        getRecipes().removeIf(r -> (input.test(r.getItemIn()) || input.test(r.getFluidIn())) && doAddBackup(r));
+    }
+
+    @MethodDescription(example = @Example("item('factorytech:machinepart:141')"))
+    public void removeByOutput(IIngredient output) {
+        getRecipes().removeIf(r -> output.test(r.getOutputStack()) && doAddBackup(r));
+    }
+
+    @Property(property = "input", comp = @Comp(eq = 1))
+    @Property(property = "fluidInput", comp = @Comp(gte = 0, lte = 1))
+    @Property(property = "output", comp = @Comp(eq = 1))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<TileEntityCompressionChamber.CompressorRecipe> {
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Factory Tech Compressor recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 1, 1, 1, 1);
+            validateFluids(msg, 0, 1, 0, 0);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable TileEntityCompressionChamber.CompressorRecipe register() {
+            if (!validate()) return null;
+            TileEntityCompressionChamber.CompressorRecipe recipe = null;
+            for (var stack : input.get(0).getMatchingStacks()) {
+                recipe = new TileEntityCompressionChamber.CompressorRecipe(stack, fluidInput.getOrEmpty(0), output.get(0));
+                ModSupport.FACTORY_TECH.get().compressor.add(recipe);
+            }
+            return recipe;
+        }
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/Crucible.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/Crucible.java
@@ -1,0 +1,69 @@
+package com.cleanroommc.groovyscript.compat.mods.factorytech;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import com.cleanroommc.groovyscript.registry.StandardListRegistry;
+import dalapo.factech.auxiliary.MachineRecipes;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+
+@RegistryDescription
+public class Crucible extends StandardListRegistry<MachineRecipes.MachineRecipe<ItemStack, FluidStack>> {
+
+    @Override
+    public Collection<MachineRecipes.MachineRecipe<ItemStack, FluidStack>> getRecipes() {
+        return MachineRecipes.CRUCIBLE;
+    }
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:clay')).fluidOutput(fluid('water'))"),
+            @Example(".input(item('minecraft:gold_ingot')).fluidOutput(fluid('lava') * 30)")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @MethodDescription(example = @Example("item('minecraft:ice')"))
+    public void removeByInput(IIngredient input) {
+        getRecipes().removeIf(r -> input.test(r.input()) && doAddBackup(r));
+    }
+
+    @MethodDescription(example = @Example("fluid('lava')"))
+    public void removeByOutput(IIngredient output) {
+        getRecipes().removeIf(r -> output.test(r.getOutputStack()) && doAddBackup(r));
+    }
+
+    @Property(property = "input", comp = @Comp(eq = 1))
+    @Property(property = "fluidOutput", comp = @Comp(eq = 1))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<MachineRecipes.MachineRecipe<ItemStack, FluidStack>> {
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Factory Tech Crucible recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 1, 1, 0, 0);
+            validateFluids(msg, 0, 0, 1, 1);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable MachineRecipes.MachineRecipe<ItemStack, FluidStack> register() {
+            if (!validate()) return null;
+            MachineRecipes.MachineRecipe<ItemStack, FluidStack> recipe = null;
+            for (var stack : input.get(0).getMatchingStacks()) {
+                recipe = new MachineRecipes.MachineRecipe<>(stack, fluidOutput.get(0));
+                ModSupport.FACTORY_TECH.get().crucible.add(recipe);
+            }
+            return recipe;
+        }
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/Crucible.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/Crucible.java
@@ -49,6 +49,11 @@ public class Crucible extends StandardListRegistry<MachineRecipes.MachineRecipe<
         }
 
         @Override
+        protected int getMaxItemInput() {
+            return 1;
+        }
+
+        @Override
         public void validate(GroovyLog.Msg msg) {
             validateItems(msg, 1, 1, 0, 0);
             validateFluids(msg, 0, 0, 1, 1);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/DeepDrill.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/DeepDrill.java
@@ -1,0 +1,70 @@
+package com.cleanroommc.groovyscript.compat.mods.factorytech;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import com.cleanroommc.groovyscript.registry.StandardListRegistry;
+import dalapo.factech.auxiliary.MachineRecipes;
+import dalapo.factech.helper.Pair;
+import net.minecraft.item.ItemStack;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+
+@RegistryDescription(category = RegistryDescription.Category.ENTRIES)
+public class DeepDrill extends StandardListRegistry<Pair<ItemStack, Double>> {
+
+    @Override
+    public Collection<Pair<ItemStack, Double>> getRecipes() {
+        return MachineRecipes.DEEP_DRILL;
+    }
+
+    @RecipeBuilderDescription(example = {
+            @Example(".output(item('minecraft:diamond')).weight(10)"),
+            @Example(".output(item('minecraft:clay')).weight(30)")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @MethodDescription(example = @Example("item('minecraft:gold_ore')"))
+    public void removeByInput(IIngredient input) {
+        getRecipes().removeIf(r -> input.test(r.a) && doAddBackup(r));
+    }
+
+    @Property(property = "output", comp = @Comp(eq = 1))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<Pair<ItemStack, Double>> {
+
+        @Property(comp = @Comp(gte = 0))
+        private double weight;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder weight(double weight) {
+            this.weight = weight;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Factory Tech Deep Drill recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 0, 0, 1, 1);
+            validateFluids(msg);
+            msg.add(weight < 0, "weight must be a non-negative double, yet it was {}", weight);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable Pair<ItemStack, Double> register() {
+            if (!validate()) return null;
+            var recipe = new Pair<>(output.get(0), weight);
+            ModSupport.FACTORY_TECH.get().deepDrill.add(recipe);
+            return recipe;
+        }
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/Disassembler.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/Disassembler.java
@@ -1,0 +1,123 @@
+package com.cleanroommc.groovyscript.compat.mods.factorytech;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import dalapo.factech.auxiliary.MachineRecipes;
+import net.minecraft.entity.EntityLiving;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fml.common.registry.EntityEntry;
+import org.apache.commons.lang3.tuple.Pair;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+import java.util.Map;
+
+@RegistryDescription
+public class Disassembler extends VirtualizedRegistry<Map.Entry<Class<? extends EntityLiving>, List<ItemStack>>> {
+
+    public Map<Class<? extends EntityLiving>, List<ItemStack>> getRecipes() {
+        return MachineRecipes.DISASSEMBLER;
+    }
+
+    @RecipeBuilderDescription(example = {
+            @Example(".entity(entity('minecraft:chicken')).output(item('minecraft:obsidian'), item('minecraft:gold_ingot') * 2, item('minecraft:clay'), item('minecraft:diamond'))"),
+            @Example(".entity(entity('minecraft:rabbit')).output(item('minecraft:clay'), item('minecraft:diamond') * 2)")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @Override
+    public void onReload() {
+        var recipes = getRecipes();
+        removeScripted().forEach(pair -> recipes.remove(pair.getKey()));
+        restoreFromBackup().forEach(pair -> recipes.put(pair.getKey(), pair.getValue()));
+    }
+
+    @MethodDescription(type = MethodDescription.Type.ADDITION, priority = 500)
+    public boolean add(Map.Entry<Class<? extends EntityLiving>, List<ItemStack>> recipe) {
+        if (recipe != null) {
+            getRecipes().put(recipe.getKey(), recipe.getValue());
+            return doAddScripted(recipe);
+        }
+        return false;
+    }
+
+    @MethodDescription(priority = 500)
+    public boolean remove(Map.Entry<Class<? extends EntityLiving>, List<ItemStack>> recipe) {
+        return recipe != null && getRecipes().entrySet().removeIf(r -> r == recipe) && doAddBackup(recipe);
+    }
+
+    @MethodDescription
+    public void removeByEntity(Class<? extends EntityLiving> entity) {
+        getRecipes().entrySet().removeIf(r -> r.getKey().equals(entity) && doAddBackup(r));
+    }
+
+    @SuppressWarnings("unchecked")
+    @MethodDescription(example = @Example("entity('minecraft:creeper')"))
+    public void removeByEntity(EntityEntry entity) {
+        removeByEntity((Class<? extends EntityLiving>) entity.getEntityClass());
+    }
+
+    @MethodDescription(example = @Example("item('minecraft:rotten_flesh')"))
+    public void removeByOutput(IIngredient output) {
+        getRecipes().entrySet().removeIf(r -> r.getValue().stream().anyMatch(output) && doAddBackup(r));
+    }
+
+    @MethodDescription(priority = 2000, example = @Example(commented = true))
+    public void removeAll() {
+        var recipes = getRecipes();
+        recipes.entrySet().forEach(this::addBackup);
+        recipes.clear();
+    }
+
+    @MethodDescription(type = MethodDescription.Type.QUERY)
+    public SimpleObjectStream<Map.Entry<Class<? extends EntityLiving>, List<ItemStack>>> streamRecipes() {
+        return new SimpleObjectStream<>(getRecipes().entrySet()).setRemover(this::remove);
+    }
+
+    @Property(property = "output", comp = @Comp(gte = 1))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<Map.Entry<Class<? extends EntityLiving>, List<ItemStack>>> {
+
+        @Property(comp = @Comp(not = "null"))
+        private Class<? extends EntityLiving> entity;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder entity(Class<? extends EntityLiving> entity) {
+            this.entity = entity;
+            return this;
+        }
+
+        @SuppressWarnings("unchecked")
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder entity(EntityEntry entity) {
+            return entity((Class<? extends EntityLiving>) entity.getEntityClass());
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Factory Tech Disassembler recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 0, 0, 1, Integer.MAX_VALUE);
+            validateFluids(msg);
+            msg.add(entity == null, "entity must be defined and extended EntityLiving, instead it was {}", entity);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable Map.Entry<Class<? extends EntityLiving>, List<ItemStack>> register() {
+            if (!validate()) return null;
+            Map.Entry<Class<? extends EntityLiving>, List<ItemStack>> recipe = Pair.of(entity, output);
+            ModSupport.FACTORY_TECH.get().disassembler.add(recipe);
+            return recipe;
+        }
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/Electroplater.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/Electroplater.java
@@ -63,6 +63,11 @@ public class Electroplater extends StandardListRegistry<MachineRecipes.MachineRe
         }
 
         @Override
+        protected int getMaxItemInput() {
+            return 1;
+        }
+
+        @Override
         public void validate(GroovyLog.Msg msg) {
             validateItems(msg, 1, 1, 1, 1);
             validateFluids(msg);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/Electroplater.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/Electroplater.java
@@ -1,0 +1,83 @@
+package com.cleanroommc.groovyscript.compat.mods.factorytech;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import com.cleanroommc.groovyscript.registry.StandardListRegistry;
+import dalapo.factech.auxiliary.MachineRecipes;
+import net.minecraft.item.ItemStack;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+
+@RegistryDescription
+public class Electroplater extends StandardListRegistry<MachineRecipes.MachineRecipe<ItemStack, ItemStack>> {
+
+    @Override
+    public Collection<MachineRecipes.MachineRecipe<ItemStack, ItemStack>> getRecipes() {
+        return MachineRecipes.ELECTROPLATER;
+    }
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:clay')).output(item('minecraft:diamond'))"),
+            @Example(".input(item('minecraft:gold_ingot')).output(item('minecraft:clay')).allowStoneParts()")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @MethodDescription(example = @Example("item('minecraft:sand')"))
+    public void removeByInput(IIngredient input) {
+        getRecipes().removeIf(r -> input.test(r.input()) && doAddBackup(r));
+    }
+
+    @MethodDescription(example = @Example("item('minecraft:gold_ingot')"))
+    public void removeByOutput(IIngredient output) {
+        getRecipes().removeIf(r -> output.test(r.getOutputStack()) && doAddBackup(r));
+    }
+
+    @Property(property = "input", comp = @Comp(eq = 1))
+    @Property(property = "output", comp = @Comp(eq = 1))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<MachineRecipes.MachineRecipe<ItemStack, ItemStack>> {
+
+        @Property("groovyscript.wiki.factorytech.allowStoneParts.value")
+        private boolean allowStoneParts;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder allowStoneParts(boolean allowStoneParts) {
+            this.allowStoneParts = allowStoneParts;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder allowStoneParts() {
+            this.allowStoneParts = !this.allowStoneParts;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Factory Tech Electroplater recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 1, 1, 1, 1);
+            validateFluids(msg);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable MachineRecipes.MachineRecipe<ItemStack, ItemStack> register() {
+            if (!validate()) return null;
+            MachineRecipes.MachineRecipe<ItemStack, ItemStack> recipe = null;
+            for (var stack : input.get(0).getMatchingStacks()) {
+                recipe = new MachineRecipes.MachineRecipe<>(stack, output.get(0), allowStoneParts);
+                ModSupport.FACTORY_TECH.get().electroplater.add(recipe);
+            }
+            return recipe;
+        }
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/FactoryTech.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/FactoryTech.java
@@ -1,0 +1,26 @@
+package com.cleanroommc.groovyscript.compat.mods.factorytech;
+
+import com.cleanroommc.groovyscript.compat.mods.GroovyPropertyContainer;
+
+public class FactoryTech extends GroovyPropertyContainer {
+
+    public final Agitator agitator = new Agitator();
+    public final Centrifuge centrifuge = new Centrifuge();
+    public final CircuitScribe circuitScribe = new CircuitScribe();
+    public final Compressor compressor = new Compressor();
+    public final Crucible crucible = new Crucible();
+    public final DeepDrill deepDrill = new DeepDrill();
+    public final Disassembler disassembler = new Disassembler();
+    public final Electroplater electroplater = new Electroplater();
+    public final Grindstone grindstone = new Grindstone();
+    public final HighTechFurnace highTechFurnace = new HighTechFurnace();
+    public final MagnetCentrifuge magnetCentrifuge = new MagnetCentrifuge();
+    public final Magnetizer magnetizer = new Magnetizer();
+    public final MetalCutter metalCutter = new MetalCutter();
+    public final OreDrill oreDrill = new OreDrill();
+    public final Reclaimer reclaimer = new Reclaimer();
+    public final Refrigerator refrigerator = new Refrigerator();
+    public final RiverGrate riverGrate = new RiverGrate();
+    public final Saw saw = new Saw();
+    public final Temperer temperer = new Temperer();
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/Grindstone.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/Grindstone.java
@@ -1,0 +1,83 @@
+package com.cleanroommc.groovyscript.compat.mods.factorytech;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import com.cleanroommc.groovyscript.registry.StandardListRegistry;
+import dalapo.factech.auxiliary.MachineRecipes;
+import net.minecraft.item.ItemStack;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+
+@RegistryDescription
+public class Grindstone extends StandardListRegistry<MachineRecipes.MachineRecipe<ItemStack, ItemStack>> {
+
+    @Override
+    public Collection<MachineRecipes.MachineRecipe<ItemStack, ItemStack>> getRecipes() {
+        return MachineRecipes.GRINDSTONE;
+    }
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:clay')).output(item('minecraft:diamond'))"),
+            @Example(".input(item('minecraft:gold_ingot')).output(item('minecraft:clay')).allowStoneParts()")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @MethodDescription(example = @Example("item('minecraft:stone')"))
+    public void removeByInput(IIngredient input) {
+        getRecipes().removeIf(r -> input.test(r.input()) && doAddBackup(r));
+    }
+
+    @MethodDescription(example = @Example("item('factorytech:machinepart:1')"))
+    public void removeByOutput(IIngredient output) {
+        getRecipes().removeIf(r -> output.test(r.getOutputStack()) && doAddBackup(r));
+    }
+
+    @Property(property = "input", comp = @Comp(eq = 1))
+    @Property(property = "output", comp = @Comp(eq = 1))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<MachineRecipes.MachineRecipe<ItemStack, ItemStack>> {
+
+        @Property("groovyscript.wiki.factorytech.allowStoneParts.value")
+        private boolean allowStoneParts;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder allowStoneParts(boolean allowStoneParts) {
+            this.allowStoneParts = allowStoneParts;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder allowStoneParts() {
+            this.allowStoneParts = !this.allowStoneParts;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Factory Tech Grindstone recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 1, 1, 1, 1);
+            validateFluids(msg);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable MachineRecipes.MachineRecipe<ItemStack, ItemStack> register() {
+            if (!validate()) return null;
+            MachineRecipes.MachineRecipe<ItemStack, ItemStack> recipe = null;
+            for (var stack : input.get(0).getMatchingStacks()) {
+                recipe = new MachineRecipes.MachineRecipe<>(stack, output.get(0), allowStoneParts);
+                ModSupport.FACTORY_TECH.get().grindstone.add(recipe);
+            }
+            return recipe;
+        }
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/Grindstone.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/Grindstone.java
@@ -63,6 +63,11 @@ public class Grindstone extends StandardListRegistry<MachineRecipes.MachineRecip
         }
 
         @Override
+        protected int getMaxItemInput() {
+            return 1;
+        }
+
+        @Override
         public void validate(GroovyLog.Msg msg) {
             validateItems(msg, 1, 1, 1, 1);
             validateFluids(msg);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/HighTechFurnace.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/HighTechFurnace.java
@@ -63,6 +63,11 @@ public class HighTechFurnace extends StandardListRegistry<MachineRecipes.Machine
         }
 
         @Override
+        protected int getMaxItemInput() {
+            return 1;
+        }
+
+        @Override
         public void validate(GroovyLog.Msg msg) {
             validateItems(msg, 1, 1, 1, 1);
             validateFluids(msg);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/HighTechFurnace.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/HighTechFurnace.java
@@ -1,0 +1,83 @@
+package com.cleanroommc.groovyscript.compat.mods.factorytech;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import com.cleanroommc.groovyscript.registry.StandardListRegistry;
+import dalapo.factech.auxiliary.MachineRecipes;
+import net.minecraft.item.ItemStack;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+
+@RegistryDescription
+public class HighTechFurnace extends StandardListRegistry<MachineRecipes.MachineRecipe<ItemStack, ItemStack>> {
+
+    @Override
+    public Collection<MachineRecipes.MachineRecipe<ItemStack, ItemStack>> getRecipes() {
+        return MachineRecipes.HTFURNACE;
+    }
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:clay')).output(item('minecraft:diamond'))"),
+            @Example(".input(item('minecraft:gold_ingot')).output(item('minecraft:clay')).allowStoneParts()")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @MethodDescription(example = @Example("item('minecraft:cactus')"))
+    public void removeByInput(IIngredient input) {
+        getRecipes().removeIf(r -> input.test(r.input()) && doAddBackup(r));
+    }
+
+    @MethodDescription(example = @Example("item('minecraft:iron_ingot')"))
+    public void removeByOutput(IIngredient output) {
+        getRecipes().removeIf(r -> output.test(r.getOutputStack()) && doAddBackup(r));
+    }
+
+    @Property(property = "input", comp = @Comp(eq = 1))
+    @Property(property = "output", comp = @Comp(eq = 1))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<MachineRecipes.MachineRecipe<ItemStack, ItemStack>> {
+
+        @Property("groovyscript.wiki.factorytech.allowStoneParts.value")
+        private boolean allowStoneParts;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder allowStoneParts(boolean allowStoneParts) {
+            this.allowStoneParts = allowStoneParts;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder allowStoneParts() {
+            this.allowStoneParts = !this.allowStoneParts;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Factory Tech High Tech Furnace recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 1, 1, 1, 1);
+            validateFluids(msg);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable MachineRecipes.MachineRecipe<ItemStack, ItemStack> register() {
+            if (!validate()) return null;
+            MachineRecipes.MachineRecipe<ItemStack, ItemStack> recipe = null;
+            for (var stack : input.get(0).getMatchingStacks()) {
+                recipe = new MachineRecipes.MachineRecipe<>(stack, output.get(0), allowStoneParts);
+                ModSupport.FACTORY_TECH.get().highTechFurnace.add(recipe);
+            }
+            return recipe;
+        }
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/MagnetCentrifuge.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/MagnetCentrifuge.java
@@ -64,6 +64,11 @@ public class MagnetCentrifuge extends StandardListRegistry<MachineRecipes.Machin
         }
 
         @Override
+        protected int getMaxItemInput() {
+            return 1;
+        }
+
+        @Override
         public void validate(GroovyLog.Msg msg) {
             validateItems(msg, 1, 1, 1, 3);
             validateFluids(msg);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/MagnetCentrifuge.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/MagnetCentrifuge.java
@@ -1,0 +1,84 @@
+package com.cleanroommc.groovyscript.compat.mods.factorytech;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import com.cleanroommc.groovyscript.registry.StandardListRegistry;
+import dalapo.factech.auxiliary.MachineRecipes;
+import net.minecraft.item.ItemStack;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+@RegistryDescription
+public class MagnetCentrifuge extends StandardListRegistry<MachineRecipes.MachineRecipe<ItemStack, ItemStack[]>> {
+
+    @Override
+    public Collection<MachineRecipes.MachineRecipe<ItemStack, ItemStack[]>> getRecipes() {
+        return MachineRecipes.MAGNET_CENTRIFUGE;
+    }
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:clay')).output(item('minecraft:obsidian'), item('minecraft:gold_ingot') * 2, item('minecraft:diamond'))"),
+            @Example(".input(item('minecraft:gold_ingot')).output(item('minecraft:clay')).allowStoneParts()")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @MethodDescription(example = @Example("item('minecraft:gravel')"))
+    public void removeByInput(IIngredient input) {
+        getRecipes().removeIf(r -> input.test(r.input()) && doAddBackup(r));
+    }
+
+    @MethodDescription(example = @Example("item('minecraft:redstone')"))
+    public void removeByOutput(IIngredient output) {
+        getRecipes().removeIf(r -> Arrays.stream(r.getOutputStack()).anyMatch(output) && doAddBackup(r));
+    }
+
+    @Property(property = "input", comp = @Comp(eq = 1))
+    @Property(property = "output", comp = @Comp(gte = 1, lte = 3))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<MachineRecipes.MachineRecipe<ItemStack, ItemStack[]>> {
+
+        @Property("groovyscript.wiki.factorytech.allowStoneParts.value")
+        private boolean allowStoneParts;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder allowStoneParts(boolean allowStoneParts) {
+            this.allowStoneParts = allowStoneParts;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder allowStoneParts() {
+            this.allowStoneParts = !this.allowStoneParts;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Factory Tech Magnet Centrifuge recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 1, 1, 1, 3);
+            validateFluids(msg);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable MachineRecipes.MachineRecipe<ItemStack, ItemStack[]> register() {
+            if (!validate()) return null;
+            MachineRecipes.MachineRecipe<ItemStack, ItemStack[]> recipe = null;
+            for (var stack : input.get(0).getMatchingStacks()) {
+                recipe = new MachineRecipes.MachineRecipe<>(stack, output.toArray(new ItemStack[0]), allowStoneParts);
+                ModSupport.FACTORY_TECH.get().magnetCentrifuge.add(recipe);
+            }
+            return recipe;
+        }
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/Magnetizer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/Magnetizer.java
@@ -63,6 +63,11 @@ public class Magnetizer extends StandardListRegistry<MachineRecipes.MachineRecip
         }
 
         @Override
+        protected int getMaxItemInput() {
+            return 1;
+        }
+
+        @Override
         public void validate(GroovyLog.Msg msg) {
             validateItems(msg, 1, 1, 1, 1);
             validateFluids(msg);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/Magnetizer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/Magnetizer.java
@@ -1,0 +1,83 @@
+package com.cleanroommc.groovyscript.compat.mods.factorytech;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import com.cleanroommc.groovyscript.registry.StandardListRegistry;
+import dalapo.factech.auxiliary.MachineRecipes;
+import net.minecraft.item.ItemStack;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+
+@RegistryDescription
+public class Magnetizer extends StandardListRegistry<MachineRecipes.MachineRecipe<ItemStack, ItemStack>> {
+
+    @Override
+    public Collection<MachineRecipes.MachineRecipe<ItemStack, ItemStack>> getRecipes() {
+        return MachineRecipes.MAGNETIZER;
+    }
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:clay')).output(item('minecraft:diamond'))"),
+            @Example(".input(item('minecraft:gold_ingot')).output(item('minecraft:clay')).allowStoneParts()")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @MethodDescription(example = @Example("item('minecraft:iron_ingot')"))
+    public void removeByInput(IIngredient input) {
+        getRecipes().removeIf(r -> input.test(r.input()) && doAddBackup(r));
+    }
+
+    @MethodDescription(example = @Example(value = "item('factorytech:machinepart:130')", commented = true))
+    public void removeByOutput(IIngredient output) {
+        getRecipes().removeIf(r -> output.test(r.getOutputStack()) && doAddBackup(r));
+    }
+
+    @Property(property = "input", comp = @Comp(eq = 1))
+    @Property(property = "output", comp = @Comp(eq = 1))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<MachineRecipes.MachineRecipe<ItemStack, ItemStack>> {
+
+        @Property("groovyscript.wiki.factorytech.allowStoneParts.value")
+        private boolean allowStoneParts;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder allowStoneParts(boolean allowStoneParts) {
+            this.allowStoneParts = allowStoneParts;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder allowStoneParts() {
+            this.allowStoneParts = !this.allowStoneParts;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Factory Tech Magnetizer recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 1, 1, 1, 1);
+            validateFluids(msg);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable MachineRecipes.MachineRecipe<ItemStack, ItemStack> register() {
+            if (!validate()) return null;
+            MachineRecipes.MachineRecipe<ItemStack, ItemStack> recipe = null;
+            for (var stack : input.get(0).getMatchingStacks()) {
+                recipe = new MachineRecipes.MachineRecipe<>(stack, output.get(0), allowStoneParts);
+                ModSupport.FACTORY_TECH.get().magnetizer.add(recipe);
+            }
+            return recipe;
+        }
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/MetalCutter.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/MetalCutter.java
@@ -1,0 +1,83 @@
+package com.cleanroommc.groovyscript.compat.mods.factorytech;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import com.cleanroommc.groovyscript.registry.StandardListRegistry;
+import dalapo.factech.auxiliary.MachineRecipes;
+import net.minecraft.item.ItemStack;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+
+@RegistryDescription
+public class MetalCutter extends StandardListRegistry<MachineRecipes.MachineRecipe<ItemStack, ItemStack>> {
+
+    @Override
+    public Collection<MachineRecipes.MachineRecipe<ItemStack, ItemStack>> getRecipes() {
+        return MachineRecipes.METALCUTTER;
+    }
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:clay')).output(item('minecraft:diamond'))"),
+            @Example(".input(item('minecraft:gold_ingot')).output(item('minecraft:clay')).allowStoneParts()")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @MethodDescription(example = @Example("item('minecraft:gold_ingot')"))
+    public void removeByInput(IIngredient input) {
+        getRecipes().removeIf(r -> input.test(r.input()) && doAddBackup(r));
+    }
+
+    @MethodDescription(example = @Example("item('factorytech:machinepart:20')"))
+    public void removeByOutput(IIngredient output) {
+        getRecipes().removeIf(r -> output.test(r.getOutputStack()) && doAddBackup(r));
+    }
+
+    @Property(property = "input", comp = @Comp(eq = 1))
+    @Property(property = "output", comp = @Comp(eq = 1))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<MachineRecipes.MachineRecipe<ItemStack, ItemStack>> {
+
+        @Property("groovyscript.wiki.factorytech.allowStoneParts.value")
+        private boolean allowStoneParts;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder allowStoneParts(boolean allowStoneParts) {
+            this.allowStoneParts = allowStoneParts;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder allowStoneParts() {
+            this.allowStoneParts = !this.allowStoneParts;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Factory Tech Metal Cutter recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 1, 1, 1, 1);
+            validateFluids(msg);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable MachineRecipes.MachineRecipe<ItemStack, ItemStack> register() {
+            if (!validate()) return null;
+            MachineRecipes.MachineRecipe<ItemStack, ItemStack> recipe = null;
+            for (var stack : input.get(0).getMatchingStacks()) {
+                recipe = new MachineRecipes.MachineRecipe<>(stack, output.get(0), allowStoneParts);
+                ModSupport.FACTORY_TECH.get().metalCutter.add(recipe);
+            }
+            return recipe;
+        }
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/MetalCutter.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/MetalCutter.java
@@ -63,6 +63,11 @@ public class MetalCutter extends StandardListRegistry<MachineRecipes.MachineReci
         }
 
         @Override
+        protected int getMaxItemInput() {
+            return 1;
+        }
+
+        @Override
         public void validate(GroovyLog.Msg msg) {
             validateItems(msg, 1, 1, 1, 1);
             validateFluids(msg);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/OreDrill.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/OreDrill.java
@@ -1,0 +1,83 @@
+package com.cleanroommc.groovyscript.compat.mods.factorytech;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import com.cleanroommc.groovyscript.registry.StandardListRegistry;
+import dalapo.factech.auxiliary.MachineRecipes;
+import net.minecraft.item.ItemStack;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+
+@RegistryDescription
+public class OreDrill extends StandardListRegistry<MachineRecipes.MachineRecipe<ItemStack, ItemStack>> {
+
+    @Override
+    public Collection<MachineRecipes.MachineRecipe<ItemStack, ItemStack>> getRecipes() {
+        return MachineRecipes.OREDRILL;
+    }
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:clay')).output(item('minecraft:diamond'))"),
+            @Example(".input(item('minecraft:gold_ingot')).output(item('minecraft:clay')).allowStoneParts()")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @MethodDescription(example = @Example("item('minecraft:gold_ore')"))
+    public void removeByInput(IIngredient input) {
+        getRecipes().removeIf(r -> input.test(r.input()) && doAddBackup(r));
+    }
+
+    @MethodDescription(example = @Example("item('minecraft:sand')"))
+    public void removeByOutput(IIngredient output) {
+        getRecipes().removeIf(r -> output.test(r.getOutputStack()) && doAddBackup(r));
+    }
+
+    @Property(property = "input", comp = @Comp(eq = 1))
+    @Property(property = "output", comp = @Comp(eq = 1))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<MachineRecipes.MachineRecipe<ItemStack, ItemStack>> {
+
+        @Property("groovyscript.wiki.factorytech.allowStoneParts.value")
+        private boolean allowStoneParts;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder allowStoneParts(boolean allowStoneParts) {
+            this.allowStoneParts = allowStoneParts;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder allowStoneParts() {
+            this.allowStoneParts = !this.allowStoneParts;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Factory Tech Ore Drill recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 1, 1, 1, 1);
+            validateFluids(msg);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable MachineRecipes.MachineRecipe<ItemStack, ItemStack> register() {
+            if (!validate()) return null;
+            MachineRecipes.MachineRecipe<ItemStack, ItemStack> recipe = null;
+            for (var stack : input.get(0).getMatchingStacks()) {
+                recipe = new MachineRecipes.MachineRecipe<>(stack, output.get(0), allowStoneParts);
+                ModSupport.FACTORY_TECH.get().oreDrill.add(recipe);
+            }
+            return recipe;
+        }
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/OreDrill.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/OreDrill.java
@@ -63,6 +63,11 @@ public class OreDrill extends StandardListRegistry<MachineRecipes.MachineRecipe<
         }
 
         @Override
+        protected int getMaxItemInput() {
+            return 1;
+        }
+
+        @Override
         public void validate(GroovyLog.Msg msg) {
             validateItems(msg, 1, 1, 1, 1);
             validateFluids(msg);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/Reclaimer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/Reclaimer.java
@@ -1,0 +1,83 @@
+package com.cleanroommc.groovyscript.compat.mods.factorytech;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import com.cleanroommc.groovyscript.registry.StandardListRegistry;
+import dalapo.factech.auxiliary.MachineRecipes;
+import net.minecraft.item.ItemStack;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+
+@RegistryDescription
+public class Reclaimer extends StandardListRegistry<MachineRecipes.MachineRecipe<ItemStack, ItemStack>> {
+
+    @Override
+    public Collection<MachineRecipes.MachineRecipe<ItemStack, ItemStack>> getRecipes() {
+        return MachineRecipes.RECLAIMER;
+    }
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:clay')).output(item('minecraft:diamond'))"),
+            @Example(".input(item('minecraft:gold_ingot')).output(item('minecraft:clay')).allowStoneParts()")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @MethodDescription(example = @Example("item('factorytech:salvagepart:22')"))
+    public void removeByInput(IIngredient input) {
+        getRecipes().removeIf(r -> input.test(r.input()) && doAddBackup(r));
+    }
+
+    @MethodDescription(example = @Example("item('minecraft:iron_nugget')"))
+    public void removeByOutput(IIngredient output) {
+        getRecipes().removeIf(r -> output.test(r.getOutputStack()) && doAddBackup(r));
+    }
+
+    @Property(property = "input", comp = @Comp(eq = 1))
+    @Property(property = "output", comp = @Comp(eq = 1))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<MachineRecipes.MachineRecipe<ItemStack, ItemStack>> {
+
+        @Property("groovyscript.wiki.factorytech.allowStoneParts.value")
+        private boolean allowStoneParts;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder allowStoneParts(boolean allowStoneParts) {
+            this.allowStoneParts = allowStoneParts;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder allowStoneParts() {
+            this.allowStoneParts = !this.allowStoneParts;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Factory Tech Reclaimer recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 1, 1, 1, 1);
+            validateFluids(msg);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable MachineRecipes.MachineRecipe<ItemStack, ItemStack> register() {
+            if (!validate()) return null;
+            MachineRecipes.MachineRecipe<ItemStack, ItemStack> recipe = null;
+            for (var stack : input.get(0).getMatchingStacks()) {
+                recipe = new MachineRecipes.MachineRecipe<>(stack, output.get(0), allowStoneParts);
+                ModSupport.FACTORY_TECH.get().reclaimer.add(recipe);
+            }
+            return recipe;
+        }
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/Reclaimer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/Reclaimer.java
@@ -63,6 +63,11 @@ public class Reclaimer extends StandardListRegistry<MachineRecipes.MachineRecipe
         }
 
         @Override
+        protected int getMaxItemInput() {
+            return 1;
+        }
+
+        @Override
         public void validate(GroovyLog.Msg msg) {
             validateItems(msg, 1, 1, 1, 1);
             validateFluids(msg);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/Refrigerator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/Refrigerator.java
@@ -1,0 +1,66 @@
+package com.cleanroommc.groovyscript.compat.mods.factorytech;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import com.cleanroommc.groovyscript.registry.StandardListRegistry;
+import dalapo.factech.auxiliary.MachineRecipes;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+
+@RegistryDescription
+public class Refrigerator extends StandardListRegistry<MachineRecipes.MachineRecipe<FluidStack, ItemStack>> {
+
+    @Override
+    public Collection<MachineRecipes.MachineRecipe<FluidStack, ItemStack>> getRecipes() {
+        return MachineRecipes.REFRIGERATOR;
+    }
+
+    @RecipeBuilderDescription(example = {
+            @Example(".fluidInput(fluid('water') * 100).output(item('minecraft:diamond'))"),
+            @Example(".fluidInput(fluid('lava') * 30).output(item('minecraft:clay'))")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @MethodDescription(example = @Example("fluid('water')"))
+    public void removeByInput(IIngredient input) {
+        getRecipes().removeIf(r -> input.test(r.input()) && doAddBackup(r));
+    }
+
+    @MethodDescription(example = @Example("item('minecraft:obsidian')"))
+    public void removeByOutput(IIngredient output) {
+        getRecipes().removeIf(r -> output.test(r.getOutputStack()) && doAddBackup(r));
+    }
+
+    @Property(property = "fluidInput", comp = @Comp(eq = 1))
+    @Property(property = "output", comp = @Comp(eq = 1))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<MachineRecipes.MachineRecipe<FluidStack, ItemStack>> {
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Factory Tech Refrigerator recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 0, 0, 1, 1);
+            validateFluids(msg, 1, 1, 0, 0);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable MachineRecipes.MachineRecipe<FluidStack, ItemStack> register() {
+            if (!validate()) return null;
+            var recipe = new MachineRecipes.MachineRecipe<>(fluidInput.get(0), output.get(0));
+            ModSupport.FACTORY_TECH.get().refrigerator.add(recipe);
+            return recipe;
+        }
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/RiverGrate.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/RiverGrate.java
@@ -1,0 +1,83 @@
+package com.cleanroommc.groovyscript.compat.mods.factorytech;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import com.cleanroommc.groovyscript.registry.StandardListRegistry;
+import dalapo.factech.auxiliary.MachineRecipes;
+import net.minecraft.item.ItemStack;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+
+@RegistryDescription(category = RegistryDescription.Category.ENTRIES)
+public class RiverGrate extends StandardListRegistry<MachineRecipes.MachineRecipe<Double, ItemStack>> {
+
+    @Override
+    public Collection<MachineRecipes.MachineRecipe<Double, ItemStack>> getRecipes() {
+        return MachineRecipes.RIVER_GRATE;
+    }
+
+    @RecipeBuilderDescription(example = {
+            @Example(".output(item('minecraft:diamond')).weight(10)"),
+            @Example(".output(item('minecraft:clay')).allowStoneParts().weight(30)")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @MethodDescription(example = @Example("item('minecraft:fish')"))
+    public void removeByOutput(IIngredient output) {
+        getRecipes().removeIf(r -> output.test(r.getOutputStack()) && doAddBackup(r));
+    }
+
+    @Property(property = "output", comp = @Comp(eq = 1))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<MachineRecipes.MachineRecipe<Double, ItemStack>> {
+
+        @Property("groovyscript.wiki.factorytech.allowStoneParts.value")
+        private boolean allowStoneParts;
+        @Property(comp = @Comp(gte = 0))
+        private double weight;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder allowStoneParts(boolean allowStoneParts) {
+            this.allowStoneParts = allowStoneParts;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder allowStoneParts() {
+            this.allowStoneParts = !this.allowStoneParts;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder weight(double weight) {
+            this.weight = weight;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Factory Tech River Grate recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 0, 0, 1, 1);
+            validateFluids(msg);
+            msg.add(weight < 0, "weight must be a non-negative double, yet it was {}", weight);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable MachineRecipes.MachineRecipe<Double, ItemStack> register() {
+            if (!validate()) return null;
+            var recipe = new MachineRecipes.MachineRecipe<>(weight, output.get(0), allowStoneParts);
+            ModSupport.FACTORY_TECH.get().riverGrate.add(recipe);
+            return recipe;
+        }
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/Saw.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/Saw.java
@@ -1,0 +1,83 @@
+package com.cleanroommc.groovyscript.compat.mods.factorytech;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import com.cleanroommc.groovyscript.registry.StandardListRegistry;
+import dalapo.factech.auxiliary.MachineRecipes;
+import net.minecraft.item.ItemStack;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+
+@RegistryDescription
+public class Saw extends StandardListRegistry<MachineRecipes.MachineRecipe<ItemStack, ItemStack>> {
+
+    @Override
+    public Collection<MachineRecipes.MachineRecipe<ItemStack, ItemStack>> getRecipes() {
+        return MachineRecipes.SAW;
+    }
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:clay')).output(item('minecraft:diamond'))"),
+            @Example(".input(item('minecraft:gold_ingot')).output(item('minecraft:clay')).allowStoneParts()")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @MethodDescription(example = @Example("item('minecraft:log')"))
+    public void removeByInput(IIngredient input) {
+        getRecipes().removeIf(r -> input.test(r.input()) && doAddBackup(r));
+    }
+
+    @MethodDescription(example = @Example("item('minecraft:stick')"))
+    public void removeByOutput(IIngredient output) {
+        getRecipes().removeIf(r -> output.test(r.getOutputStack()) && doAddBackup(r));
+    }
+
+    @Property(property = "input", comp = @Comp(eq = 1))
+    @Property(property = "output", comp = @Comp(eq = 1))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<MachineRecipes.MachineRecipe<ItemStack, ItemStack>> {
+
+        @Property("groovyscript.wiki.factorytech.allowStoneParts.value")
+        private boolean allowStoneParts;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder allowStoneParts(boolean allowStoneParts) {
+            this.allowStoneParts = allowStoneParts;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder allowStoneParts() {
+            this.allowStoneParts = !this.allowStoneParts;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Factory Tech Saw recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 1, 1, 1, 1);
+            validateFluids(msg);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable MachineRecipes.MachineRecipe<ItemStack, ItemStack> register() {
+            if (!validate()) return null;
+            MachineRecipes.MachineRecipe<ItemStack, ItemStack> recipe = null;
+            for (var stack : input.get(0).getMatchingStacks()) {
+                recipe = new MachineRecipes.MachineRecipe<>(stack, output.get(0), allowStoneParts);
+                ModSupport.FACTORY_TECH.get().saw.add(recipe);
+            }
+            return recipe;
+        }
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/Saw.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/Saw.java
@@ -63,6 +63,11 @@ public class Saw extends StandardListRegistry<MachineRecipes.MachineRecipe<ItemS
         }
 
         @Override
+        protected int getMaxItemInput() {
+            return 1;
+        }
+
+        @Override
         public void validate(GroovyLog.Msg msg) {
             validateItems(msg, 1, 1, 1, 1);
             validateFluids(msg);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/Temperer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/Temperer.java
@@ -1,0 +1,78 @@
+package com.cleanroommc.groovyscript.compat.mods.factorytech;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import com.cleanroommc.groovyscript.registry.StandardListRegistry;
+import dalapo.factech.auxiliary.MachineRecipes;
+import dalapo.factech.tileentity.specialized.TileEntityTemperer;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+
+@RegistryDescription
+public class Temperer extends StandardListRegistry<TileEntityTemperer.TempererRecipe> {
+
+    @Override
+    public Collection<TileEntityTemperer.TempererRecipe> getRecipes() {
+        return MachineRecipes.TEMPERER;
+    }
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:clay')).output(item('minecraft:diamond'))"),
+            @Example(".input(item('minecraft:gold_ingot')).output(item('minecraft:clay')).time(30)")
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @MethodDescription(example = @Example("item('minecraft:iron_ingot')"))
+    public void removeByInput(IIngredient input) {
+        getRecipes().removeIf(r -> input.test(r.getInput()) && doAddBackup(r));
+    }
+
+    @MethodDescription(example = @Example("item('factorytech:machinepart:4')"))
+    public void removeByOutput(IIngredient output) {
+        getRecipes().removeIf(r -> output.test(r.getOutputStack()) && doAddBackup(r));
+    }
+
+    @Property(property = "input", comp = @Comp(eq = 1))
+    @Property(property = "output", comp = @Comp(eq = 1))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<TileEntityTemperer.TempererRecipe> {
+
+        @Property(defaultValue = "5", comp = @Comp(gte = 5))
+        private int time = 5;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder time(int time) {
+            this.time = time;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Factory Tech Temperer recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 1, 1, 1, 1);
+            validateFluids(msg);
+            msg.add(time < 5, "time must be an integer greater than or equal to 5, yet it was {}", time);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable TileEntityTemperer.TempererRecipe register() {
+            if (!validate()) return null;
+            TileEntityTemperer.TempererRecipe recipe = null;
+            for (var stack : input.get(0).getMatchingStacks()) {
+                recipe = new TileEntityTemperer.TempererRecipe(stack, output.get(0), time);
+                ModSupport.FACTORY_TECH.get().temperer.add(recipe);
+            }
+            return recipe;
+        }
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/Temperer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/factorytech/Temperer.java
@@ -57,6 +57,11 @@ public class Temperer extends StandardListRegistry<TileEntityTemperer.TempererRe
         }
 
         @Override
+        protected int getMaxItemInput() {
+            return 1;
+        }
+
+        @Override
         public void validate(GroovyLog.Msg msg) {
             validateItems(msg, 1, 1, 1, 1);
             validateFluids(msg);

--- a/src/main/resources/assets/groovyscript/lang/en_us.lang
+++ b/src/main/resources/assets/groovyscript/lang/en_us.lang
@@ -1081,6 +1081,75 @@ groovyscript.wiki.extrautils2.resonator.requirementText.value=Sets the text in J
 groovyscript.wiki.extrautils2.resonator.shouldProgress.value=Sets the function used to determine if the recipe should run, with the Closure taking 3 parameters, `TileEntity resonator`, `int frequency`, `ItemStack input` and returning a `boolean`
 
 
+# Factory Tech
+groovyscript.wiki.factorytech.allowStoneParts.value=Sets if the recipe can use stone parts
+
+groovyscript.wiki.factorytech.agitator.title=Fluid Agitator
+groovyscript.wiki.factorytech.agitator.description=Converts either one or two input fluidstacks and up to one input itemstack into an output itemstack, output fluidstack, or both.
+
+groovyscript.wiki.factorytech.centrifuge.title=Centrifuge
+groovyscript.wiki.factorytech.centrifuge.description=Converts an input itemstack into up to 3 output itemstacks, with the ability to control if stone parts are allowed.
+
+groovyscript.wiki.factorytech.circuit_scribe.title=Circuit Scribe
+groovyscript.wiki.factorytech.circuit_scribe.description=Converts an input itemstack into an output itemstack, with the ability to control if stone parts are allowed.
+groovyscript.wiki.factorytech.circuit_scribe.note0=Recipes will not appear properly in JEI
+
+groovyscript.wiki.factorytech.compressor.title=Compression Chamber
+groovyscript.wiki.factorytech.compressor.description=Converts an input itemstack and input fluidstack into an output itemstack.
+
+groovyscript.wiki.factorytech.crucible.title=Crucible
+groovyscript.wiki.factorytech.crucible.description=Converts an input itemstack into an output fluidstack.
+
+groovyscript.wiki.factorytech.deep_drill.title=Terraneous Extractor
+groovyscript.wiki.factorytech.deep_drill.description=Passively generates resources when placed at or below y 8 and
+groovyscript.wiki.factorytech.deep_drill.weight.value=Sets the weight compared to other entries
+
+groovyscript.wiki.factorytech.disassembler.title=Mob Disassembler
+groovyscript.wiki.factorytech.disassembler.description=Kills an entity in-world, dropping the mob's normal loot in addition to custom loot.
+groovyscript.wiki.factorytech.disassembler.add=Adds the given entry to the map
+groovyscript.wiki.factorytech.disassembler.entity.value=Sets the entity class used
+groovyscript.wiki.factorytech.disassembler.remove=Removes the given entry from the map
+groovyscript.wiki.factorytech.disassembler.removeByEntity=Removes all recipes matching the given entity class
+
+groovyscript.wiki.factorytech.electroplater.title=Electroplater
+groovyscript.wiki.factorytech.electroplater.description=Converts an input itemstack into an output itemstack, with the ability to control if stone parts are allowed.
+
+groovyscript.wiki.factorytech.grindstone.title=Grindstone
+groovyscript.wiki.factorytech.grindstone.description=Converts an input itemstack into an output itemstack, with the ability to control if stone parts are allowed.
+
+groovyscript.wiki.factorytech.high_tech_furnace.title=Electric Furnace
+groovyscript.wiki.factorytech.high_tech_furnace.description=Converts an input itemstack into an output itemstack, with the ability to control if stone parts are allowed.
+
+groovyscript.wiki.factorytech.magnet_centrifuge.title=Magnet Centrifuge
+groovyscript.wiki.factorytech.magnet_centrifuge.description=Converts an input itemstack into up to 3 output itemstacks, with the ability to control if stone parts are allowed.
+
+groovyscript.wiki.factorytech.magnetizer.title=Magnetizer
+groovyscript.wiki.factorytech.magnetizer.description=Converts an input itemstack into an output itemstack, with the ability to control if stone parts are allowed.
+
+groovyscript.wiki.factorytech.metal_cutter.title=Metal Cutter
+groovyscript.wiki.factorytech.metal_cutter.description=Converts an input itemstack into an output itemstack, with the ability to control if stone parts are allowed.
+
+groovyscript.wiki.factorytech.ore_drill.title=Drill Grinder
+groovyscript.wiki.factorytech.ore_drill.description=Converts an input itemstack into an output itemstack, with the ability to control if stone parts are allowed.
+
+groovyscript.wiki.factorytech.reclaimer.title=Scrap Furnace
+groovyscript.wiki.factorytech.reclaimer.description=Converts an input itemstack into an output itemstack, with the ability to control if stone parts are allowed.
+
+groovyscript.wiki.factorytech.refrigerator.title=Refrigerator
+groovyscript.wiki.factorytech.refrigerator.description=Converts an input fluidstack into an output itemstack.
+
+groovyscript.wiki.factorytech.river_grate.title=River Grate
+groovyscript.wiki.factorytech.river_grate.description=Slowly produces the output entries while in a river biome surrounded by water, and between y 60 and 70.
+groovyscript.wiki.factorytech.river_grate.weight.value=Sets the weight compared to other entries
+
+groovyscript.wiki.factorytech.saw.title=Chop Saw
+groovyscript.wiki.factorytech.saw.description=Converts an input itemstack into an output itemstack, with the ability to control if stone parts are allowed.
+
+groovyscript.wiki.factorytech.temperer.title=Tempering Oven
+groovyscript.wiki.factorytech.temperer.description=Converts an input itemstack into an output itemstack, with the ability to control if stone parts are allowed and how long the recipe takes.
+groovyscript.wiki.factorytech.temperer.time.value=Sets the time in ticks the recipe takes to complete
+
+
 # Future MC
 groovyscript.wiki.futuremc.blast_furnace.title=Blast Furnace
 groovyscript.wiki.futuremc.blast_furnace.description=Converts an input itemstack into an output itemstack at the cost of burnable fuel.


### PR DESCRIPTION
changes in this PR:
- add compat with Factory Tech `agitator`, `centrifuge`, `circuitScribe`, `compressor`, `crucible`, `deepDrill`, `disassembler`, `electroplater`, `grindstone`, `highTechFurnace`, `magnetCentrifuge`, `magnetizer`, `metalCutter`, `oreDrill`, `reclaimer`, `refrigerator`, `riverGrate`, `saw`, and `temperer`. examples and i18n for those.
- apply the `getMaxItemInput` method to all applicable.