### PR TITLE
Fix some IDE warnings

### DIFF
--- a/src/main/java/com/cleanroommc/groovyscript/GroovyScript.java
+++ b/src/main/java/com/cleanroommc/groovyscript/GroovyScript.java
@@ -203,33 +203,27 @@ public class GroovyScript {
         }
     }
 
-    @NotNull
-    public static String getScriptPath() {
+    public static @NotNull String getScriptPath() {
         return getScriptFile().getPath();
     }
 
-    @NotNull
-    public static File getMinecraftHome() {
+    public static @NotNull File getMinecraftHome() {
         return SandboxData.getMinecraftHome();
     }
 
-    @NotNull
-    public static File getScriptFile() {
+    public static @NotNull File getScriptFile() {
         return SandboxData.getScriptFile();
     }
 
-    @NotNull
-    public static File getResourcesFile() {
+    public static @NotNull File getResourcesFile() {
         return SandboxData.getResourcesFile();
     }
 
-    @NotNull
-    public static File getRunConfigFile() {
+    public static @NotNull File getRunConfigFile() {
         return SandboxData.getRunConfigFile();
     }
 
-    @NotNull
-    public static GroovyScriptSandbox getSandbox() {
+    public static @NotNull GroovyScriptSandbox getSandbox() {
         if (sandbox == null) {
             throw new IllegalStateException("GroovyScript is not yet loaded or failed to load!");
         }

--- a/src/main/java/com/cleanroommc/groovyscript/api/GroovyLog.java
+++ b/src/main/java/com/cleanroommc/groovyscript/api/GroovyLog.java
@@ -39,8 +39,7 @@ public interface GroovyLog {
     /**
      * @return an instance of {@link GroovyLog}
      */
-    @NotNull
-    static GroovyLog get() {
+    static @NotNull GroovyLog get() {
         return GroovyLogImpl.LOG;
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/api/IGroovyContainer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/api/IGroovyContainer.java
@@ -45,8 +45,7 @@ public interface IGroovyContainer {
      *
      * @return aliases
      */
-    @NotNull
-    default Collection<String> getAliases() {
+    default @NotNull Collection<String> getAliases() {
         return Collections.singletonList(getModId());
     }
 
@@ -67,8 +66,7 @@ public interface IGroovyContainer {
      * @return the override priority
      * @see Priority
      */
-    @NotNull
-    default Priority getOverridePriority() {
+    default @NotNull Priority getOverridePriority() {
         return Priority.NONE;
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/api/IIngredient.java
+++ b/src/main/java/com/cleanroommc/groovyscript/api/IIngredient.java
@@ -98,9 +98,8 @@ public interface IIngredient extends IResourceStack, Predicate<ItemStack>, IMark
             return stack.isEmpty();
         }
 
-        @Nullable
         @Override
-        public String getMark() {
+        public @Nullable String getMark() {
             return null;
         }
 
@@ -152,9 +151,8 @@ public interface IIngredient extends IResourceStack, Predicate<ItemStack>, IMark
             return true;
         }
 
-        @Nullable
         @Override
-        public String getMark() {
+        public @Nullable String getMark() {
             return null;
         }
 

--- a/src/main/java/com/cleanroommc/groovyscript/api/INBTResourceStack.java
+++ b/src/main/java/com/cleanroommc/groovyscript/api/INBTResourceStack.java
@@ -20,8 +20,7 @@ public interface INBTResourceStack extends IResourceStack {
     @Nullable
     NBTTagCompound getNbt();
 
-    @NotNull
-    default NBTTagCompound getOrCreateNbt() {
+    default @NotNull NBTTagCompound getOrCreateNbt() {
         NBTTagCompound nbt = getNbt();
         if (nbt == null) {
             nbt = new NBTTagCompound();
@@ -30,8 +29,7 @@ public interface INBTResourceStack extends IResourceStack {
         return nbt;
     }
 
-    @Nullable
-    default NBTBase getSubTag(String key) {
+    default @Nullable NBTBase getSubTag(String key) {
         NBTTagCompound nbt = getNbt();
         return nbt == null ? null : nbt.getTag(key);
     }

--- a/src/main/java/com/cleanroommc/groovyscript/api/Result.java
+++ b/src/main/java/com/cleanroommc/groovyscript/api/Result.java
@@ -36,6 +36,7 @@ public interface Result<T> {
     @NotNull
     T getValue();
 
+    @SuppressWarnings("ClassCanBeRecord")
     class Some<T> implements Result<T> {
 
         private final T value;
@@ -60,6 +61,7 @@ public interface Result<T> {
         }
     }
 
+    @SuppressWarnings("ClassCanBeRecord")
     class Error<T> implements Result<T> {
 
         private final String error;

--- a/src/main/java/com/cleanroommc/groovyscript/api/infocommand/InfoParserPackage.java
+++ b/src/main/java/com/cleanroommc/groovyscript/api/infocommand/InfoParserPackage.java
@@ -23,24 +23,20 @@ public class InfoParserPackage {
     /**
      * Server where the command is executed
      */
-    @NotNull
-    private final MinecraftServer server;
+    private final @NotNull MinecraftServer server;
     /**
      * Player who executes the command
      */
-    @NotNull
-    private final EntityPlayer player;
+    private final @NotNull EntityPlayer player;
     /**
      * Arguments of the command
      */
-    @NotNull
-    private final List<String> args;
+    private final @NotNull List<String> args;
     /**
      * A list of messages that will be sent to the player after this event.
      * Add or remove your messages here.
      */
-    @NotNull
-    private final List<ITextComponent> messages;
+    private final @NotNull List<ITextComponent> messages;
     /**
      * If pretty nbt is enabled
      */
@@ -48,33 +44,27 @@ public class InfoParserPackage {
     /**
      * The held item or the item form of the block being looked at.
      */
-    @NotNull
-    private ItemStack stack;
+    private @NotNull ItemStack stack;
     /**
      * The entity the player is looking at
      */
-    @Nullable
-    private Entity entity;
+    private @Nullable Entity entity;
     /**
      * The block position the player is looking at
      */
-    @Nullable
-    private BlockPos pos;
+    private @Nullable BlockPos pos;
     /**
      * The block state of the held item or the block state the player is looking at
      */
-    @Nullable
-    private IBlockState blockState;
+    private @Nullable IBlockState blockState;
     /**
      * The block of the held item or the block the player is looking at
      */
-    @Nullable
-    private Block block;
+    private @Nullable Block block;
     /**
      * The tile entity the player is looking at
      */
-    @Nullable
-    private TileEntity tileEntity;
+    private @Nullable TileEntity tileEntity;
 
     public InfoParserPackage(
             @NotNull MinecraftServer server,

--- a/src/main/java/com/cleanroommc/groovyscript/command/GSCommand.java
+++ b/src/main/java/com/cleanroommc/groovyscript/command/GSCommand.java
@@ -161,20 +161,17 @@ public class GSCommand extends CommandTreeBase {
     }
 
     @Override
-    @NotNull
-    public String getName() {
+    public @NotNull String getName() {
         return "groovyscript";
     }
 
     @Override
-    @NotNull
-    public List<String> getAliases() {
+    public @NotNull List<String> getAliases() {
         return Arrays.asList("grs", "GroovyScript", "gs");
     }
 
     @Override
-    @NotNull
-    public String getUsage(@NotNull ICommandSender sender) {
+    public @NotNull String getUsage(@NotNull ICommandSender sender) {
         return "/grs []";
     }
 }

--- a/src/main/java/com/cleanroommc/groovyscript/command/GSCommand.java
+++ b/src/main/java/com/cleanroommc/groovyscript/command/GSCommand.java
@@ -32,22 +32,22 @@ public class GSCommand extends CommandTreeBase {
         addSubcommand(new SimpleCommand("log", (server, sender, args) -> postLogFiles(sender)));
 
         addSubcommand(new SimpleCommand("reload", (server, sender, args) -> {
-            if (sender instanceof EntityPlayerMP) {
+            if (sender instanceof EntityPlayerMP player) {
                 if (hasArgument(args, "--clean")) {
                     GroovyLogImpl.LOG.cleanLog();
                 }
-                runReload((EntityPlayerMP) sender, server);
+                runReload(player, server);
             }
         }));
 
         addSubcommand(new SimpleCommand("check", (server, sender, args) -> {
-            if (sender instanceof EntityPlayerMP) {
+            if (sender instanceof EntityPlayerMP player) {
                 sender.sendMessage(new TextComponentString("Checking groovy syntax..."));
                 long time = System.currentTimeMillis();
                 GroovyScript.getSandbox().checkSyntax();
                 time = System.currentTimeMillis() - time;
                 sender.sendMessage(new TextComponentString("Checking syntax took " + time + "ms"));
-                GroovyScript.postScriptRunResult((EntityPlayerMP) sender, false, false, false, time);
+                GroovyScript.postScriptRunResult(player, false, false, false, time);
             }
         }));
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/FluidRecipe.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/FluidRecipe.java
@@ -227,8 +227,7 @@ public abstract class FluidRecipe {
      */
     public abstract void handleRecipeResult(World world, BlockPos pos);
 
-    @Nullable
-    public static Fluid getFluid(IBlockState state) {
+    public static @Nullable Fluid getFluid(IBlockState state) {
         Block block = state.getBlock();
 
         if (block instanceof IFluidBlock) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/FluidRecipe.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/FluidRecipe.java
@@ -230,8 +230,8 @@ public abstract class FluidRecipe {
     public static @Nullable Fluid getFluid(IBlockState state) {
         Block block = state.getBlock();
 
-        if (block instanceof IFluidBlock) {
-            return ((IFluidBlock) block).getFluid();
+        if (block instanceof IFluidBlock iFluidBlock) {
+            return iFluidBlock.getFluid();
         }
         if (block instanceof BlockLiquid) {
             if (state.getMaterial() == Material.WATER) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/FluidToItem.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/FluidToItem.java
@@ -122,7 +122,7 @@ public class FluidToItem extends VirtualizedRegistry<FluidToItem.Recipe> {
 
     public static class RecipeBuilder extends FluidRecipe.RecipeBuilder<FluidToItem.Recipe> {
 
-        private float fluidConsumptionChance = 1f;
+        private float fluidConsumptionChance = 1.0f;
 
         public RecipeBuilder fluidInput(FluidStack fluidStack, float fluidConsumptionChance) {
             fluidInput(fluidStack);
@@ -144,7 +144,7 @@ public class FluidToItem extends VirtualizedRegistry<FluidToItem.Recipe> {
             validateItems(msg, 1, Recipe.MAX_ITEM_INPUT, 1, 1);
             validateFluids(msg, 1, 1, 0, 0);
             validateChances(msg);
-            this.fluidConsumptionChance = MathHelper.clamp(this.fluidConsumptionChance, 0f, 1f);
+            this.fluidConsumptionChance = MathHelper.clamp(this.fluidConsumptionChance, 0.0f, 1.0f);
         }
 
         @Override

--- a/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/jei/BurningRecipeCategory.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/jei/BurningRecipeCategory.java
@@ -55,9 +55,8 @@ public class BurningRecipeCategory extends BaseCategory<BurningRecipeCategory.Re
         GlStateManager.popMatrix();
     }
 
-    @Nullable
     @Override
-    public IDrawable getIcon() {
+    public @Nullable IDrawable getIcon() {
         return icon;
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/jei/ExplosionRecipeCategory.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/jei/ExplosionRecipeCategory.java
@@ -56,9 +56,8 @@ public class ExplosionRecipeCategory extends BaseCategory<ExplosionRecipeCategor
         GlStateManager.popMatrix();
     }
 
-    @Nullable
     @Override
-    public IDrawable getIcon() {
+    public @Nullable IDrawable getIcon() {
         return icon;
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/jei/FluidRecipeCategory.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/jei/FluidRecipeCategory.java
@@ -68,7 +68,7 @@ public class FluidRecipeCategory extends BaseCategory<FluidRecipeCategory.Recipe
         recipeLayout.getItemStacks().addTooltipCallback((slotIndex, input, ingredient, tooltip) -> {
             if (slotIndex < 9) {
                 float chance = recipeWrapper.recipe.getItemConsumeChance()[slotIndex];
-                if (chance < 1f) {
+                if (chance < 1.0f) {
                     tooltip.add(1, I18n.format("groovyscript.recipe.chance_consume", numberFormat.format(chance)));
                 }
             }
@@ -76,7 +76,7 @@ public class FluidRecipeCategory extends BaseCategory<FluidRecipeCategory.Recipe
         recipeLayout.getFluidStacks().addTooltipCallback((slotIndex, input, ingredient, tooltip) -> {
             if (slotIndex == 10 && recipeWrapper.recipe instanceof FluidToItem.Recipe fluidToItemRecipe) {
                 float chance = fluidToItemRecipe.getFluidConsumptionChance();
-                if (chance < 1f) {
+                if (chance < 1.0f) {
                     tooltip.add(1, I18n.format("groovyscript.recipe.chance_consume", numberFormat.format(chance)));
                 }
             }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/jei/FluidRecipeCategory.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/jei/FluidRecipeCategory.java
@@ -104,9 +104,8 @@ public class FluidRecipeCategory extends BaseCategory<FluidRecipeCategory.Recipe
         rightArrow.draw(minecraft, 76, outputY + 1);
     }
 
-    @Nullable
     @Override
-    public IDrawable getIcon() {
+    public @Nullable IDrawable getIcon() {
         return this.icon;
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/jei/PistonPushRecipeCategory.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/jei/PistonPushRecipeCategory.java
@@ -55,9 +55,8 @@ public class PistonPushRecipeCategory extends BaseCategory<PistonPushRecipeCateg
         GlStateManager.popMatrix();
     }
 
-    @Nullable
     @Override
-    public IDrawable getIcon() {
+    public @Nullable IDrawable getIcon() {
         return icon;
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/loot/GroovyLootCondition.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/loot/GroovyLootCondition.java
@@ -10,6 +10,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Arrays;
 import java.util.Random;
 
+@SuppressWarnings("ClassCanBeRecord")
 public class GroovyLootCondition implements LootCondition {
 
     private static final Class<?>[] CLOSURE_CLASSES = {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ExternalModContainer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ExternalModContainer.java
@@ -48,9 +48,8 @@ public class ExternalModContainer extends GroovyContainer<GroovyPropertyContaine
         return true;
     }
 
-    @NotNull
     @Override
-    public Collection<String> getAliases() {
+    public @NotNull Collection<String> getAliases() {
         return aliases;
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/GroovyPropertyContainer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/GroovyPropertyContainer.java
@@ -32,13 +32,11 @@ public class GroovyPropertyContainer {
         }
     }
 
-    @UnmodifiableView
-    public Collection<INamed> getRegistries() {
+    public @UnmodifiableView Collection<INamed> getRegistries() {
         return this.view.values();
     }
 
-    @UnmodifiableView
-    public Map<String, INamed> getProperties() {
+    public @UnmodifiableView Map<String, INamed> getProperties() {
         return view;
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/InternalModContainer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/InternalModContainer.java
@@ -56,9 +56,8 @@ public class InternalModContainer<T extends GroovyPropertyContainer> extends Gro
         return loaded;
     }
 
-    @NotNull
     @Override
-    public Collection<String> getAliases() {
+    public @NotNull Collection<String> getAliases() {
         return aliases;
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ModSupport.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ModSupport.java
@@ -225,8 +225,7 @@ public class ModSupport {
         }
     }
 
-    @NotNull
-    public GroovyContainer<?> getContainer(String mod) {
+    public @NotNull GroovyContainer<?> getContainer(String mod) {
         if (!containers.containsKey(mod)) {
             throw new IllegalStateException("There is no compat registered for '" + mod + "'!");
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/advancedrocketry/BaseRegistry.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/advancedrocketry/BaseRegistry.java
@@ -23,9 +23,8 @@ public abstract class BaseRegistry extends StandardListRegistry<IRecipe> {
     protected abstract Class<?> getMachineClass();
 
     @Override
-    @NotNull
     @SuppressWarnings("unchecked")
-    public Collection<IRecipe> getRecipes() {
+    public @NotNull Collection<IRecipe> getRecipes() {
         Class<?> clazz = getMachineClass();
         RecipesMachine registry = RecipesMachine.getInstance();
         List<IRecipe> recipes = registry.getRecipes(clazz);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/advancedrocketry/BaseRegistry.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/advancedrocketry/BaseRegistry.java
@@ -49,8 +49,8 @@ public abstract class BaseRegistry extends StandardListRegistry<IRecipe> {
     }
 
     public boolean removeByInput(IIngredient inputItem) {
-        if (inputItem instanceof FluidStack) {
-            return removeByFluidInput((FluidStack) inputItem);
+        if (inputItem instanceof FluidStack fluidStack) {
+            return removeByFluidInput(fluidStack);
         }
         return getRecipes().removeIf(r -> {
             List<List<ItemStack>> input = r.getIngredients();
@@ -74,8 +74,8 @@ public abstract class BaseRegistry extends StandardListRegistry<IRecipe> {
     }
 
     public boolean removeByOutput(IIngredient outputItem) {
-        if (outputItem instanceof FluidStack) {
-            return removeByFluidInput((FluidStack) outputItem);
+        if (outputItem instanceof FluidStack fluidStack) {
+            return removeByFluidInput(fluidStack);
         }
         return getRecipes().removeIf(r -> {
             List<ItemStack> output = r.getOutput();
@@ -135,8 +135,8 @@ public abstract class BaseRegistry extends StandardListRegistry<IRecipe> {
             for (int i = 0; i < input.size(); i++) {
                 IIngredient in = input.get(i);
                 inputs.add(Arrays.asList(in.getMatchingStacks()));
-                if (in instanceof OreDictIngredient) {
-                    oredicts.put(i, ((OreDictIngredient) in).getOreDict());
+                if (in instanceof OreDictIngredient oreDictIngredient) {
+                    oredicts.put(i, oreDictIngredient.getOreDict());
                 }
             }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/aetherlegacy/Accessory.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/aetherlegacy/Accessory.java
@@ -77,7 +77,7 @@ public class Accessory extends ForgeRegistryWrapper<AetherAccessory> {
         public void validate(GroovyLog.Msg msg) {
             validateItems(msg, 1, 1, 0, 0);
             validateFluids(msg);
-            msg.add(accessoryType == null, "type with name {} does not exist. Valid values are {}.", accessoryType.toString(), Arrays.toString(AccessoryType.values()));
+            msg.add(accessoryType == null, "accessoryType must be defined. Valid values are {}.", Arrays.toString(AccessoryType.values()));
         }
 
         @RecipeBuilderRegistrationMethod

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Atomizer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Atomizer.java
@@ -88,10 +88,9 @@ public class Atomizer extends StandardListRegistry<AtomizerRecipe> {
             validateFluids(msg, 1, 1, 0, 0);
         }
 
-        @Nullable
         @Override
         @RecipeBuilderRegistrationMethod
-        public AtomizerRecipe register() {
+        public @Nullable AtomizerRecipe register() {
             if (!validate()) return null;
 
             AtomizerRecipe recipe = new AtomizerRecipe(false, fluidInput.get(0), output.get(0));

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Dissolver.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Dissolver.java
@@ -140,10 +140,9 @@ public class Dissolver extends StandardListRegistry<DissolverRecipe> {
             msg.add(rolls < 1, "rolls must be greater than or equal to 1, yet it was {}", rolls);
         }
 
-        @Nullable
         @Override
         @RecipeBuilderRegistrationMethod
-        public DissolverRecipe register() {
+        public @Nullable DissolverRecipe register() {
             if (!validate()) return null;
 
             DissolverRecipe recipe = new DissolverRecipe(input.get(0).toMcIngredient(), false, new ProbabilitySet(probabilityGroup, relativeProbability, rolls));

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Electrolyzer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Electrolyzer.java
@@ -127,10 +127,9 @@ public class Electrolyzer extends StandardListRegistry<ElectrolyzerRecipe> {
             msg.add(consumptionChance < 0 || consumptionChance > 100, "consumption chance must be between 0 and 100, yet it was {}", consumptionChance);
         }
 
-        @Nullable
         @Override
         @RecipeBuilderRegistrationMethod
-        public ElectrolyzerRecipe register() {
+        public @Nullable ElectrolyzerRecipe register() {
             if (!validate()) return null;
             ElectrolyzerRecipe recipe = new ElectrolyzerRecipe(
                     fluidInput.get(0),

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Evaporator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Evaporator.java
@@ -72,10 +72,9 @@ public class Evaporator extends StandardListRegistry<EvaporatorRecipe> {
             validateFluids(msg, 1, 1, 0, 0);
         }
 
-        @Nullable
         @Override
         @RecipeBuilderRegistrationMethod
-        public EvaporatorRecipe register() {
+        public @Nullable EvaporatorRecipe register() {
             if (!validate()) return null;
             EvaporatorRecipe recipe = new EvaporatorRecipe(fluidInput.get(0), output.get(0));
             ModSupport.ALCHEMISTRY.get().evaporator.add(recipe);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Liquifier.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/alchemistry/Liquifier.java
@@ -72,10 +72,9 @@ public class Liquifier extends StandardListRegistry<LiquifierRecipe> {
             validateFluids(msg, 0, 0, 1, 1);
         }
 
-        @Nullable
         @Override
         @RecipeBuilderRegistrationMethod
-        public LiquifierRecipe register() {
+        public @Nullable LiquifierRecipe register() {
             if (!validate()) return null;
             LiquifierRecipe recipe = new LiquifierRecipe(IngredientHelper.toItemStack(input.get(0)), fluidOutput.get(0));
             ModSupport.ALCHEMISTRY.get().liquifier.add(recipe);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/appliedenergistics2/Attunement.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/appliedenergistics2/Attunement.java
@@ -29,12 +29,12 @@ public class Attunement extends VirtualizedRegistry<Pair<Object, TunnelType>> {
             }
         });
         restoreFromBackup().forEach(pair -> {
-            if (pair.getKey() instanceof ItemStack) {
-                AEApi.instance().registries().p2pTunnel().addNewAttunement((ItemStack) pair.getKey(), pair.getValue());
-            } else if (pair.getKey() instanceof String) {
-                AEApi.instance().registries().p2pTunnel().addNewAttunement((String) pair.getKey(), pair.getValue());
-            } else if (pair.getKey() instanceof Capability<?>) {
-                AEApi.instance().registries().p2pTunnel().addNewAttunement((Capability<?>) pair.getKey(), pair.getValue());
+            if (pair.getKey() instanceof ItemStack itemStack) {
+                AEApi.instance().registries().p2pTunnel().addNewAttunement(itemStack, pair.getValue());
+            } else if (pair.getKey() instanceof String s) {
+                AEApi.instance().registries().p2pTunnel().addNewAttunement(s, pair.getValue());
+            } else if (pair.getKey() instanceof Capability<?>capability) {
+                AEApi.instance().registries().p2pTunnel().addNewAttunement(capability, pair.getValue());
             }
         });
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/AstralSorcery.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/AstralSorcery.java
@@ -60,8 +60,8 @@ public class AstralSorcery extends GroovyPropertyContainer {
     }
 
     public static ItemHandle toItemHandle(IIngredient ingredient) {
-        if (ingredient instanceof FluidStack) return new ItemHandle(((FluidStack) ingredient).getFluid());
-        if (ingredient instanceof OreDictIngredient) return new ItemHandle(((OreDictIngredient) ingredient).getOreDict());
+        if (ingredient instanceof FluidStack fluidStack) return new ItemHandle(fluidStack.getFluid());
+        if (ingredient instanceof OreDictIngredient oreDictIngredient) return new ItemHandle(oreDictIngredient.getOreDict());
         return new ItemHandle(ingredient.getMatchingStacks());
     }
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/Constellation.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/Constellation.java
@@ -316,7 +316,7 @@ public class Constellation extends VirtualizedRegistry<IConstellation> {
         private boolean validate() {
             ArrayList<String> errors = new ArrayList<>();
 
-            if (this.name == null || "".equals(this.name))
+            if (this.name == null || this.name.isEmpty())
                 errors.add("name must be provided");
             if (this.connections.isEmpty())
                 errors.add("connections must not be empty");

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/InfusionAltar.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/InfusionAltar.java
@@ -60,15 +60,15 @@ public class InfusionAltar extends VirtualizedRegistry<BasicInfusionRecipe> {
     }
 
     private boolean remove(AbstractInfusionRecipe recipe) {
-        if (recipe instanceof BasicInfusionRecipe) addBackup((BasicInfusionRecipe) recipe);
+        if (recipe instanceof BasicInfusionRecipe basicInfusionRecipe) addBackup(basicInfusionRecipe);
         return InfusionRecipeRegistry.recipes.removeIf(rec -> rec.getUniqueRecipeId() == recipe.getUniqueRecipeId());
     }
 
     @MethodDescription(example = @Example("item('minecraft:diamond_ore')"))
     public void removeByInput(ItemStack input) {
         InfusionRecipeRegistry.recipes.removeIf(r -> {
-            if (r instanceof BasicInfusionRecipe && r.getInput().matchCrafting(input)) {
-                addBackup((BasicInfusionRecipe) r);
+            if (r instanceof BasicInfusionRecipe basicInfusionRecipe && r.getInput().matchCrafting(input)) {
+                addBackup(basicInfusionRecipe);
                 return true;
             }
             return false;
@@ -89,8 +89,8 @@ public class InfusionAltar extends VirtualizedRegistry<BasicInfusionRecipe> {
     @MethodDescription(priority = 2000, example = @Example(commented = true))
     public void removeAll() {
         InfusionRecipeRegistry.recipes.removeIf(r -> {
-            if (r instanceof BasicInfusionRecipe) {
-                addBackup((BasicInfusionRecipe) r);
+            if (r instanceof BasicInfusionRecipe basicInfusionRecipe) {
+                addBackup(basicInfusionRecipe);
                 return true;
             }
             return false;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/OreChance.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/OreChance.java
@@ -68,7 +68,7 @@ public class OreChance extends VirtualizedRegistry<OreEntry> {
             GroovyLog.msg("Error adding Astral Sorcery OreChance. Weight must be a positive integer.").error().post();
             return;
         }
-        if (ore == null || "".equals(ore)) {
+        if (ore == null || ore.isEmpty()) {
             GroovyLog.msg("Error adding Astral Sorcery OreChance. Ore name cannot be null.").error().post();
             return;
         }
@@ -76,7 +76,7 @@ public class OreChance extends VirtualizedRegistry<OreEntry> {
     }
 
     public void add(OreDictIngredient ore, int weight) {
-        if (ore == null || ore.getOreDict() == null || "".equals(ore.getOreDict())) {
+        if (ore == null || ore.getOreDict() == null || ore.getOreDict().isEmpty()) {
             GroovyLog.msg("Error adding Astral Sorcery OreChance. Ore name cannot be null.").error().post();
             return;
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/Research.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/Research.java
@@ -260,7 +260,7 @@ public class Research extends VirtualizedRegistry<ResearchNode> {
         private boolean validate() {
             GroovyLog.Msg out = GroovyLog.msg("Error adding Research Node to Astral Sorcery Journal").error();
 
-            if (this.name == null || "".equals(this.name)) {
+            if (this.name == null || this.name.isEmpty()) {
                 out.add("Name not provided.");
             }
             if (this.node == null || this.node.isItemEqual(ItemStack.EMPTY)) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/crystal/CrystalHelper.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/crystal/CrystalHelper.java
@@ -66,16 +66,16 @@ public class CrystalHelper {
     }
 
     public static ItemStack tuneTo(ItemStack crystal, IConstellation constellation) {
-        if (constellation instanceof IWeakConstellation)
-            ItemTunedCrystalBase.applyMainConstellation(crystal, (IWeakConstellation) constellation);
+        if (constellation instanceof IWeakConstellation iWeakConstellation)
+            ItemTunedCrystalBase.applyMainConstellation(crystal, iWeakConstellation);
         else
             GroovyLog.msg("Main constellation must be Major or Weak (Bright or Dim)").error().post();
         return crystal;
     }
 
     public static ItemStack setTrait(ItemStack crystal, IConstellation constellation) {
-        if (constellation instanceof IMinorConstellation)
-            ItemTunedCrystalBase.applyTrait(crystal, (IMinorConstellation) constellation);
+        if (constellation instanceof IMinorConstellation iMinorConstellation)
+            ItemTunedCrystalBase.applyTrait(crystal, iMinorConstellation);
         else
             GroovyLog.msg("Trait constellation must be Minor (Faint)").error().post();
         return crystal;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/HopperFilters.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/betterwithmods/HopperFilters.java
@@ -72,8 +72,8 @@ public class HopperFilters extends VirtualizedRegistry<IHopperFilter> {
     @MethodDescription
     public boolean removeByFiltered(IIngredient output) {
         return ((HopperFiltersAccessor) BWRegistry.HOPPER_FILTERS).getFILTERS().values().removeIf(r -> {
-            if (!(r instanceof HopperFilter)) return false;
-            for (Ingredient ingredient : ((HopperFilter) r).getFiltered()) {
+            if (!(r instanceof HopperFilter hopperFilter)) return false;
+            for (Ingredient ingredient : hopperFilter.getFiltered()) {
                 for (ItemStack item : ingredient.getMatchingStacks()) {
                     if (output.test(item)) {
                         addBackup(r);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/Apothecary.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/Apothecary.java
@@ -60,7 +60,7 @@ public class Apothecary extends StandardListRegistry<RecipePetals> {
     @MethodDescription(example = @Example("ore('runeFireB')"))
     public boolean removeByInput(IIngredient... inputs) {
         List<Object> converted = Arrays.stream(inputs)
-                .map(i -> i instanceof OreDictIngredient ? ((OreDictIngredient) i).getOreDict() : i.getMatchingStacks()[0])
+                .map(i -> i instanceof OreDictIngredient oreDictIngredient ? oreDictIngredient.getOreDict() : i.getMatchingStacks()[0])
                 .collect(Collectors.toList());
         if (getRecipes().removeIf(recipe -> {
             boolean found = converted.stream()
@@ -113,8 +113,8 @@ public class Apothecary extends StandardListRegistry<RecipePetals> {
                     output.get(0),
                     input.stream()
                             .map(
-                                    i -> i instanceof OreDictIngredient
-                                            ? ((OreDictIngredient) i).getOreDict()
+                                    i -> i instanceof OreDictIngredient oreDictIngredient
+                                            ? oreDictIngredient.getOreDict()
                                             : i.getMatchingStacks()[0])
                             .toArray());
             add(recipe);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/Brew.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/Brew.java
@@ -170,10 +170,9 @@ public class Brew extends VirtualizedRegistry<vazkii.botania.api.brew.Brew> {
             msg.add(effects.size() < 1, "must have at least 1 potion effect, got " + effects.size());
         }
 
-        @Nullable
         @Override
         @RecipeBuilderRegistrationMethod
-        public vazkii.botania.api.brew.Brew register() {
+        public @Nullable vazkii.botania.api.brew.Brew register() {
             if (!validate()) return null;
             if (name == null) name = key;
             vazkii.botania.api.brew.Brew brew = new vazkii.botania.api.brew.Brew(key, name, color, cost, effects.toArray(new PotionEffect[0]));

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/BrewRecipe.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/BrewRecipe.java
@@ -52,7 +52,7 @@ public class BrewRecipe extends StandardListRegistry<RecipeBrew> {
     @MethodDescription(example = @Example("item('minecraft:iron_ingot')"))
     public boolean removeByInput(IIngredient... inputs) {
         List<Object> converted = Arrays.stream(inputs)
-                .map(i -> i instanceof OreDictIngredient ? ((OreDictIngredient) i).getOreDict() : i.getMatchingStacks()[0])
+                .map(i -> i instanceof OreDictIngredient oreDictIngredient ? oreDictIngredient.getOreDict() : i.getMatchingStacks()[0])
                 .collect(Collectors.toList());
         if (getRecipes().removeIf(recipe -> {
             boolean found = converted.stream()
@@ -113,8 +113,8 @@ public class BrewRecipe extends StandardListRegistry<RecipeBrew> {
                     brew,
                     input.stream()
                             .map(
-                                    i -> i instanceof OreDictIngredient
-                                            ? ((OreDictIngredient) i).getOreDict()
+                                    i -> i instanceof OreDictIngredient oreDictIngredient
+                                            ? oreDictIngredient.getOreDict()
                                             : i.getMatchingStacks()[0])
                             .toArray());
             add(recipe);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/ElvenTrade.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/ElvenTrade.java
@@ -31,8 +31,8 @@ public class ElvenTrade extends StandardListRegistry<RecipeElvenTrade> {
     protected Object[] convertIngredients(IIngredient[] inputs) {
         return Arrays.stream(inputs)
                 .map(
-                        input -> input instanceof OreDictIngredient
-                                ? ((OreDictIngredient) input).getOreDict()
+                        input -> input instanceof OreDictIngredient oreDictIngredient
+                                ? oreDictIngredient.getOreDict()
                                 : input.getMatchingStacks()[0])
                 .toArray();
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/ManaInfusion.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/ManaInfusion.java
@@ -52,9 +52,9 @@ public class ManaInfusion extends StandardListRegistry<RecipeManaInfusion> {
     @MethodDescription(example = @Example("item('minecraft:ender_pearl')"))
     public boolean removeByInput(IIngredient input) {
         if (getRecipes().removeIf(recipe -> {
-            boolean found = recipe.getInput() instanceof ItemStack
-                    ? input.test((ItemStack) recipe.getInput())
-                    : (input instanceof OreDictIngredient && ((OreDictIngredient) input).getOreDict().equals(recipe.getInput()));
+            boolean found = recipe.getInput() instanceof ItemStack itemStack
+                    ? input.test(itemStack)
+                    : (input instanceof OreDictIngredient oreDictIngredient && oreDictIngredient.getOreDict().equals(recipe.getInput()));
             if (found) addBackup(recipe);
             return found;
         })) return true;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/RuneAltar.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/RuneAltar.java
@@ -54,7 +54,7 @@ public class RuneAltar extends StandardListRegistry<RecipeRuneAltar> {
     @MethodDescription(example = @Example("ore('runeEarthB')"))
     public boolean removeByInput(IIngredient... inputs) {
         List<Object> converted = Arrays.stream(inputs)
-                .map(i -> i instanceof OreDictIngredient ? ((OreDictIngredient) i).getOreDict() : i.getMatchingStacks()[0])
+                .map(i -> i instanceof OreDictIngredient oreDictIngredient ? oreDictIngredient.getOreDict() : i.getMatchingStacks()[0])
                 .collect(Collectors.toList());
         if (getRecipes().removeIf(recipe -> {
             boolean found = converted.stream()
@@ -121,8 +121,8 @@ public class RuneAltar extends StandardListRegistry<RecipeRuneAltar> {
                     mana,
                     input.stream()
                             .map(
-                                    i -> i instanceof OreDictIngredient
-                                            ? ((OreDictIngredient) i).getOreDict()
+                                    i -> i instanceof OreDictIngredient oreDictIngredient
+                                            ? oreDictIngredient.getOreDict()
                                             : i.getMatchingStacks()[0])
                             .toArray());
             add(recipe);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/recipe/OrechidRecipe.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/botania/recipe/OrechidRecipe.java
@@ -1,5 +1,6 @@
 package com.cleanroommc.groovyscript.compat.mods.botania.recipe;
 
+@SuppressWarnings("ClassCanBeRecord")
 public class OrechidRecipe {
 
     public final int weight;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/botanicadditions/GaiaPlate.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/botanicadditions/GaiaPlate.java
@@ -84,7 +84,7 @@ public class GaiaPlate extends StandardListRegistry<GaiaPlateRecipes.RecipeGaiaP
         public @Nullable GaiaPlateRecipes.RecipeGaiaPlate register() {
             if (!validate()) return null;
             Object[] inputs = input.stream()
-                    .map(i -> i instanceof OreDictIngredient ? ((OreDictIngredient) i).getOreDict() : i.getMatchingStacks()[0])
+                    .map(i -> i instanceof OreDictIngredient oreDictIngredient ? oreDictIngredient.getOreDict() : i.getMatchingStacks()[0])
                     .toArray();
             GaiaPlateRecipes.RecipeGaiaPlate recipe = new GaiaPlateRecipes.RecipeGaiaPlate(output.get(0), mana, inputs);
             ModSupport.BOTANIC_ADDITIONS.get().gaiaPlate.add(recipe);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/calculator/Calculator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/calculator/Calculator.java
@@ -39,8 +39,8 @@ public class Calculator extends GroovyPropertyContainer {
     public static List<ISonarRecipeObject> toSonarRecipeObjectList(IngredientList<IIngredient> list) {
         List<ISonarRecipeObject> output = new ArrayList<>();
         for (IIngredient ingredient : list) {
-            if (ingredient instanceof OreDictIngredient) {
-                output.add(new RecipeOreStack(((OreDictIngredient) ingredient).getOreDict(), ingredient.getAmount()));
+            if (ingredient instanceof OreDictIngredient oreDictIngredient) {
+                output.add(new RecipeOreStack(oreDictIngredient.getOreDict(), ingredient.getAmount()));
             } else if (IngredientHelper.isItem(ingredient)) {
                 output.add(new RecipeItemStack(IngredientHelper.toItemStack(ingredient), true));
             } else {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/compactmachines/Miniaturization.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/compactmachines/Miniaturization.java
@@ -173,10 +173,9 @@ public class Miniaturization extends StandardListRegistry<MultiblockRecipe> {
             msg.add(!missingKeys.isEmpty(), "shape must contain only characters that are underscore('_'), space(' '), or declared via a key, but the following keys were not declared: {}", missingKeys);
         }
 
-        @Nullable
         @Override
         @RecipeBuilderRegistrationMethod
-        public org.dave.compactmachines3.miniaturization.MultiblockRecipe register() {
+        public @Nullable org.dave.compactmachines3.miniaturization.MultiblockRecipe register() {
             if (!validate()) return null;
 
             org.dave.compactmachines3.miniaturization.MultiblockRecipe recipe = new org.dave.compactmachines3.miniaturization.MultiblockRecipe(

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/compactmachines/Miniaturization.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/compactmachines/Miniaturization.java
@@ -209,6 +209,7 @@ public class Miniaturization extends StandardListRegistry<MultiblockRecipe> {
             return recipe;
         }
 
+        @SuppressWarnings("ClassCanBeRecord")
         public static class ReferenceValues {
 
             private final IBlockState state;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/draconicevolution/helpers/BlockStateEnergyCoreStructure.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/draconicevolution/helpers/BlockStateEnergyCoreStructure.java
@@ -178,8 +178,8 @@ public class BlockStateEnergyCoreStructure extends EnergyCoreStructure {
 
         else if (flag == FLAG_REVERT) {
             TileEntity tile = world.getTileEntity(pos);
-            if (tile instanceof TileInvisECoreBlock) {
-                ((TileInvisECoreBlock) tile).revert();
+            if (tile instanceof TileInvisECoreBlock tileInvisECoreBlock) {
+                tileInvisECoreBlock.revert();
             }
         }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/draconicevolution/helpers/InvisECoreBlockLogic.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/draconicevolution/helpers/InvisECoreBlockLogic.java
@@ -33,7 +33,7 @@ public class InvisECoreBlockLogic {
                 }
             }
 
-            IMultiBlockPart master = ((TileInvisECoreBlock) tile).getController();
+            IMultiBlockPart master = invis.getController();
             if (master != null) {
                 world.setBlockToAir(pos);
                 master.validateStructure();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/Enchanter.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/Enchanter.java
@@ -70,8 +70,8 @@ public class Enchanter extends VirtualizedRegistry<EnchanterRecipe> {
         }
         List<EnchanterRecipe> recipes = new ArrayList<>();
         for (IMachineRecipe recipe : MachineRecipeRegistry.instance.getRecipesForMachine(MachineRecipeRegistry.ENCHANTER).values()) {
-            if (recipe instanceof EnchanterRecipe && enchantment == ((EnchanterRecipe) recipe).getEnchantment()) {
-                recipes.add((EnchanterRecipe) recipe);
+            if (recipe instanceof EnchanterRecipe enchanterRecipe && enchantment == enchanterRecipe.getEnchantment()) {
+                recipes.add(enchanterRecipe);
             }
         }
         if (recipes.isEmpty()) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/FluidCoolant.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/FluidCoolant.java
@@ -85,8 +85,7 @@ public class FluidCoolant extends VirtualizedRegistry<IFluidCoolant> {
         }
     }
 
-    @Nullable
-    public IFluidCoolant find(Fluid fluid) {
+    public @Nullable IFluidCoolant find(Fluid fluid) {
         return ((FluidFuelRegisterAccessor) FluidFuelRegister.instance).getCoolants().get(fluid.getName());
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/FluidFuel.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/FluidFuel.java
@@ -80,8 +80,7 @@ public class FluidFuel extends VirtualizedRegistry<IFluidFuel> {
         }
     }
 
-    @Nullable
-    public IFluidFuel find(Fluid fluid) {
+    public @Nullable IFluidFuel find(Fluid fluid) {
         return FluidFuelRegister.instance.getFuel(fluid);
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/SliceNSplice.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/SliceNSplice.java
@@ -74,9 +74,9 @@ public class SliceNSplice extends StandardListRegistry<IManyToOneRecipe> {
     @MethodDescription(example = @Example("[item('enderio:item_alloy_ingot:7'), item('enderio:block_enderman_skull'), item('enderio:item_alloy_ingot:7'), item('minecraft:potion').withNbt(['Potion': 'minecraft:water']), item('enderio:item_basic_capacitor'), item('minecraft:potion').withNbt(['Potion': 'minecraft:water'])]"))
     public void removeByInput(List<ItemStack> input) {
         IRecipe recipe = SliceAndSpliceRecipeManager.getInstance().getRecipeForInputs(RecipeLevel.IGNORE, RecipeUtils.getMachineInputs(input));
-        if (recipe instanceof IManyToOneRecipe) {
+        if (recipe instanceof IManyToOneRecipe iManyToOneRecipe) {
             getRecipes().remove(recipe);
-            addBackup((IManyToOneRecipe) recipe);
+            addBackup(iManyToOneRecipe);
         } else {
             GroovyLog.get().error("No EnderIO Slice'n'Splice recipe found for " + input);
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/recipe/CustomEnchanterRecipe.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/recipe/CustomEnchanterRecipe.java
@@ -22,15 +22,13 @@ public class CustomEnchanterRecipe extends EnchanterRecipe {
         this.book = RecipeUtils.toThings(book);
     }
 
-    @NotNull
     @Override
-    public Things getLapis() {
+    public @NotNull Things getLapis() {
         return lapis;
     }
 
-    @NotNull
     @Override
-    public Things getBook() {
+    public @NotNull Things getBook() {
         return book;
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/recipe/RecipeInput.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/recipe/RecipeInput.java
@@ -25,9 +25,8 @@ public class RecipeInput implements IRecipeInput {
         }
     }
 
-    @NotNull
     @Override
-    public IRecipeInput copy() {
+    public @NotNull IRecipeInput copy() {
         return new RecipeInput(ing);
     }
 
@@ -36,9 +35,8 @@ public class RecipeInput implements IRecipeInput {
         return ing instanceof FluidStack;
     }
 
-    @NotNull
     @Override
-    public ItemStack getInput() {
+    public @NotNull ItemStack getInput() {
         return ing.getMatchingStacks().length == 0 ? ItemStack.EMPTY : ing.getMatchingStacks()[0].copy();
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/recipe/RecipeInput.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/recipe/RecipeInput.java
@@ -42,7 +42,7 @@ public class RecipeInput implements IRecipeInput {
 
     @Override
     public FluidStack getFluidInput() {
-        return ing instanceof FluidStack ? ((FluidStack) ing).copy() : null;
+        return ing instanceof FluidStack fluidStack ? fluidStack.copy() : null;
     }
 
     @Override

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/extendedcrafting/CombinationCrafting.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/extendedcrafting/CombinationCrafting.java
@@ -156,10 +156,9 @@ public class CombinationCrafting extends StandardListRegistry<CombinationRecipe>
             msg.add(perTick < 0, () -> "per tick must not be negative");
         }
 
-        @Nullable
         @Override
         @RecipeBuilderRegistrationMethod
-        public CombinationRecipe register() {
+        public @Nullable CombinationRecipe register() {
             if (!validate()) return null;
             CombinationRecipe recipe = new CombinationRecipe(output.get(0), cost, perTick, input.get(0).toMcIngredient(), IngredientHelper.toIngredientNonNullList(pedestals));
             ModSupport.EXTENDED_CRAFTING.get().combinationCrafting.add(recipe);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/extendedcrafting/CompressionCrafting.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/extendedcrafting/CompressionCrafting.java
@@ -153,10 +153,9 @@ public class CompressionCrafting extends StandardListRegistry<CompressorRecipe> 
             msg.add(powerRate < 0, "power rate must not be negative");
         }
 
-        @Nullable
         @Override
         @RecipeBuilderRegistrationMethod
-        public CompressorRecipe register() {
+        public @Nullable CompressorRecipe register() {
             if (!validate()) return null;
             CompressorRecipe recipe = new CompressorRecipe(output.get(0), input.get(0).toMcIngredient(), inputCount, catalyst.toMcIngredient(), consumeCatalyst, powerCost, powerRate);
             ModSupport.EXTENDED_CRAFTING.get().compressionCrafting.add(recipe);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/extrabotany/Pedestal.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/extrabotany/Pedestal.java
@@ -71,10 +71,9 @@ public class Pedestal extends StandardListRegistry<RecipePedestal> {
             validateFluids(msg);
         }
 
-        @Nullable
         @Override
         @RecipeBuilderRegistrationMethod
-        public RecipePedestal register() {
+        public @Nullable RecipePedestal register() {
             if (!validate()) return null;
             RecipePedestal recipe = null;
             for (ItemStack matchingStack : input.get(0).getMatchingStacks()) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/extrautils2/Resonator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/extrautils2/Resonator.java
@@ -169,10 +169,9 @@ public class Resonator extends StandardListRegistry<IResonatorRecipe> {
             msg.add(energy < 100, () -> "energy must not be less than 1 GP (100)");
         }
 
-        @Nullable
         @Override
         @RecipeBuilderRegistrationMethod
-        public IResonatorRecipe register() {
+        public @Nullable IResonatorRecipe register() {
             if (!validate()) return null;
             IResonatorRecipe recipe = new ResonatorRecipe(input.get(0).getMatchingStacks()[0], output.get(0), energy, ownerTag) {
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/forestry/BeeProduce.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/forestry/BeeProduce.java
@@ -110,7 +110,7 @@ public class BeeProduce extends ForestryRegistry<BeeProduct> {
 
     public void removeAll() {
         ((AlleleRegistryAccessor) AlleleManager.alleleRegistry).getAlleleMap().forEach((uid, allele) -> {
-            if (allele instanceof AlleleBeeSpecies) removeAll((AlleleBeeSpecies) allele);
+            if (allele instanceof AlleleBeeSpecies alleleBeeSpecies) removeAll(alleleBeeSpecies);
         });
     }
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/forestry/Carpenter.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/forestry/Carpenter.java
@@ -91,8 +91,8 @@ public class Carpenter extends ForestryRegistry<ICarpenterRecipe> {
         if (CarpenterRecipeManagerAccessor.getRecipes().removeIf(recipe -> {
             boolean found = Arrays.stream(inputs).allMatch(i -> {
                 boolean matches = false;
-                if (i instanceof OreDictIngredient) {
-                    matches = recipe.getCraftingGridRecipe().getOreDicts().contains(((OreDictIngredient) i).getOreDict());
+                if (i instanceof OreDictIngredient oreDictIngredient) {
+                    matches = recipe.getCraftingGridRecipe().getOreDicts().contains(oreDictIngredient.getOreDict());
                 } else {
                     for (int x = 0; x < recipe.getCraftingGridRecipe().getWidth(); x++) {
                         if (recipe.getCraftingGridRecipe().getRawIngredients().get(x).contains(i.getMatchingStacks()[0])) {
@@ -129,7 +129,7 @@ public class Carpenter extends ForestryRegistry<ICarpenterRecipe> {
         List<Object> argList = new ArrayList<>(Arrays.asList(pattern));
         for (Map.Entry<Character, IIngredient> entry : keyMap.entrySet()) {
             argList.add(entry.getKey());
-            if (entry.getValue() instanceof OreDictIngredient) argList.add(((OreDictIngredient) entry.getValue()).getOreDict());
+            if (entry.getValue() instanceof OreDictIngredient oreDictIngredient) argList.add(oreDictIngredient.getOreDict());
             else argList.add(entry.getValue().getMatchingStacks()[0]);
         }
         return ShapedRecipeCustom.createShapedRecipe(output, argList.toArray());

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/forestry/Fermenter.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/forestry/Fermenter.java
@@ -28,8 +28,8 @@ public class Fermenter extends ForestryRegistry<IFermenterRecipe> {
 
     public IFermenterRecipe add(FluidStack output, FluidStack input, IIngredient catalyst, int value, float modifier) {
         IFermenterRecipe recipe;
-        if (catalyst instanceof OreDictIngredient)
-            recipe = new FermenterRecipe(((OreDictIngredient) catalyst).getOreDict(), value, modifier, input.getFluid(), output);
+        if (catalyst instanceof OreDictIngredient oreDictIngredient)
+            recipe = new FermenterRecipe(oreDictIngredient.getOreDict(), value, modifier, input.getFluid(), output);
         else recipe = new FermenterRecipe(catalyst.getMatchingStacks()[0], value, modifier, input.getFluid(), output);
         add(recipe);
         return recipe;
@@ -63,8 +63,8 @@ public class Fermenter extends ForestryRegistry<IFermenterRecipe> {
 
     public boolean removeByCatalyst(IIngredient input) {
         if (FermenterRecipeManagerAccessor.getRecipes().removeIf(recipe -> {
-            boolean found = input instanceof OreDictIngredient
-                    ? recipe.getResourceOreName().equals(((OreDictIngredient) input).getOreDict())
+            boolean found = input instanceof OreDictIngredient oreDictIngredient
+                    ? recipe.getResourceOreName().equals(oreDictIngredient.getOreDict())
                     : recipe.getResource().isItemEqual(input.getMatchingStacks()[0]);
             if (found) addBackup(recipe);
             return found;
@@ -131,8 +131,8 @@ public class Fermenter extends ForestryRegistry<IFermenterRecipe> {
             if (!validate()) return null;
             IFermenterRecipe recipe;
             IIngredient catalyst = input.get(0);
-            if (catalyst instanceof OreDictIngredient)
-                recipe = new FermenterRecipe(((OreDictIngredient) catalyst).getOreDict(), value, modifier, fluidInput.get(0).getFluid(), fluidOutput.get(0));
+            if (catalyst instanceof OreDictIngredient oreDictIngredient)
+                recipe = new FermenterRecipe(oreDictIngredient.getOreDict(), value, modifier, fluidInput.get(0).getFluid(), fluidOutput.get(0));
             else recipe = new FermenterRecipe(catalyst.getMatchingStacks()[0], value, modifier, fluidInput.get(0).getFluid(), fluidOutput.get(0));
             add(recipe);
             return recipe;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/forestry/Forestry.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/forestry/Forestry.java
@@ -38,10 +38,10 @@ public class Forestry extends GroovyPropertyContainer {
             }
         }
         IAlleleBeeSpecies species = (IAlleleBeeSpecies) AlleleManager.alleleRegistry.getAllele(parts[0] + "." + parts[1]);
-        if (species instanceof AlleleBeeSpecies) return Result.some((AlleleBeeSpecies) species);
+        if (species instanceof AlleleBeeSpecies beeSpecies) return Result.some(beeSpecies);
 
         species = (IAlleleBeeSpecies) AlleleManager.alleleRegistry.getAllele(parts[0] + "." + getNormalName(parts[1]));
-        if (species instanceof AlleleBeeSpecies) return Result.some((AlleleBeeSpecies) species);
+        if (species instanceof AlleleBeeSpecies alleleBeeSpecies) return Result.some(alleleBeeSpecies);
         return Result.error();
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/forestry/ThermionicFabricator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/forestry/ThermionicFabricator.java
@@ -99,8 +99,8 @@ public class ThermionicFabricator extends ForestryRegistry<IFabricatorRecipe> {
         if (FabricatorRecipeManagerAccessor.getRecipes().removeIf(recipe -> {
             boolean found = Arrays.stream(input).allMatch(i -> {
                 boolean matches = false;
-                if (i instanceof OreDictIngredient) {
-                    matches = recipe.getOreDicts().contains(((OreDictIngredient) i).getOreDict());
+                if (i instanceof OreDictIngredient oreDictIngredient) {
+                    matches = recipe.getOreDicts().contains(oreDictIngredient.getOreDict());
                 } else {
                     for (int x = 0; x < recipe.getWidth(); x++) {
                         if (recipe.getIngredients().get(x).contains(i.getMatchingStacks()[0])) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/forestry/recipe/BeeProduct.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/forestry/recipe/BeeProduct.java
@@ -3,6 +3,7 @@ package com.cleanroommc.groovyscript.compat.mods.forestry.recipe;
 import forestry.apiculture.genetics.alleles.AlleleBeeSpecies;
 import net.minecraft.item.ItemStack;
 
+@SuppressWarnings("ClassCanBeRecord")
 public class BeeProduct {
 
     public final AlleleBeeSpecies species;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/iceandfire/FireForge.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/iceandfire/FireForge.java
@@ -55,10 +55,9 @@ public class FireForge extends StandardListRegistry<DragonForgeRecipe> {
             validateFluids(msg);
         }
 
-        @Nullable
         @Override
         @RecipeBuilderRegistrationMethod
-        public DragonForgeRecipe register() {
+        public @Nullable DragonForgeRecipe register() {
             if (!validate()) return null;
             DragonForgeRecipe recipe = null;
             for (var inputStack : input.get(0).getMatchingStacks()) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/iceandfire/IceForge.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/iceandfire/IceForge.java
@@ -55,10 +55,9 @@ public class IceForge extends StandardListRegistry<DragonForgeRecipe> {
             validateFluids(msg);
         }
 
-        @Nullable
         @Override
         @RecipeBuilderRegistrationMethod
-        public DragonForgeRecipe register() {
+        public @Nullable DragonForgeRecipe register() {
             if (!validate()) return null;
             DragonForgeRecipe recipe = null;
             for (var inputStack : input.get(0).getMatchingStacks()) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/iceandfire/LightningForge.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/iceandfire/LightningForge.java
@@ -56,10 +56,9 @@ public class LightningForge extends StandardListRegistry<DragonForgeRecipe> {
             validateFluids(msg);
         }
 
-        @Nullable
         @Override
         @RecipeBuilderRegistrationMethod
-        public DragonForgeRecipe register() {
+        public @Nullable DragonForgeRecipe register() {
             if (!validate()) return null;
             DragonForgeRecipe recipe = null;
             for (var inputStack : input.get(0).getMatchingStacks()) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/ImmersiveEngineering.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/ImmersiveEngineering.java
@@ -31,11 +31,11 @@ public class ImmersiveEngineering extends GroovyPropertyContainer {
         if (IngredientHelper.isItem(ingredient)) {
             return new IngredientStack(IngredientHelper.toItemStack(ingredient).copy());
         }
-        if (ingredient instanceof OreDictIngredient) {
-            return new IngredientStack(((OreDictIngredient) ingredient).getOreDict(), ingredient.getAmount());
+        if (ingredient instanceof OreDictIngredient oreDictIngredient) {
+            return new IngredientStack(oreDictIngredient.getOreDict(), ingredient.getAmount());
         }
-        if (ingredient instanceof FluidStack) {
-            return new IngredientStack(((FluidStack) ingredient).copy());
+        if (ingredient instanceof FluidStack fluidStack) {
+            return new IngredientStack(fluidStack.copy());
         }
         return new IngredientStack(Arrays.asList(ingredient.getMatchingStacks()), ingredient.getAmount());
     }
@@ -49,8 +49,8 @@ public class ImmersiveEngineering extends GroovyPropertyContainer {
     }
 
     public static Object toIEInput(IIngredient ingredient) {
-        if (ingredient instanceof OreDictIngredient) {
-            return ((OreDictIngredient) ingredient).getOreDict();
+        if (ingredient instanceof OreDictIngredient oreDictIngredient) {
+            return oreDictIngredient.getOreDict();
         }
         ItemStack[] matchingStacks = ingredient.getMatchingStacks();
         return matchingStacks.length == 0 ? ItemStack.EMPTY : matchingStacks[0];

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/inspirations/Cauldron.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/inspirations/Cauldron.java
@@ -37,7 +37,7 @@ public class Cauldron extends StandardListRegistry<ICauldronRecipe> {
 
     private static boolean compareFluids(Object first, Object second) {
         if (first == second) return true;
-        if (first instanceof Fluid && second instanceof Fluid) return ((Fluid) first).getName().equals(((Fluid) second).getName());
+        if (first instanceof Fluid fluid1 && second instanceof Fluid fluid2) return fluid1.getName().equals(fluid2.getName());
         return false;
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/Catalyst.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/Catalyst.java
@@ -24,7 +24,7 @@ public class Catalyst extends VirtualizedRegistry<Pair<String, ItemStack>> {
         for (var backupRecipe : getBackupRecipes()) {
             ((ModRegistryAccessor) modRegistry).getRecipeCatalysts()
                     .get(backupRecipe.getKey())
-                    .removeIf(x -> backupRecipe.getValue() == null || x instanceof ItemStack && ItemStack.areItemStacksEqual((ItemStack) x, backupRecipe.getValue()));
+                    .removeIf(x -> backupRecipe.getValue() == null || x instanceof ItemStack stack && ItemStack.areItemStacksEqual(stack, backupRecipe.getValue()));
         }
         for (var scriptedRecipe : getScriptedRecipes()) {
             modRegistry.addRecipeCatalyst(scriptedRecipe.getValue(), scriptedRecipe.getKey());

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/Description.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/Description.java
@@ -52,7 +52,9 @@ public class Description extends VirtualizedRegistry<Pair<List<IIngredient>, Lis
                 if (!VanillaTypes.ITEM.equals(accessor.getIngredientType())) return;
 
                 for (Pair<List<IIngredient>, List<String>> entry : this.getBackupRecipes()) {
-                    if (entry.getKey().stream().anyMatch(x -> accessor.getIngredients().stream().anyMatch(a -> a instanceof ItemStack && x.test((ItemStack) a)))) {
+                    if (entry.getKey()
+                            .stream()
+                            .anyMatch(x -> accessor.getIngredients().stream().anyMatch(a -> a instanceof ItemStack itemStack && x.test(itemStack)))) {
                         recipeRegistry.hideRecipe(wrapper, VanillaRecipeCategoryUid.INFORMATION);
                     }
                 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/JeiPlugin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/JeiPlugin.java
@@ -22,6 +22,7 @@ import mezz.jei.plugins.vanilla.crafting.ShapelessRecipeWrapper;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.text.TextComponentString;
 import net.minecraftforge.fluids.FluidStack;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Comparator;
 
@@ -66,7 +67,7 @@ public class JeiPlugin implements IModPlugin {
     }
 
     @Override
-    public void registerCategories(IRecipeCategoryRegistration registry) {
+    public void registerCategories(@NotNull IRecipeCategoryRegistration registry) {
         IngredientRegistry ingredientRegistry = Internal.getIngredientRegistry();
         fluidRenderer = ingredientRegistry.getIngredientRenderer(VanillaTypes.FLUID);
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/recipe/MekanismIngredientHelper.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/recipe/MekanismIngredientHelper.java
@@ -35,8 +35,8 @@ public class MekanismIngredientHelper {
     }
 
     private static IIngredient getIngredient(Object ingredient) {
-        if (ingredient instanceof IIngredient) {
-            return (IIngredient) ingredient;
+        if (ingredient instanceof IIngredient iIngredient) {
+            return iIngredient;
         }
 
         if (ingredient instanceof Gas) {
@@ -50,14 +50,14 @@ public class MekanismIngredientHelper {
     }
 
     public static boolean matches(IIngredient input, IIngredient toMatch) {
-        if (input instanceof GasStack) {
-            return matches(toMatch, (GasStack) input);
+        if (input instanceof GasStack gasStack) {
+            return matches(toMatch, gasStack);
         }
         if (IngredientHelper.isItem(input)) {
             return toMatch != null && toMatch.test(IngredientHelper.toItemStack(input));
         }
-        if (input instanceof FluidStack) {
-            return toMatch != null && toMatch.test((FluidStack) input);
+        if (input instanceof FluidStack fluidStack) {
+            return toMatch != null && toMatch.test(fluidStack);
         }
         //TODO: Support other types of things like ore dict
         return false;
@@ -113,8 +113,8 @@ public class MekanismIngredientHelper {
     }
 
     public static IMekanismIngredient<ItemStack> getMekanismIngredient(IIngredient ingredient) {
-        if (ingredient instanceof OreDictIngredient) {
-            return new OredictMekIngredient(((OreDictIngredient) ingredient).getOreDict());
+        if (ingredient instanceof OreDictIngredient oreDictIngredient) {
+            return new OredictMekIngredient(oreDictIngredient.getOreDict());
         }
         if (IngredientHelper.isItem(ingredient)) {
             return new ItemStackMekIngredient(IngredientHelper.toItemStack(ingredient));
@@ -129,8 +129,8 @@ public class MekanismIngredientHelper {
         if (ingredient == IIngredient.ANY) {
             return true;
         }
-        if (ingredient instanceof GasStack) {
-            return ((GasStack) ingredient).isGasEqual(gasStack);
+        if (ingredient instanceof GasStack stack) {
+            return stack.isGasEqual(gasStack);
         }
         return false;
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/recipe/MekanismIngredientHelper.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/mekanism/recipe/MekanismIngredientHelper.java
@@ -68,60 +68,45 @@ public class MekanismIngredientHelper {
     }
 
     public static <INPUT extends MachineInput<INPUT>> boolean matches(INPUT in, IngredientWrapper toMatch) {
-        if (in instanceof ItemStackInput) {
-            ItemStackInput input = (ItemStackInput) in;
+        if (in instanceof ItemStackInput input) {
             return matches(input.ingredient, toMatch.getIngredient());
-        } else if (in instanceof GasInput) {
-            GasInput input = (GasInput) in;
+        } else if (in instanceof GasInput input) {
             return matches(input.ingredient, toMatch.getIngredient());
-        } else if (in instanceof FluidInput) {
-            FluidInput input = (FluidInput) in;
+        } else if (in instanceof FluidInput input) {
             return matches(input.ingredient, toMatch.getIngredient());
-        } else if (in instanceof AdvancedMachineInput) {
-            AdvancedMachineInput input = (AdvancedMachineInput) in;
+        } else if (in instanceof AdvancedMachineInput input) {
             return matches(input.itemStack, toMatch.getLeft()) && matches(input.gasType, toMatch.getRight());
-        } else if (in instanceof ChemicalPairInput) {
-            ChemicalPairInput input = (ChemicalPairInput) in;
+        } else if (in instanceof ChemicalPairInput input) {
             return matches(input.leftGas, toMatch.getLeft()) && matches(input.rightGas, toMatch.getRight());
-        } else if (in instanceof DoubleMachineInput) {
-            DoubleMachineInput input = (DoubleMachineInput) in;
+        } else if (in instanceof DoubleMachineInput input) {
             return matches(input.itemStack, toMatch.getLeft()) && matches(input.extraStack, toMatch.getRight());
-        } else if (in instanceof PressurizedInput) {
-            PressurizedInput input = (PressurizedInput) in;
+        } else if (in instanceof PressurizedInput input) {
             return matches(input.getSolid(), toMatch.getLeft()) && matches(input.getFluid(), toMatch.getMiddle()) && matches(input.getGas(), toMatch.getRight());
-        } else if (in instanceof InfusionInput) {
-            InfusionInput input = (InfusionInput) in;
+        } else if (in instanceof InfusionInput input) {
             return matches(input.inputStack, toMatch.getIngredient()) && (toMatch.getInfuseType().isEmpty() || toMatch.getInfuseType().equalsIgnoreCase(input.infuse.getType().name));
-        } else if (in instanceof IntegerInput) {
-            IntegerInput input = (IntegerInput) in;
+        } else if (in instanceof IntegerInput input) {
             return input.ingredient == toMatch.getAmount();
         }
         return false;
     }
 
     public static <OUTPUT extends MachineOutput<OUTPUT>> boolean matches(OUTPUT out, IngredientWrapper toMatch) {
-        if (out instanceof ItemStackOutput) {
-            ItemStackOutput output = (ItemStackOutput) out;
+        if (out instanceof ItemStackOutput output) {
             return matches(output.output, toMatch.getIngredient());
         }
-        if (out instanceof GasOutput) {
-            GasOutput output = (GasOutput) out;
+        if (out instanceof GasOutput output) {
             return matches(output.output, toMatch.getIngredient());
         }
-        if (out instanceof FluidOutput) {
-            FluidOutput output = (FluidOutput) out;
+        if (out instanceof FluidOutput output) {
             return matches(output.output, toMatch.getIngredient());
         }
-        if (out instanceof ChanceOutput) {
-            ChanceOutput output = (ChanceOutput) out;
+        if (out instanceof ChanceOutput output) {
             return matches(output.primaryOutput, toMatch.getLeft()) && matches(output.secondaryOutput, toMatch.getRight());
         }
-        if (out instanceof ChemicalPairOutput) {
-            ChemicalPairOutput output = (ChemicalPairOutput) out;
+        if (out instanceof ChemicalPairOutput output) {
             return matches(output.leftGas, toMatch.getLeft()) && matches(output.rightGas, toMatch.getRight());
         }
-        if (out instanceof PressurizedOutput) {
-            PressurizedOutput output = (PressurizedOutput) out;
+        if (out instanceof PressurizedOutput output) {
             return matches(output.getItemOutput(), toMatch.getLeft()) && matches(output.getGasOutput(), toMatch.getRight());
         }
         return false;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/prodigytech/AtomicReshaper.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/prodigytech/AtomicReshaper.java
@@ -42,8 +42,8 @@ public class AtomicReshaper extends VirtualizedRegistry<AtomicReshaperManager.At
 
     @MethodDescription(example = @Example("ore('paper')"))
     public boolean removeByInput(IIngredient input) {
-        if (input instanceof OreDictIngredient) {
-            AtomicReshaperManager.AtomicReshaperRecipe recipe = AtomicReshaperManager.INSTANCE.removeOreRecipe(((OreDictIngredient) input).getOreDict());
+        if (input instanceof OreDictIngredient oreDictIngredient) {
+            AtomicReshaperManager.AtomicReshaperRecipe recipe = AtomicReshaperManager.INSTANCE.removeOreRecipe(oreDictIngredient.getOreDict());
             if (recipe == null) return false;
             addBackup(recipe);
             return true;
@@ -186,8 +186,8 @@ public class AtomicReshaper extends VirtualizedRegistry<AtomicReshaperManager.At
             if (!validate()) return null;
             AtomicReshaperManager.AtomicReshaperRecipe recipe = null;
             IIngredient inputItem = input.get(0);
-            if (inputItem instanceof OreDictIngredient) {
-                String oredict = ((OreDictIngredient) inputItem).getOreDict();
+            if (inputItem instanceof OreDictIngredient oreDictIngredient) {
+                String oredict = oreDictIngredient.getOreDict();
                 recipe = new AtomicReshaperManager.AtomicReshaperRecipe(oredict, time, primordium, getRecipeOutput());
                 ModSupport.PRODIGY_TECH.get().atomicReshaper.add(recipe);
             } else {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/prodigytech/AtomicReshaper.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/prodigytech/AtomicReshaper.java
@@ -115,11 +115,13 @@ public class AtomicReshaper extends VirtualizedRegistry<AtomicReshaperManager.At
             return this;
         }
 
+        @Override
         public AtomicReshaper.RecipeBuilder output(ItemStack output) {
             output(output, 1);
             return this;
         }
 
+        @Override
         public AtomicReshaper.RecipeBuilder output(ItemStack... outputs) {
             for (ItemStack output : outputs) {
                 output(output, 1);
@@ -127,6 +129,7 @@ public class AtomicReshaper extends VirtualizedRegistry<AtomicReshaperManager.At
             return this;
         }
 
+        @Override
         public AtomicReshaper.RecipeBuilder output(Collection<ItemStack> outputs) {
             for (ItemStack output : outputs) {
                 output(output, 1);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/prodigytech/ExplosionFurnaceAdditives.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/prodigytech/ExplosionFurnaceAdditives.java
@@ -117,8 +117,8 @@ public class ExplosionFurnaceAdditives extends VirtualizedRegistry<ExplosionFurn
 
         @Override
         public void register() {
-            if (this.input instanceof OreDictIngredient) {
-                ExplosionFurnaceManager.addExplosive(((OreDictIngredient) this.input).getOreDict(), this.value);
+            if (this.input instanceof OreDictIngredient oreDictIngredient) {
+                ExplosionFurnaceManager.addExplosive(oreDictIngredient.getOreDict(), this.value);
             } else {
                 for (ItemStack it : this.input.getMatchingStacks()) {
                     ExplosionFurnaceManager.addExplosive(it, this.value);
@@ -128,8 +128,8 @@ public class ExplosionFurnaceAdditives extends VirtualizedRegistry<ExplosionFurn
 
         @Override
         public void unregister() {
-            if (this.input instanceof OreDictIngredient) {
-                ExplosionFurnaceManager.removeExplosive(((OreDictIngredient) this.input).getOreDict());
+            if (this.input instanceof OreDictIngredient oreDictIngredient) {
+                ExplosionFurnaceManager.removeExplosive(oreDictIngredient.getOreDict());
             } else {
                 for (ItemStack it : this.input.getMatchingStacks()) {
                     ExplosionFurnaceManager.removeExplosive(it);
@@ -177,8 +177,8 @@ public class ExplosionFurnaceAdditives extends VirtualizedRegistry<ExplosionFurn
 
         @Override
         public void register() {
-            if (this.input instanceof OreDictIngredient) {
-                ExplosionFurnaceManager.addDampener(((OreDictIngredient) this.input).getOreDict(), this.value);
+            if (this.input instanceof OreDictIngredient oreDictIngredient) {
+                ExplosionFurnaceManager.addDampener(oreDictIngredient.getOreDict(), this.value);
             } else {
                 for (ItemStack it : this.input.getMatchingStacks()) {
                     ExplosionFurnaceManager.addDampener(it, this.value);
@@ -188,8 +188,8 @@ public class ExplosionFurnaceAdditives extends VirtualizedRegistry<ExplosionFurn
 
         @Override
         public void unregister() {
-            if (this.input instanceof OreDictIngredient) {
-                ExplosionFurnaceManager.removeDampener(((OreDictIngredient) this.input).getOreDict());
+            if (this.input instanceof OreDictIngredient oreDictIngredient) {
+                ExplosionFurnaceManager.removeDampener(oreDictIngredient.getOreDict());
             } else {
                 for (ItemStack it : this.input.getMatchingStacks()) {
                     ExplosionFurnaceManager.removeDampener(it);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/prodigytech/PrimordialisReactor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/prodigytech/PrimordialisReactor.java
@@ -27,8 +27,8 @@ public class PrimordialisReactor extends VirtualizedRegistry<IIngredient> {
     }
 
     private void addRecipeBase(IIngredient x) {
-        if (x instanceof OreDictIngredient) {
-            PrimordialisReactorManager.addInput(((OreDictIngredient) x).getOreDict());
+        if (x instanceof OreDictIngredient oreDictIngredient) {
+            PrimordialisReactorManager.addInput(oreDictIngredient.getOreDict());
         } else {
             for (ItemStack it : x.getMatchingStacks()) {
                 PrimordialisReactorManager.addInput(it);
@@ -37,8 +37,8 @@ public class PrimordialisReactor extends VirtualizedRegistry<IIngredient> {
     }
 
     private boolean removeRecipeBase(IIngredient x) {
-        if (x instanceof OreDictIngredient) {
-            PrimordialisReactorManager.removeInput(((OreDictIngredient) x).getOreDict());
+        if (x instanceof OreDictIngredient oreDictIngredient) {
+            PrimordialisReactorManager.removeInput(oreDictIngredient.getOreDict());
         } else {
             for (ItemStack it : x.getMatchingStacks()) {
                 PrimordialisReactorManager.removeInput(it);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/prodigytech/SimpleRecipeHandler.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/prodigytech/SimpleRecipeHandler.java
@@ -64,8 +64,8 @@ public abstract class SimpleRecipeHandler extends SimpleRecipeHandlerAbstract<Si
             if (!validate()) return null;
             SimpleRecipe recipe = null;
             IIngredient input1 = input.get(0);
-            if (input1 instanceof OreDictIngredient) {
-                recipe = new SimpleRecipe(((OreDictIngredient) input1).getOreDict(), output.get(0), time);
+            if (input1 instanceof OreDictIngredient oreDictIngredient) {
+                recipe = new SimpleRecipe(oreDictIngredient.getOreDict(), output.get(0), time);
                 addRecipe(recipe);
             } else {
                 for (ItemStack input : input1.getMatchingStacks()) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/prodigytech/SimpleRecipeHandlerAbstract.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/prodigytech/SimpleRecipeHandlerAbstract.java
@@ -60,8 +60,8 @@ public abstract class SimpleRecipeHandlerAbstract<T extends SimpleRecipe> extend
     }
 
     public boolean removeByInput(IIngredient input) {
-        if (input instanceof OreDictIngredient) {
-            return removeOreRecipe(((OreDictIngredient) input).getOreDict());
+        if (input instanceof OreDictIngredient oreDictIngredient) {
+            return removeOreRecipe(oreDictIngredient.getOreDict());
         } else {
             boolean removed = false;
             for (ItemStack it : input.getMatchingStacks()) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/prodigytech/SimpleRecipeHandlerSecondaryOutput.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/prodigytech/SimpleRecipeHandlerSecondaryOutput.java
@@ -74,8 +74,8 @@ public abstract class SimpleRecipeHandlerSecondaryOutput extends SimpleRecipeHan
             SimpleRecipeSecondaryOutput recipe = null;
             IIngredient input1 = input.get(0);
             ItemStack secondaryOutput = output.size() == 1 ? ItemStack.EMPTY : output.get(1);
-            if (input1 instanceof OreDictIngredient) {
-                recipe = new SimpleRecipeSecondaryOutput(((OreDictIngredient) input1).getOreDict(), output.get(0), secondaryOutput, time, secondaryChance);
+            if (input1 instanceof OreDictIngredient oreDictIngredient) {
+                recipe = new SimpleRecipeSecondaryOutput(oreDictIngredient.getOreDict(), output.get(0), secondaryOutput, time, secondaryChance);
                 addRecipe(recipe);
             } else {
                 for (ItemStack input : input1.getMatchingStacks()) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/prodigytech/ZorraAltar.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/prodigytech/ZorraAltar.java
@@ -35,6 +35,7 @@ public class ZorraAltar extends VirtualizedRegistry<ZorraAltar.ZorraRecipeData> 
         return managers.get(key);
     }
 
+    @Override
     @GroovyBlacklist
     public void onReload() {
         removeScripted().forEach(this::removeEnchantment);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/projecte/EntityRandomizer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/projecte/EntityRandomizer.java
@@ -31,6 +31,7 @@ public class EntityRandomizer extends VirtualizedRegistry<Class<? extends Entity
         WorldHelperAccessor.getMobs().add(entry);
     }
 
+    @SuppressWarnings("unchecked")
     @MethodDescription(type = MethodDescription.Type.ADDITION, example = @Example("entity('minecraft:pig')"))
     public void addMob(EntityEntry entity) {
         addMob((Class<? extends EntityLiving>) entity.getEntityClass());
@@ -42,6 +43,7 @@ public class EntityRandomizer extends VirtualizedRegistry<Class<? extends Entity
         WorldHelperAccessor.getPeacefuls().add(entry);
     }
 
+    @SuppressWarnings("unchecked")
     @MethodDescription(type = MethodDescription.Type.ADDITION, example = @Example("entity('minecraft:zombie')"))
     public void addPeaceful(EntityEntry entity) {
         addPeaceful((Class<? extends EntityLiving>) entity.getEntityClass());
@@ -56,6 +58,7 @@ public class EntityRandomizer extends VirtualizedRegistry<Class<? extends Entity
         return false;
     }
 
+    @SuppressWarnings("unchecked")
     @MethodDescription(example = @Example("entity('minecraft:zombie')"))
     public boolean removeMob(EntityEntry entity) {
         return removeMob((Class<? extends EntityLiving>) entity.getEntityClass());
@@ -70,6 +73,7 @@ public class EntityRandomizer extends VirtualizedRegistry<Class<? extends Entity
         return false;
     }
 
+    @SuppressWarnings("unchecked")
     @MethodDescription(example = @Example("entity('minecraft:pig')"))
     public boolean removePeaceful(EntityEntry entity) {
         return removePeaceful((Class<? extends EntityLiving>) entity.getEntityClass());

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/AnimalHarvest.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/AnimalHarvest.java
@@ -87,6 +87,7 @@ public class AnimalHarvest extends VirtualizedRegistry<AnimalHarvestRecipe> {
         @Property(comp = @Comp(not = "null"))
         private Class<? extends EntityLivingBase> entity;
 
+        @SuppressWarnings("unchecked")
         @RecipeBuilderMethodDescription
         public RecipeBuilder entity(EntityEntry entity) {
             this.entity = (Class<? extends EntityLivingBase>) entity.getEntityClass();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/LifeEssence.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/LifeEssence.java
@@ -25,6 +25,7 @@ public class LifeEssence extends StandardListRegistry<Class<? extends EntityLivi
         add(entity.getClass());
     }
 
+    @SuppressWarnings("unchecked")
     @MethodDescription(example = @Example("entity('minecraft:wither_skeleton')"), type = MethodDescription.Type.ADDITION)
     public void add(EntityEntry entity) {
         add((Class<? extends EntityLivingBase>) entity.getEntityClass());
@@ -35,6 +36,7 @@ public class LifeEssence extends StandardListRegistry<Class<? extends EntityLivi
         return remove(entity.getClass());
     }
 
+    @SuppressWarnings("unchecked")
     @MethodDescription(example = @Example("entity('minecraft:sheep')"))
     public boolean remove(EntityEntry entity) {
         return remove((Class<? extends EntityLivingBase>) entity.getEntityClass());

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Moss.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/Moss.java
@@ -44,10 +44,10 @@ public class Moss extends VirtualizedRegistry<Pair<ItemStack, ItemStack>> {
             ItemStack in = entry.getKey();
             ItemStack out = entry.getValue();
 
-            if (!(in.getItem() instanceof ItemBlock) || !(out.getItem() instanceof ItemBlock)) continue;
+            if (!(in.getItem() instanceof ItemBlock itemBlockIn) || !(out.getItem() instanceof ItemBlock itemBlockOut)) continue;
 
-            Block blockIn = ((ItemBlock) in.getItem()).getBlock();
-            Block blockOut = ((ItemBlock) out.getItem()).getBlock();
+            Block blockIn = itemBlockIn.getBlock();
+            Block blockOut = itemBlockOut.getBlock();
 
             if (in.getMetadata() == 0 && out.getMetadata() == 0) {
                 MossConfigAccessor.getMossyBlocks().put(blockIn, blockOut);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/RunicShearEntity.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/RunicShearEntity.java
@@ -74,6 +74,7 @@ public class RunicShearEntity extends VirtualizedRegistry<RunicShearEntityRecipe
         });
     }
 
+    @SuppressWarnings("unchecked")
     @MethodDescription(example = @Example("entity('minecraft:chicken')"))
     public boolean removeByEntity(EntityEntry entity) {
         return removeByEntity((Class<? extends EntityLivingBase>) entity.getEntityClass());
@@ -114,6 +115,7 @@ public class RunicShearEntity extends VirtualizedRegistry<RunicShearEntityRecipe
         @Property
         private Function<EntityLivingBase, ItemStack> functionMap;
 
+        @SuppressWarnings("unchecked")
         @RecipeBuilderMethodDescription
         public RecipeBuilder entity(EntityEntry entity) {
             this.entity = (Class<? extends EntityLivingBase>) entity.getEntityClass();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/SummonCreature.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/roots/SummonCreature.java
@@ -59,6 +59,7 @@ public class SummonCreature extends VirtualizedRegistry<SummonCreatureRecipe> {
         return true;
     }
 
+    @SuppressWarnings("unchecked")
     @MethodDescription(example = @Example("entity('minecraft:chicken')"))
     public boolean removeByEntity(EntityEntry entity) {
         return removeByEntity((Class<? extends EntityLivingBase>) entity.getEntityClass());
@@ -96,6 +97,7 @@ public class SummonCreature extends VirtualizedRegistry<SummonCreatureRecipe> {
         @Property(comp = @Comp(not = "null"))
         private Class<? extends EntityLivingBase> entity;
 
+        @SuppressWarnings("unchecked")
         @RecipeBuilderMethodDescription
         public RecipeBuilder entity(EntityEntry entity) {
             this.entity = (Class<? extends EntityLivingBase>) entity.getEntityClass();

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/tcomplement/HighOven.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/tcomplement/HighOven.java
@@ -125,7 +125,7 @@ public class HighOven extends StandardListRegistry<MeltingRecipe> {
 
         public boolean removeByInput(FluidStack input) {
             if (getRecipes().removeIf(recipe -> {
-                HighOvenFilter recipe1 = (recipe instanceof HighOvenFilter) ? (HighOvenFilter) recipe : null;
+                HighOvenFilter recipe1 = (recipe instanceof HighOvenFilter highOvenFilter) ? highOvenFilter : null;
                 boolean found = recipe1 != null && recipe1.getInput().isFluidEqual(input);
                 if (found) addBackup(recipe);
                 return found;
@@ -140,7 +140,7 @@ public class HighOven extends StandardListRegistry<MeltingRecipe> {
 
         public boolean removeByInputAndOutput(FluidStack input, FluidStack output) {
             if (getRecipes().removeIf(recipe -> {
-                HighOvenFilter recipe1 = (recipe instanceof HighOvenFilter) ? (HighOvenFilter) recipe : null;
+                HighOvenFilter recipe1 = (recipe instanceof HighOvenFilter highOvenFilter) ? highOvenFilter : null;
                 boolean found = recipe1 != null && recipe1.getInput().isFluidEqual(input) && recipe1.getOutput().isFluidEqual(output);
                 if (found) addBackup(recipe);
                 return found;
@@ -155,7 +155,7 @@ public class HighOven extends StandardListRegistry<MeltingRecipe> {
 
         public boolean removeByAdditives(Map<MixAdditive, IIngredient> additives) {
             if (getRecipes().removeIf(recipe -> {
-                MixRecipe recipe1 = (recipe instanceof MixRecipe) ? (MixRecipe) recipe : null;
+                MixRecipe recipe1 = (recipe instanceof MixRecipe mixRecipe) ? mixRecipe : null;
                 if (recipe1 != null) {
                     for (Map.Entry<MixAdditive, IIngredient> entry : additives.entrySet()) {
                         if (recipe1.getAdditives(entry.getKey()).contains(entry.getValue().getMatchingStacks()[0])) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/Crucible.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/Crucible.java
@@ -87,8 +87,8 @@ public class Crucible extends VirtualizedRegistry<CrucibleRecipe> {
         List<CrucibleRecipe> recipes = new ArrayList<>();
         for (IThaumcraftRecipe iThaumcraftRecipe : ThaumcraftApi.getCraftingRecipes().values()) {
             r = iThaumcraftRecipe;
-            if ((r instanceof CrucibleRecipe) && output.test(((CrucibleRecipe) r).getRecipeOutput())) {
-                recipes.add((CrucibleRecipe) r);
+            if ((r instanceof CrucibleRecipe crucibleRecipe) && output.test(crucibleRecipe.getRecipeOutput())) {
+                recipes.add(crucibleRecipe);
             }
         }
         if (recipes.isEmpty()) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/InfusionCrafting.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/InfusionCrafting.java
@@ -63,8 +63,8 @@ public class InfusionCrafting extends VirtualizedRegistry<Pair<ResourceLocation,
     public boolean remove(InfusionRecipe recipe) {
         List<InfusionRecipe> recipes = new ArrayList<>();
         for (IThaumcraftRecipe r : ThaumcraftApi.getCraftingRecipes().values()) {
-            if (r instanceof InfusionRecipe && r.equals(recipe))
-                recipes.add((InfusionRecipe) r);
+            if (r instanceof InfusionRecipe infusionRecipe && r.equals(recipe))
+                recipes.add(infusionRecipe);
         }
         recipes.forEach(rec -> {
             if (rec.getGroup().isEmpty()) {
@@ -88,7 +88,7 @@ public class InfusionCrafting extends VirtualizedRegistry<Pair<ResourceLocation,
         }
         List<InfusionRecipe> recipes = new ArrayList<>();
         for (IThaumcraftRecipe r : ThaumcraftApi.getCraftingRecipes().values()) {
-            if (r instanceof InfusionRecipe && ((InfusionRecipe) r).getRecipeOutput() instanceof ItemStack ro) {
+            if (r instanceof InfusionRecipe infusionRecipe && infusionRecipe.getRecipeOutput() instanceof ItemStack ro) {
                 if (output.test(ro)) {
                     recipes.add((InfusionRecipe) r);
                 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/InfusionCrafting.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/InfusionCrafting.java
@@ -67,7 +67,7 @@ public class InfusionCrafting extends VirtualizedRegistry<Pair<ResourceLocation,
                 recipes.add((InfusionRecipe) r);
         }
         recipes.forEach(rec -> {
-            if ("".equals(rec.getGroup())) {
+            if (rec.getGroup().isEmpty()) {
                 this.addBackup(Pair.of(new ResourceLocation("thaumcraft:" + ((ItemStack) rec.recipeOutput).getItem()), recipe));
             } else {
                 this.addBackup(Pair.of(new ResourceLocation(rec.getGroup()), recipe));
@@ -102,7 +102,7 @@ public class InfusionCrafting extends VirtualizedRegistry<Pair<ResourceLocation,
             return;
         }
         recipes.forEach(recipe -> {
-            if ("".equals(recipe.getGroup())) {
+            if (recipe.getGroup().isEmpty()) {
                 this.addBackup(Pair.of(new ResourceLocation("thaumcraft:" + ((ItemStack) recipe.recipeOutput).getItem()), recipe));
             } else {
                 this.addBackup(Pair.of(new ResourceLocation(recipe.getGroup()), recipe));

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/SmeltingBonus.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/SmeltingBonus.java
@@ -39,9 +39,9 @@ public class SmeltingBonus extends VirtualizedRegistry<ThaumcraftApi.SmeltBonus>
 
     @MethodDescription(description = "groovyscript.wiki.thaumcraft.smelting_bonus.add1", type = MethodDescription.Type.ADDITION)
     public void add(IIngredient in, ItemStack out, float chance) {
-        if (in instanceof OreDictIngredient) {
-            ThaumcraftApi.addSmeltingBonus(((OreDictIngredient) in).getOreDict(), out, chance);
-            addScripted(new ThaumcraftApi.SmeltBonus(((OreDictIngredient) in).getOreDict(), out, chance));
+        if (in instanceof OreDictIngredient oreDictIngredient) {
+            ThaumcraftApi.addSmeltingBonus(oreDictIngredient.getOreDict(), out, chance);
+            addScripted(new ThaumcraftApi.SmeltBonus(oreDictIngredient.getOreDict(), out, chance));
         } else if (in.getMatchingStacks().length == 1) {
             ThaumcraftApi.addSmeltingBonus(in.getMatchingStacks()[0], out, chance);
             addScripted(new ThaumcraftApi.SmeltBonus(in.getMatchingStacks()[0], out, chance));

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/arcane/ShapedArcaneCR.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/arcane/ShapedArcaneCR.java
@@ -79,14 +79,12 @@ public class ShapedArcaneCR extends ShapedArcaneRecipe implements ICraftingRecip
     }
 
     @Override
-    @Nullable
-    public Closure<Void> getRecipeAction() {
+    public @Nullable Closure<Void> getRecipeAction() {
         return craftingRecipe.getRecipeAction();
     }
 
     @Override
-    @Nullable
-    public Closure<ItemStack> getRecipeFunction() {
+    public @Nullable Closure<ItemStack> getRecipeFunction() {
         return craftingRecipe.getRecipeFunction();
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/arcane/ShapelessArcaneCR.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/arcane/ShapelessArcaneCR.java
@@ -57,14 +57,12 @@ public class ShapelessArcaneCR extends ShapelessArcaneRecipe implements ICraftin
     }
 
     @Override
-    @Nullable
-    public Closure<Void> getRecipeAction() {
+    public @Nullable Closure<Void> getRecipeAction() {
         return craftingRecipe.getRecipeAction();
     }
 
     @Override
-    @Nullable
-    public Closure<ItemStack> getRecipeFunction() {
+    public @Nullable Closure<ItemStack> getRecipeFunction() {
         return craftingRecipe.getRecipeFunction();
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/aspect/AspectHelper.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/aspect/AspectHelper.java
@@ -51,10 +51,10 @@ public class AspectHelper extends VirtualizedRegistry<AspectListHelper> {
     public void addScripted(Object target, AspectStack aspect) {
         AtomicBoolean found = new AtomicBoolean(false);
         getScriptedRecipes().forEach(scriptedAspect -> {
-            if (target instanceof EntityEntry && scriptedAspect.entity != null && ((EntityEntry) target).getName().equals(scriptedAspect.entity.getName())) {
+            if (target instanceof EntityEntry entityEntry && scriptedAspect.entity != null && entityEntry.getName().equals(scriptedAspect.entity.getName())) {
                 found.set(true);
                 scriptedAspect.addAspect(aspect);
-            } else if (target instanceof ItemStack && scriptedAspect.item != null && ((ItemStack) target).isItemEqual(scriptedAspect.item)) {
+            } else if (target instanceof ItemStack itemStack && scriptedAspect.item != null && itemStack.isItemEqual(scriptedAspect.item)) {
                 found.set(true);
                 scriptedAspect.addAspect(aspect);
             }
@@ -63,10 +63,10 @@ public class AspectHelper extends VirtualizedRegistry<AspectListHelper> {
         if (!found.get()) {
             ArrayList<AspectStack> aspectList = new ArrayList<>();
             aspectList.add(aspect);
-            if (target instanceof ItemStack)
-                addScripted(new AspectListHelper((ItemStack) target, aspectList));
-            else if (target instanceof EntityEntry)
-                addScripted(new AspectListHelper((EntityEntry) target, aspectList));
+            if (target instanceof ItemStack itemStack)
+                addScripted(new AspectListHelper(itemStack, aspectList));
+            else if (target instanceof EntityEntry entityEntry)
+                addScripted(new AspectListHelper(entityEntry, aspectList));
         }
     }
 
@@ -74,10 +74,10 @@ public class AspectHelper extends VirtualizedRegistry<AspectListHelper> {
     public void addBackup(Object target, AspectStack aspect) {
         AtomicBoolean found = new AtomicBoolean(false);
         getBackupRecipes().forEach(backupAspect -> {
-            if (target instanceof EntityEntry && backupAspect.entity != null && ((EntityEntry) target).getName().equals(backupAspect.entity.getName())) {
+            if (target instanceof EntityEntry entityEntry && backupAspect.entity != null && entityEntry.getName().equals(backupAspect.entity.getName())) {
                 found.set(true);
                 backupAspect.addAspect(aspect);
-            } else if (target instanceof ItemStack && backupAspect.item != null && ((ItemStack) target).isItemEqual(backupAspect.item)) {
+            } else if (target instanceof ItemStack itemStack && backupAspect.item != null && itemStack.isItemEqual(backupAspect.item)) {
                 found.set(true);
                 backupAspect.addAspect(aspect);
             }
@@ -86,10 +86,10 @@ public class AspectHelper extends VirtualizedRegistry<AspectListHelper> {
         if (!found.get()) {
             ArrayList<AspectStack> aspectList = new ArrayList<>();
             aspectList.add(aspect);
-            if (target instanceof ItemStack)
-                addBackup(new AspectListHelper((ItemStack) target, aspectList));
-            else if (target instanceof EntityEntry)
-                addBackup(new AspectListHelper((EntityEntry) target, aspectList));
+            if (target instanceof ItemStack itemStack)
+                addBackup(new AspectListHelper(itemStack, aspectList));
+            else if (target instanceof EntityEntry entityEntry)
+                addBackup(new AspectListHelper(entityEntry, aspectList));
         }
     }
 
@@ -342,8 +342,8 @@ public class AspectHelper extends VirtualizedRegistry<AspectListHelper> {
             if (stripAspects) {
                 if (entity != null) {
                     ModSupport.THAUMCRAFT.get().aspectHelper.removeAll(entity);
-                } else if (object != null && object instanceof OreDictIngredient) {
-                    ModSupport.THAUMCRAFT.get().aspectHelper.removeAll((OreDictIngredient) object);
+                } else if (object != null && object instanceof OreDictIngredient oreDictIngredient) {
+                    ModSupport.THAUMCRAFT.get().aspectHelper.removeAll(oreDictIngredient);
                 } else if (object != null && IngredientHelper.isItem(object) && !IngredientHelper.isEmpty(object)) {
                     ModSupport.THAUMCRAFT.get().aspectHelper.removeAll(IngredientHelper.toItemStack(object));
                 } else {
@@ -355,8 +355,8 @@ public class AspectHelper extends VirtualizedRegistry<AspectListHelper> {
             aspects.forEach(aspectStack -> {
                 if (entity != null)
                     ModSupport.THAUMCRAFT.get().aspectHelper.add(entity, aspectStack);
-                else if (object != null && object instanceof OreDictIngredient)
-                    ModSupport.THAUMCRAFT.get().aspectHelper.add(((OreDictIngredient) object), aspectStack);
+                else if (object != null && object instanceof OreDictIngredient oreDictIngredient)
+                    ModSupport.THAUMCRAFT.get().aspectHelper.add(oreDictIngredient, aspectStack);
                 else if (object != null && IngredientHelper.isItem(object) && !IngredientHelper.isEmpty(object))
                     ModSupport.THAUMCRAFT.get().aspectHelper.add(IngredientHelper.toItemStack(object), aspectStack);
                 else

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/tinkersconstruct/material/GroovyMaterial.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/tinkersconstruct/material/GroovyMaterial.java
@@ -34,7 +34,7 @@ public class GroovyMaterial extends Material {
     }
 
     public GroovyMaterial addItem(IIngredient item, int amountNeeded, int amountMatched) {
-        if (item instanceof OreDictIngredient) addItem(((OreDictIngredient) item).getOreDict(), amountNeeded, amountMatched * 144);
+        if (item instanceof OreDictIngredient oreDictIngredient) addItem(oreDictIngredient.getOreDict(), amountNeeded, amountMatched * 144);
         else addItem(item.getMatchingStacks()[0], amountNeeded, amountMatched * 144);
         return this;
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/tinkersconstruct/material/MaterialRepairIngredient.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/tinkersconstruct/material/MaterialRepairIngredient.java
@@ -2,6 +2,7 @@ package com.cleanroommc.groovyscript.compat.mods.tinkersconstruct.material;
 
 import com.cleanroommc.groovyscript.api.IIngredient;
 
+@SuppressWarnings("ClassCanBeRecord")
 public class MaterialRepairIngredient {
 
     public final IIngredient ingredient;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/tinkersconstruct/material/ToolMaterialBuilder.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/tinkersconstruct/material/ToolMaterialBuilder.java
@@ -219,8 +219,7 @@ public class ToolMaterialBuilder {
         msg.add(displayName == null || displayName.isEmpty(), "Expected a localized material name, got " + displayName);
     }
 
-    @Nullable
-    public Material register() {
+    public @Nullable Material register() {
         if (!validate()) return null;
         GroovyMaterial material = new GroovyMaterial(name, color, traits);
         addedMaterials.add(material);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/tinkersconstruct/material/ToolMaterialBuilder.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/tinkersconstruct/material/ToolMaterialBuilder.java
@@ -236,13 +236,13 @@ public class ToolMaterialBuilder {
             if (stat != null) material.addStats(stat);
         });
         repairIngredients.forEach(repair -> {
-            if (repair.ingredient instanceof OreDictIngredient)
-                material.addItem(((OreDictIngredient) repair.ingredient).getOreDict(), repair.amountNeeded, repair.amountMatched * 144);
+            if (repair.ingredient instanceof OreDictIngredient oreDictIngredient)
+                material.addItem(oreDictIngredient.getOreDict(), repair.amountNeeded, repair.amountMatched * 144);
             else material.addItem(repair.ingredient.getMatchingStacks()[0], repair.amountNeeded, repair.amountMatched * 144);
         });
 
         if (representativeItem != null) {
-            if (representativeItem instanceof OreDictIngredient) material.setRepresentativeItem(((OreDictIngredient) representativeItem).getOreDict());
+            if (representativeItem instanceof OreDictIngredient oreDictIngredient) material.setRepresentativeItem(oreDictIngredient.getOreDict());
             else material.representativeItem = representativeItem;
         }
         material.shard = shard;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/tinkersconstruct/material/armory/GroovyArmorTrait.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/tinkersconstruct/material/armory/GroovyArmorTrait.java
@@ -16,7 +16,7 @@ public class GroovyArmorTrait extends ArmorModifierTrait implements IArmorTrait 
     }
 
     public GroovyArmorTrait addItem(IIngredient ingredient, int amountNeeded, int amountMatched) {
-        if (ingredient instanceof OreDictIngredient) addItem(((OreDictIngredient) ingredient).getOreDict(), amountNeeded, amountMatched * 144);
+        if (ingredient instanceof OreDictIngredient oreDictIngredient) addItem(oreDictIngredient.getOreDict(), amountNeeded, amountMatched * 144);
         else addItem(ingredient.getMatchingStacks()[0], amountNeeded, amountMatched * 144);
         return this;
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/tinkersconstruct/material/traits/GroovyTrait.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/tinkersconstruct/material/traits/GroovyTrait.java
@@ -16,7 +16,7 @@ public class GroovyTrait extends ModifierTrait implements ITrait {
     }
 
     public GroovyTrait addItem(IIngredient ingredient, int amountNeeded, int amountMatched) {
-        if (ingredient instanceof OreDictIngredient) addItem(((OreDictIngredient) ingredient).getOreDict(), amountNeeded, amountMatched);
+        if (ingredient instanceof OreDictIngredient oreDictIngredient) addItem(oreDictIngredient.getOreDict(), amountNeeded, amountMatched);
         else addItem(ingredient.getMatchingStacks()[0], amountNeeded, amountMatched);
         return this;
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/tinkersconstruct/recipe/MeltingRecipeBuilder.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/tinkersconstruct/recipe/MeltingRecipeBuilder.java
@@ -23,8 +23,8 @@ public class MeltingRecipeBuilder extends AbstractRecipeBuilder<MeltingRecipe> {
     private final String recipeName;
 
     public static RecipeMatch recipeMatchFromIngredient(IIngredient ingredient, int amount) {
-        return (ingredient instanceof OreDictIngredient)
-                ? RecipeMatch.of(((OreDictIngredient) ingredient).getOreDict(), amount)
+        return (ingredient instanceof OreDictIngredient oreDictIngredient)
+                ? RecipeMatch.of(oreDictIngredient.getOreDict(), amount)
                 : RecipeMatch.of(ingredient.getMatchingStacks()[0], amount);
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/tinkersconstruct/recipe/SmelteryFuelRecipe.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/tinkersconstruct/recipe/SmelteryFuelRecipe.java
@@ -4,6 +4,7 @@ import net.minecraftforge.fluids.FluidStack;
 
 import java.util.Map;
 
+@SuppressWarnings("ClassCanBeRecord")
 public class SmelteryFuelRecipe {
 
     public final FluidStack fluid;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/CraftingRecipe.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/CraftingRecipe.java
@@ -190,8 +190,8 @@ public abstract class CraftingRecipe extends IForgeRegistryEntry.Impl<IRecipe> i
         Container eventHandler = ((InventoryCraftingAccess) inventory).getEventHandler();
         if (eventHandler != null) {
             for (Slot slot : eventHandler.inventorySlots) {
-                if (slot instanceof SlotCraftingAccess) {
-                    return ((SlotCraftingAccess) slot).getPlayer();
+                if (slot instanceof SlotCraftingAccess slotCraftingAccess) {
+                    return slotCraftingAccess.getPlayer();
                 }
             }
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/CraftingRecipe.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/CraftingRecipe.java
@@ -129,6 +129,7 @@ public abstract class CraftingRecipe extends IForgeRegistryEntry.Impl<IRecipe> i
         }
     }
 
+    @SuppressWarnings("ClassCanBeRecord")
     public static class SlotMatchResult {
 
         private final IIngredient recipeIngredient;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/CraftingRecipe.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/CraftingRecipe.java
@@ -27,10 +27,8 @@ public abstract class CraftingRecipe extends IForgeRegistryEntry.Impl<IRecipe> i
     protected final ItemStack output;
     protected final List<IIngredient> input;
     private final NonNullList<Ingredient> ingredients;
-    @Nullable
-    protected final Closure<ItemStack> recipeFunction;
-    @Nullable
-    protected final Closure<Void> recipeAction;
+    protected final @Nullable Closure<ItemStack> recipeFunction;
+    protected final @Nullable Closure<Void> recipeAction;
 
     public CraftingRecipe(ItemStack output, List<IIngredient> input, @Nullable Closure<ItemStack> recipeFunction, @Nullable Closure<Void> recipeAction) {
         this.output = output;
@@ -68,15 +66,13 @@ public abstract class CraftingRecipe extends IForgeRegistryEntry.Impl<IRecipe> i
         return output;
     }
 
-    @Nullable
     @Override
-    public Closure<Void> getRecipeAction() {
+    public @Nullable Closure<Void> getRecipeAction() {
         return recipeAction;
     }
 
-    @Nullable
     @Override
-    public Closure<ItemStack> getRecipeFunction() {
+    public @Nullable Closure<ItemStack> getRecipeFunction() {
         return recipeFunction;
     }
 
@@ -109,8 +105,7 @@ public abstract class CraftingRecipe extends IForgeRegistryEntry.Impl<IRecipe> i
         return !getMatchingList(inv).isEmpty();
     }
 
-    @NotNull
-    public abstract MatchList getMatchingList(InventoryCrafting inv);
+    public abstract @NotNull MatchList getMatchingList(InventoryCrafting inv);
 
     /**
      * Contains information about a inventory that was matched against a recipe.
@@ -166,13 +161,11 @@ public abstract class CraftingRecipe extends IForgeRegistryEntry.Impl<IRecipe> i
     public static class InputList extends ArrayList<ItemStack> {
 
         // groovy [] operator
-        @Nullable
-        public ItemStack getAt(String mark) {
+        public @Nullable ItemStack getAt(String mark) {
             return findMarked(mark);
         }
 
-        @Nullable
-        public ItemStack findMarked(String mark) {
+        public @Nullable ItemStack findMarked(String mark) {
             if (isEmpty()) return null;
             for (ItemStack itemStack : this) {
                 if (mark.equals(ItemStackMixinExpansion.of(itemStack).getMark())) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/ItemStackMixinExpansion.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/ItemStackMixinExpansion.java
@@ -220,9 +220,8 @@ public interface ItemStackMixinExpansion extends IIngredient, INbtIngredient {
         return withMeta(meta);
     }
 
-    @Nullable
     @Override
-    default String getMark() {
+    default @Nullable String getMark() {
         return grs$getMark();
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/OreDictEntry.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/OreDictEntry.java
@@ -3,6 +3,7 @@ package com.cleanroommc.groovyscript.compat.vanilla;
 import com.cleanroommc.groovyscript.api.GroovyBlacklist;
 import net.minecraft.item.ItemStack;
 
+@SuppressWarnings("ClassCanBeRecord")
 public class OreDictEntry {
 
     public final String name;

--- a/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/Rarity.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/Rarity.java
@@ -76,6 +76,7 @@ public class Rarity extends NamedRegistry {
         };
     }
 
+    @SuppressWarnings("ClassCanBeRecord")
     private static class RarityImpl implements IRarity {
 
         private final TextFormatting color;

--- a/src/main/java/com/cleanroommc/groovyscript/core/GroovyScriptCore.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/GroovyScriptCore.java
@@ -32,9 +32,8 @@ public class GroovyScriptCore implements IFMLLoadingPlugin, IEarlyMixinLoader {
         return "com.cleanroommc.groovyscript.sandbox.ScriptModContainer";
     }
 
-    @Nullable
     @Override
-    public String getSetupClass() {
+    public @Nullable String getSetupClass() {
         return null;
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/FluidStackMixin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/FluidStackMixin.java
@@ -31,9 +31,8 @@ public abstract class FluidStackMixin implements IIngredient, INbtIngredient, IN
     @Shadow
     public NBTTagCompound tag;
 
-    @NotNull
     @Shadow
-    public abstract FluidStack copy();
+    public abstract @NotNull FluidStack copy();
 
     @Shadow
     public abstract boolean isFluidEqual(FluidStack other);
@@ -182,9 +181,8 @@ public abstract class FluidStackMixin implements IIngredient, INbtIngredient, IN
         this.amount = amount;
     }
 
-    @Nullable
     @Override
-    public String getMark() {
+    public @Nullable String getMark() {
         return groovyScript$mark;
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/ForgeRegistryMixin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/ForgeRegistryMixin.java
@@ -209,8 +209,7 @@ public abstract class ForgeRegistryMixin<V extends IForgeRegistryEntry<V>> imple
     }
 
     @Unique
-    @Nullable
-    public V groovyScript$getDummy(ResourceLocation rl) {
+    public @Nullable V groovyScript$getDummy(ResourceLocation rl) {
         if (dummyFactory != null) {
             return dummyFactory.createDummy(rl);
         }

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/ItemStackMixin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/ItemStackMixin.java
@@ -72,9 +72,8 @@ public abstract class ItemStackMixin implements ItemStackMixinExpansion {
     }
 
     @GroovyBlacklist
-    @Nullable
     @Override
-    public String grs$getMark() {
+    public @Nullable String grs$getMark() {
         return groovyScript$mark;
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/botania/PageCraftingRecipeMixin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/botania/PageCraftingRecipeMixin.java
@@ -69,11 +69,11 @@ public abstract class PageCraftingRecipeMixin extends PageRecipe {
                 this.oreDictRecipe = recipe instanceof ShapedOreRecipe;
                 int width = oreDictRecipe
                         ? ReflectionHelper.getPrivateValue(ShapedOreRecipe.class, (ShapedOreRecipe) recipe, "width")
-                        : recipe instanceof ShapedCraftingRecipe ? ((ShapedCraftingRecipe) recipe).getRecipeWidth()
+                        : recipe instanceof ShapedCraftingRecipe craftingRecipe ? craftingRecipe.getRecipeWidth()
                         : ((ShapedRecipes) recipe).getWidth();
                 int height = oreDictRecipe
                         ? ReflectionHelper.getPrivateValue(ShapedOreRecipe.class, (ShapedOreRecipe) recipe, "height")
-                        : recipe instanceof ShapedCraftingRecipe ? ((ShapedCraftingRecipe) recipe).getRecipeHeight()
+                        : recipe instanceof ShapedCraftingRecipe shapedCraftingRecipe ? shapedCraftingRecipe.getRecipeHeight()
                         : ((ShapedRecipes) recipe).getHeight();
 
                 for (index = 0; index < height; ++index) {

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/groovy/MetaClassImplMixin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/groovy/MetaClassImplMixin.java
@@ -117,10 +117,10 @@ public abstract class MetaClassImplMixin {
         Object value = null;
         if (metaProperty != null) {
             value = metaProperty.getProperty(object);
-        } else if (object instanceof Map) {
-            value = ((Map<?, ?>) object).get(methodName);
-        } else if (object instanceof Script) {
-            value = ((Script) object).getBinding().getVariables().get(methodName);
+        } else if (object instanceof Map<?, ?>map) {
+            value = map.get(methodName);
+        } else if (object instanceof Script script) {
+            value = script.getBinding().getVariables().get(methodName);
         } else if (object instanceof GroovyObject) {
             value = GroovyScript.getSandbox().getBindings().get(methodName);
         }

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/mekanism/GasStackMixin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/mekanism/GasStackMixin.java
@@ -52,9 +52,8 @@ public abstract class GasStackMixin implements IIngredient, IResourceStack {
         return false;
     }
 
-    @Nullable
     @Override
-    public String getMark() {
+    public @Nullable String getMark() {
         return groovyScript$mark;
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/documentation/Builder.java
+++ b/src/main/java/com/cleanroommc/groovyscript/documentation/Builder.java
@@ -204,8 +204,7 @@ public class Builder {
         return parts;
     }
 
-    @NotNull
-    private static List<String> getOutputs(List<String> parts) {
+    private static @NotNull List<String> getOutputs(List<String> parts) {
         List<String> output = new ArrayList<>();
         for (int i = 0; i < parts.size(); i++) {
             String part = parts.get(i);

--- a/src/main/java/com/cleanroommc/groovyscript/event/EventHandler.java
+++ b/src/main/java/com/cleanroommc/groovyscript/event/EventHandler.java
@@ -136,8 +136,8 @@ public class EventHandler {
             }
             if (craftResult != null) {
                 IRecipe recipe = craftResult.getRecipeUsed();
-                if (recipe instanceof ICraftingRecipe) {
-                    Closure<Void> recipeAction = ((ICraftingRecipe) recipe).getRecipeAction();
+                if (recipe instanceof ICraftingRecipe iCraftingRecipe) {
+                    Closure<Void> recipeAction = iCraftingRecipe.getRecipeAction();
                     if (recipeAction != null) {
                         GroovyLog.get().infoMC("Fire Recipe Action");
                         ClosureHelper.call(recipeAction, event.crafting, new CraftingInfo(inventoryCrafting, player));
@@ -150,8 +150,8 @@ public class EventHandler {
     @SubscribeEvent
     public static void onExplosion(ExplosionEvent.Detonate event) {
         for (Entity entity : event.getAffectedEntities()) {
-            if (entity instanceof EntityItem) {
-                VanillaModule.inWorldCrafting.explosion.findAndRunRecipe((EntityItem) entity);
+            if (entity instanceof EntityItem entityItem) {
+                VanillaModule.inWorldCrafting.explosion.findAndRunRecipe(entityItem);
             }
         }
     }

--- a/src/main/java/com/cleanroommc/groovyscript/event/GsHandEvent.java
+++ b/src/main/java/com/cleanroommc/groovyscript/event/GsHandEvent.java
@@ -24,63 +24,53 @@ public class GsHandEvent extends Event {
     /**
      * Server where the command is executed
      */
-    @NotNull
-    public final MinecraftServer server;
+    public final @NotNull MinecraftServer server;
 
     /**
      * Player who executes the command
      */
-    @NotNull
-    public final EntityPlayer player;
+    public final @NotNull EntityPlayer player;
 
     /**
      * Arguments of the command
      */
-    @NotNull
-    public final String[] commandArgs;
+    public final @NotNull String[] commandArgs;
 
     /**
      * A list of messages that will be sent to the player after this event.
      * Add or remove your messages here.
      */
-    @NotNull
-    public final List<ITextComponent> messages;
+    public final @NotNull List<ITextComponent> messages;
 
     /**
      * The held item or the item form of the block being looked at.
      */
-    @NotNull
-    public final ItemStack stack;
+    public final @NotNull ItemStack stack;
 
     /**
      * The entity the player is looking at
      */
-    @Nullable
-    public final Entity entity;
+    public final @Nullable Entity entity;
 
     /**
      * The block position the player is looking at
      */
-    @Nullable
-    public final BlockPos pos;
+    public final @Nullable BlockPos pos;
 
     /**
      * The block state of the held item or the block state the player is looking at
      */
-    @Nullable
-    public final IBlockState blockState;
+    public final @Nullable IBlockState blockState;
 
     /**
      * The block of the held item or the block the player is looking at
      */
-    @Nullable
-    public final Block block;
+    public final @Nullable Block block;
 
     /**
      * The tile entity the player is looking at
      */
-    @Nullable
-    public final TileEntity tileEntity;
+    public final @Nullable TileEntity tileEntity;
 
     /**
      * If pretty nbt is enabled

--- a/src/main/java/com/cleanroommc/groovyscript/helper/Alias.java
+++ b/src/main/java/com/cleanroommc/groovyscript/helper/Alias.java
@@ -33,17 +33,17 @@ public class Alias extends ArrayList<String> {
     }
 
     public Alias andGenerateOfClass(Object o) {
-        Class<?> clazz = o instanceof Class ? (Class<?>) o : o.getClass();
+        Class<?> clazz = o instanceof Class<?>c ? c : o.getClass();
         return andGenerate(clazz.getSimpleName());
     }
 
     public static Alias generateOfClass(Object o) {
-        Class<?> clazz = o instanceof Class ? (Class<?>) o : o.getClass();
+        Class<?> clazz = o instanceof Class<?>c ? c : o.getClass();
         return generateOf(clazz.getSimpleName(), CaseFormat.UPPER_CAMEL);
     }
 
     public static Alias generateOfClassAnd(Object o, String... names) {
-        Class<?> clazz = o instanceof Class ? (Class<?>) o : o.getClass();
+        Class<?> clazz = o instanceof Class<?>c ? c : o.getClass();
         Alias alias = new Alias();
         generateAliases(alias, clazz.getSimpleName(), CaseFormat.UPPER_CAMEL);
         for (String name : names) {

--- a/src/main/java/com/cleanroommc/groovyscript/helper/Alias.java
+++ b/src/main/java/com/cleanroommc/groovyscript/helper/Alias.java
@@ -105,8 +105,7 @@ public class Alias extends ArrayList<String> {
     private static final Pattern lowerUnderscore = Pattern.compile("[a-z]+(_[a-z]+)*");
     private static final Pattern upperUnderscore = Pattern.compile("[A-Z]+(_[A-Z]+)*");
 
-    @NotNull
-    public static CaseFormat detectCaseFormat(String s) {
+    public static @NotNull CaseFormat detectCaseFormat(String s) {
         if (s == null || s.isEmpty()) throw new IllegalArgumentException("String must not be empty");
         if (lowerCamel.matcher(s).matches()) return CaseFormat.LOWER_CAMEL;
         if (upperCamel.matcher(s).matches()) return CaseFormat.UPPER_CAMEL;

--- a/src/main/java/com/cleanroommc/groovyscript/helper/EnumHelper.java
+++ b/src/main/java/com/cleanroommc/groovyscript/helper/EnumHelper.java
@@ -15,8 +15,7 @@ public class EnumHelper {
     private static final Map<Class<? extends Enum<?>>, IObjectParser<?>> cs = new Object2ObjectOpenHashMap<>();
     private static final Map<Class<? extends Enum<?>>, IObjectParser<?>> ncs = new Object2ObjectOpenHashMap<>();
 
-    @NotNull
-    public static <T extends Enum<T>> Result<T> valueOf(Class<T> clazz, String s, boolean caseSensitive) {
+    public static @NotNull <T extends Enum<T>> Result<T> valueOf(Class<T> clazz, String s, boolean caseSensitive) {
         var map = caseSensitive ? cs : ncs;
         IObjectParser<?> goh = map.get(clazz);
         if (goh == null) {
@@ -26,8 +25,7 @@ public class EnumHelper {
         return (Result<T>) goh.parse(s, EMPTY);
     }
 
-    @Nullable
-    public static <T extends Enum<T>> T valueOfNullable(Class<T> clazz, String s, boolean caseSensitive) {
+    public static @Nullable <T extends Enum<T>> T valueOfNullable(Class<T> clazz, String s, boolean caseSensitive) {
         Result<T> res = valueOf(clazz, s, caseSensitive);
         return res.hasError() ? null : res.getValue();
     }

--- a/src/main/java/com/cleanroommc/groovyscript/helper/SimpleObjectStream.java
+++ b/src/main/java/com/cleanroommc/groovyscript/helper/SimpleObjectStream.java
@@ -59,8 +59,7 @@ public class SimpleObjectStream<T> extends AbstractList<T> {
         return recipe;
     }
 
-    @Nullable
-    public T getFirst() {
+    public @Nullable T getFirst() {
         for (T recipe : this.recipes) {
             if (recipe != null) {
                 return recipe;

--- a/src/main/java/com/cleanroommc/groovyscript/helper/ingredient/IngredientBase.java
+++ b/src/main/java/com/cleanroommc/groovyscript/helper/ingredient/IngredientBase.java
@@ -48,9 +48,8 @@ public abstract class IngredientBase implements IIngredient {
         return ForgeHooks.getContainerItem(matchedInput);
     }
 
-    @Nullable
     @Override
-    public String getMark() {
+    public @Nullable String getMark() {
         return mark;
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/helper/ingredient/IngredientHelper.java
+++ b/src/main/java/com/cleanroommc/groovyscript/helper/ingredient/IngredientHelper.java
@@ -51,8 +51,7 @@ public class IngredientHelper {
         return (IIngredient) fluidStack;
     }
 
-    @NotNull
-    public static NonNullList<IIngredient> toNonNullList(IngredientList<IIngredient> list) {
+    public static @NotNull NonNullList<IIngredient> toNonNullList(IngredientList<IIngredient> list) {
         NonNullList<IIngredient> ingredients = NonNullList.create();
         for (IIngredient i : list) {
             if (i == null) ingredients.add(IIngredient.EMPTY);
@@ -61,8 +60,7 @@ public class IngredientHelper {
         return ingredients;
     }
 
-    @NotNull
-    public static NonNullList<Ingredient> toIngredientNonNullList(Collection<IIngredient> list) {
+    public static @NotNull NonNullList<Ingredient> toIngredientNonNullList(Collection<IIngredient> list) {
         NonNullList<Ingredient> ingredients = NonNullList.create();
         for (IIngredient i : list) {
             if (i == null) ingredients.add(Ingredient.EMPTY);
@@ -185,24 +183,21 @@ public class IngredientHelper {
         return true;
     }
 
-    @NotNull
-    public static Collection<IIngredient> trim(@Nullable Collection<IIngredient> ingredients) {
+    public static @NotNull Collection<IIngredient> trim(@Nullable Collection<IIngredient> ingredients) {
         if (ingredients == null) return Collections.emptyList();
         if (ingredients.isEmpty()) return ingredients;
         ingredients.removeIf(IngredientHelper::isEmpty);
         return ingredients;
     }
 
-    @NotNull
-    public static Collection<ItemStack> trimItems(@Nullable Collection<ItemStack> ingredients) {
+    public static @NotNull Collection<ItemStack> trimItems(@Nullable Collection<ItemStack> ingredients) {
         if (ingredients == null) return Collections.emptyList();
         if (ingredients.isEmpty()) return ingredients;
         ingredients.removeIf(IngredientHelper::isEmpty);
         return ingredients;
     }
 
-    @NotNull
-    public static Collection<FluidStack> trimFluids(@Nullable Collection<FluidStack> ingredients) {
+    public static @NotNull Collection<FluidStack> trimFluids(@Nullable Collection<FluidStack> ingredients) {
         if (ingredients == null) return Collections.emptyList();
         if (ingredients.isEmpty()) return ingredients;
         ingredients.removeIf(IngredientHelper::isEmpty);
@@ -242,8 +237,7 @@ public class IngredientHelper {
     /**
      * Useful when the item can be empty or null, but only want to copy non empty items
      */
-    @NotNull
-    public static ItemStack copy(@Nullable ItemStack item) {
+    public static @NotNull ItemStack copy(@Nullable ItemStack item) {
         return item == null || item == ItemStack.EMPTY ? ItemStack.EMPTY : item.copy();
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/helper/ingredient/ItemsIngredient.java
+++ b/src/main/java/com/cleanroommc/groovyscript/helper/ingredient/ItemsIngredient.java
@@ -78,9 +78,8 @@ public class ItemsIngredient extends IngredientBase implements Iterable<ItemStac
         return Collections.unmodifiableList(this.itemStacks);
     }
 
-    @NotNull
     @Override
-    public Iterator<ItemStack> iterator() {
+    public @NotNull Iterator<ItemStack> iterator() {
         return Iterators.unmodifiableIterator(this.itemStacks.iterator());
     }
 }

--- a/src/main/java/com/cleanroommc/groovyscript/helper/ingredient/NbtHelper.java
+++ b/src/main/java/com/cleanroommc/groovyscript/helper/ingredient/NbtHelper.java
@@ -52,10 +52,10 @@ public class NbtHelper {
         if (o instanceof Map) {
             return ofMap((Map<String, Object>) o);
         }
-        if (o instanceof List) {
+        if (o instanceof List<?>objects) {
             NBTTagList list = new NBTTagList();
             byte type = 0;
-            for (Object lo : (List<?>) o) {
+            for (Object lo : objects) {
                 NBTBase lNbt = toNbt(lo);
                 if (type == 0) {
                     type = lNbt.getId();

--- a/src/main/java/com/cleanroommc/groovyscript/helper/ingredient/OreDictIngredient.java
+++ b/src/main/java/com/cleanroommc/groovyscript/helper/ingredient/OreDictIngredient.java
@@ -126,9 +126,8 @@ public class OreDictIngredient extends IngredientBase implements Iterable<ItemSt
         }
     }
 
-    @NotNull
     @Override
-    public Iterator<ItemStack> iterator() {
+    public @NotNull Iterator<ItemStack> iterator() {
         return Iterators.unmodifiableIterator(prepareItemStacks().listIterator());
     }
 }

--- a/src/main/java/com/cleanroommc/groovyscript/mapper/ObjectMapper.java
+++ b/src/main/java/com/cleanroommc/groovyscript/mapper/ObjectMapper.java
@@ -70,8 +70,7 @@ public class ObjectMapper<T> extends Closure<T> implements INamed, IDocumented {
         this.textureBinder = textureBinder;
     }
 
-    @Nullable
-    public T invoke(boolean silent, String s, Object... args) {
+    public @Nullable T invoke(boolean silent, String s, Object... args) {
         Result<T> t = Objects.requireNonNull(handler.parse(s, args), "Object mapper must return a non null result!");
         if (t.hasError()) {
             if (!silent) {

--- a/src/main/java/com/cleanroommc/groovyscript/mapper/ObjectMapper.java
+++ b/src/main/java/com/cleanroommc/groovyscript/mapper/ObjectMapper.java
@@ -107,6 +107,7 @@ public class ObjectMapper<T> extends Closure<T> implements INamed, IDocumented {
         return Collections.singleton(this.name);
     }
 
+    @Override
     public String getName() {
         return name;
     }

--- a/src/main/java/com/cleanroommc/groovyscript/mapper/ObjectMapper.java
+++ b/src/main/java/com/cleanroommc/groovyscript/mapper/ObjectMapper.java
@@ -180,7 +180,7 @@ public class ObjectMapper<T> extends Closure<T> implements INamed, IDocumented {
         private final List<Class<?>[]> paramTypes = new ArrayList<>();
         private Completer completer;
         private String documentation;
-        private TextureBinder textureBinder;
+        private TextureBinder<T> textureBinder;
 
         @ApiStatus.Internal
         public Builder(String name, Class<T> returnType) {

--- a/src/main/java/com/cleanroommc/groovyscript/mapper/ObjectMapperManager.java
+++ b/src/main/java/com/cleanroommc/groovyscript/mapper/ObjectMapperManager.java
@@ -209,8 +209,7 @@ public class ObjectMapperManager {
      * @param args    extra arguments
      * @return game object or null
      */
-    @Nullable
-    public static Object getGameObject(String name, String mainArg, Object... args) {
+    public static @Nullable Object getGameObject(String name, String mainArg, Object... args) {
         return getGameObject(false, name, mainArg, args);
     }
 
@@ -223,8 +222,7 @@ public class ObjectMapperManager {
      * @param silent if error messages should be logged
      * @return game object or null
      */
-    @Nullable
-    public static Object getGameObject(boolean silent, String name, String mainArg, Object... args) {
+    public static @Nullable Object getGameObject(boolean silent, String name, String mainArg, Object... args) {
         ObjectMapper<?> objectMapper = handlers.get(name);
         if (objectMapper != null) {
             return objectMapper.invokeWithDefault(silent, mainArg, args);

--- a/src/main/java/com/cleanroommc/groovyscript/mapper/ObjectMappers.java
+++ b/src/main/java/com/cleanroommc/groovyscript/mapper/ObjectMappers.java
@@ -51,10 +51,10 @@ public class ObjectMappers {
         }
 
         if (args.length > 0) {
-            if (args.length > 1 || !(args[0] instanceof String)) {
+            if (args.length > 1 || !(args[0] instanceof String s)) {
                 return Result.error("Arguments not valid for object mapper. Use 'resource(String)' or 'resource(String mod, String path)'");
             }
-            return Result.some(new ResourceLocation(mainArg, (String) args[0]));
+            return Result.some(new ResourceLocation(mainArg, s));
         }
         return Result.some(new ResourceLocation(GroovyScript.getRunConfig().getPackId(), mainArg));
     }

--- a/src/main/java/com/cleanroommc/groovyscript/network/NetworkHandler.java
+++ b/src/main/java/com/cleanroommc/groovyscript/network/NetworkHandler.java
@@ -47,7 +47,7 @@ public class NetworkHandler {
         network.sendTo(packet, player);
     }
 
-    final static IMessageHandler<IPacket, IPacket> S2CHandler = (message, ctx) -> {
+    static final IMessageHandler<IPacket, IPacket> S2CHandler = (message, ctx) -> {
         NetHandlerPlayClient handler = ctx.getClientHandler();
         IThreadListener threadListener = FMLCommonHandler.instance().getWorldThread(handler);
         if (threadListener.isCallingFromMinecraftThread()) {
@@ -57,7 +57,7 @@ public class NetworkHandler {
         }
         return null;
     };
-    final static IMessageHandler<IPacket, IPacket> C2SHandler = (message, ctx) -> {
+    static final IMessageHandler<IPacket, IPacket> C2SHandler = (message, ctx) -> {
         NetHandlerPlayServer handler = ctx.getServerHandler();
         IThreadListener threadListener = FMLCommonHandler.instance().getWorldThread(handler);
         if (threadListener.isCallingFromMinecraftThread()) {

--- a/src/main/java/com/cleanroommc/groovyscript/network/NetworkUtils.java
+++ b/src/main/java/com/cleanroommc/groovyscript/network/NetworkUtils.java
@@ -51,8 +51,7 @@ public class NetworkUtils {
         }
     }
 
-    @Nullable
-    public static FluidStack readFluidStack(PacketBuffer buffer) throws IOException {
+    public static @Nullable FluidStack readFluidStack(PacketBuffer buffer) throws IOException {
         if (buffer.readBoolean()) {
             return null;
         }

--- a/src/main/java/com/cleanroommc/groovyscript/packmode/Packmode.java
+++ b/src/main/java/com/cleanroommc/groovyscript/packmode/Packmode.java
@@ -15,8 +15,7 @@ public class Packmode {
 
     private static String packmode;
 
-    @NotNull
-    public static String getPackmode() {
+    public static @NotNull String getPackmode() {
         if (GroovyScript.getRunConfig().isIntegratePackmodeMod()) return PackModeAPI.getInstance().getCurrentPackMode();
         if (hasPackmode()) return Packmode.packmode;
         if (needsPackmode()) {

--- a/src/main/java/com/cleanroommc/groovyscript/registry/AbstractCraftingRecipeBuilder.java
+++ b/src/main/java/com/cleanroommc/groovyscript/registry/AbstractCraftingRecipeBuilder.java
@@ -145,12 +145,11 @@ public abstract class AbstractCraftingRecipeBuilder<R> {
     }
 
     @GroovyBlacklist
-    @Nullable
-    protected <T> T validateShape(GroovyLog.Msg msg,
-                                  List<String> errors,
-                                  String[] keyBasedMatrix,
-                                  Char2ObjectOpenHashMap<IIngredient> keyMap,
-                                  IRecipeCreator<T> recipeCreator) {
+    protected @Nullable <T> T validateShape(GroovyLog.Msg msg,
+                                            List<String> errors,
+                                            String[] keyBasedMatrix,
+                                            Char2ObjectOpenHashMap<IIngredient> keyMap,
+                                            IRecipeCreator<T> recipeCreator) {
         List<IIngredient> ingredients = new ArrayList<>();
         if (keyBasedMatrix.length > height) {
             msg.add("Defined matrix has %d rows, but should only have %d rows", keyBasedMatrix.length, height);
@@ -209,8 +208,7 @@ public abstract class AbstractCraftingRecipeBuilder<R> {
     }
 
     @GroovyBlacklist
-    @Nullable
-    protected <T> T validateShape(GroovyLog.Msg msg, List<List<IIngredient>> ingredientMatrix, IRecipeCreator<T> recipeCreator) {
+    protected @Nullable <T> T validateShape(GroovyLog.Msg msg, List<List<IIngredient>> ingredientMatrix, IRecipeCreator<T> recipeCreator) {
         List<IIngredient> ingredients = new ArrayList<>();
         if (ingredientMatrix.size() > height) {
             msg.add("defined matrix has %d rows, but should only have %d rows", ingredientMatrix.size(), height);

--- a/src/main/java/com/cleanroommc/groovyscript/registry/DummyRecipe.java
+++ b/src/main/java/com/cleanroommc/groovyscript/registry/DummyRecipe.java
@@ -10,13 +10,12 @@ import org.jetbrains.annotations.NotNull;
 public class DummyRecipe extends IForgeRegistryEntry.Impl<IRecipe> implements IRecipe {
 
     @Override
-    public boolean matches(@NotNull final InventoryCrafting inv, @NotNull final World worldIn) {
+    public boolean matches(final @NotNull InventoryCrafting inv, final @NotNull World worldIn) {
         return false;
     }
 
-    @NotNull
     @Override
-    public ItemStack getCraftingResult(@NotNull final InventoryCrafting inv) {
+    public @NotNull ItemStack getCraftingResult(final @NotNull InventoryCrafting inv) {
         return ItemStack.EMPTY;
     }
 
@@ -25,9 +24,8 @@ public class DummyRecipe extends IForgeRegistryEntry.Impl<IRecipe> implements IR
         return false;
     }
 
-    @NotNull
     @Override
-    public ItemStack getRecipeOutput() {
+    public @NotNull ItemStack getRecipeOutput() {
         return ItemStack.EMPTY;
     }
 }

--- a/src/main/java/com/cleanroommc/groovyscript/registry/ReloadableRegistryManager.java
+++ b/src/main/java/com/cleanroommc/groovyscript/registry/ReloadableRegistryManager.java
@@ -153,7 +153,7 @@ public class ReloadableRegistryManager {
             // So, to prevent duplicate categories, we need to clear the List before running.
             if (Loader.isModLoaded("sonarcore")) {
                 jeiProxy.getPlugins().forEach(plugin -> {
-                    if (plugin instanceof JEISonarPlugin) ((JEISonarPlugin) plugin).providers.clear();
+                    if (plugin instanceof JEISonarPlugin jeiSonarPlugin) jeiSonarPlugin.providers.clear();
                 });
             }
 

--- a/src/main/java/com/cleanroommc/groovyscript/registry/VirtualizedForgeRegistryEntry.java
+++ b/src/main/java/com/cleanroommc/groovyscript/registry/VirtualizedForgeRegistryEntry.java
@@ -4,6 +4,7 @@ import net.minecraftforge.registries.IForgeRegistryEntry;
 
 import java.util.Objects;
 
+@SuppressWarnings("ClassCanBeRecord")
 public class VirtualizedForgeRegistryEntry<T extends IForgeRegistryEntry<T>> {
 
     private final T value;

--- a/src/main/java/com/cleanroommc/groovyscript/sandbox/ClosureHelper.java
+++ b/src/main/java/com/cleanroommc/groovyscript/sandbox/ClosureHelper.java
@@ -15,13 +15,11 @@ public class ClosureHelper {
     private static final Object DUMMY = new Object();
     private static Field h;
 
-    @Nullable
-    public static <T> T call(Closure<T> closure, Object... args) {
+    public static @Nullable <T> T call(Closure<T> closure, Object... args) {
         return closure.call(args);
     }
 
-    @Nullable
-    public static <T> T call(Class<T> expectedType, Closure<?> closure, Object... args) {
+    public static @Nullable <T> T call(Class<T> expectedType, Closure<?> closure, Object... args) {
         Object o = call(closure, args);
         if (o != null && expectedType.isAssignableFrom(o.getClass())) {
             return (T) o;
@@ -73,8 +71,7 @@ public class ClosureHelper {
      * @return the underlying closure or null if there is no closure
      */
     @GroovyBlacklist
-    @Nullable
-    public static Closure<?> getUnderlyingClosure(Object functionalInterface) {
+    public static @Nullable Closure<?> getUnderlyingClosure(Object functionalInterface) {
         if (!(functionalInterface instanceof Proxy)) return null; // not a closure
         if (h == null) {
             try {

--- a/src/main/java/com/cleanroommc/groovyscript/sandbox/CompiledScript.java
+++ b/src/main/java/com/cleanroommc/groovyscript/sandbox/CompiledScript.java
@@ -55,8 +55,7 @@ class CompiledScript extends CompiledClass {
         super.ensureLoaded(classLoader, basePath);
     }
 
-    @NotNull
-    public JsonObject toJson() {
+    public @NotNull JsonObject toJson() {
         JsonObject jsonEntry = new JsonObject();
         jsonEntry.addProperty("name", this.name);
         jsonEntry.addProperty("path", this.path);

--- a/src/main/java/com/cleanroommc/groovyscript/sandbox/FileUtil.java
+++ b/src/main/java/com/cleanroommc/groovyscript/sandbox/FileUtil.java
@@ -47,15 +47,13 @@ public class FileUtil {
         }
     }
 
-    @NotNull
-    public static String relativize(String rootPath, String longerThanRootPath) {
+    public static @NotNull String relativize(String rootPath, String longerThanRootPath) {
         longerThanRootPath = encodeURI(fixPath(decodeURI(longerThanRootPath)));
         rootPath = encodeURI(rootPath);
         return relativizeInternal(rootPath, longerThanRootPath, false);
     }
 
-    @Nullable
-    public static String relativizeNullable(String rootPath, String longerThanRootPath) {
+    public static @Nullable String relativizeNullable(String rootPath, String longerThanRootPath) {
         longerThanRootPath = encodeURI(fixPath(decodeURI(longerThanRootPath)));
         rootPath = encodeURI(rootPath);
         return relativizeInternal(rootPath, longerThanRootPath, true);

--- a/src/main/java/com/cleanroommc/groovyscript/sandbox/GroovyLogImpl.java
+++ b/src/main/java/com/cleanroommc/groovyscript/sandbox/GroovyLogImpl.java
@@ -329,8 +329,7 @@ public class GroovyLogImpl implements GroovyLog {
         private final List<String> messages = new ArrayList<>();
         private Level level = Level.INFO;
         private boolean logToMcLog;
-        @Nullable
-        private Throwable throwable;
+        private @Nullable Throwable throwable;
 
         private MsgImpl(String msg, Object... data) {
             this.mainMsg = GroovyLog.format(msg, data);

--- a/src/main/java/com/cleanroommc/groovyscript/sandbox/GroovySandbox.java
+++ b/src/main/java/com/cleanroommc/groovyscript/sandbox/GroovySandbox.java
@@ -265,8 +265,7 @@ public abstract class GroovySandbox {
         return scriptClass;
     }
 
-    @Nullable
-    private Class<?> tryLoadDynamicFile(GroovyScriptEngine engine, File file) throws ResourceException {
+    private @Nullable Class<?> tryLoadDynamicFile(GroovyScriptEngine engine, File file) throws ResourceException {
         Path path = null;
         for (URL root : this.scriptEnvironment) {
             try {

--- a/src/main/java/com/cleanroommc/groovyscript/sandbox/GroovyScriptSandbox.java
+++ b/src/main/java/com/cleanroommc/groovyscript/sandbox/GroovyScriptSandbox.java
@@ -54,7 +54,7 @@ public class GroovyScriptSandbox extends GroovySandbox {
      * Setting this to true will cause the cache to be deleted before each script run.
      * Useful for debugging.
      */
-    public static final boolean DELETE_CACHE_ON_RUN = Boolean.parseBoolean(System.getProperty("groovyscript.disable_cache"));;
+    public static final boolean DELETE_CACHE_ON_RUN = Boolean.parseBoolean(System.getProperty("groovyscript.disable_cache"));
 
     private final File cacheRoot;
     private final File scriptRoot;

--- a/src/main/java/com/cleanroommc/groovyscript/sandbox/GroovyScriptSandbox.java
+++ b/src/main/java/com/cleanroommc/groovyscript/sandbox/GroovyScriptSandbox.java
@@ -370,8 +370,7 @@ public class GroovyScriptSandbox extends GroovySandbox {
         return GroovyScript.getRunConfig().getSortedFiles(this.scriptRoot, this.currentLoadStage.getName());
     }
 
-    @Nullable
-    public LoadStage getCurrentLoader() {
+    public @Nullable LoadStage getCurrentLoader() {
         return currentLoadStage;
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/sandbox/SandboxData.java
+++ b/src/main/java/com/cleanroommc/groovyscript/sandbox/SandboxData.java
@@ -74,49 +74,41 @@ public class SandboxData {
         initialised = true;
     }
 
-    @NotNull
-    public static String getScriptPath() {
+    public static @NotNull String getScriptPath() {
         return getScriptFile().getPath();
     }
 
-    @NotNull
-    public static File getMinecraftHome() {
+    public static @NotNull File getMinecraftHome() {
         ensureLoaded();
         return minecraftHome;
     }
 
-    @NotNull
-    public static File getScriptFile() {
+    public static @NotNull File getScriptFile() {
         ensureLoaded();
         return scriptPath;
     }
 
-    @NotNull
-    public static File getResourcesFile() {
+    public static @NotNull File getResourcesFile() {
         ensureLoaded();
         return resourcesFile;
     }
 
-    @NotNull
-    public static File getRunConfigFile() {
+    public static @NotNull File getRunConfigFile() {
         ensureLoaded();
         return runConfigFile;
     }
 
-    @NotNull
-    public static File getCachePath() {
+    public static @NotNull File getCachePath() {
         ensureLoaded();
         return cachePath;
     }
 
-    @NotNull
-    public static URL getRootUrl() {
+    public static @NotNull URL getRootUrl() {
         ensureLoaded();
         return rootUrl;
     }
 
-    @NotNull
-    public static URL[] getRootUrls() {
+    public static @NotNull URL[] getRootUrls() {
         ensureLoaded();
         return rootUrls;
     }

--- a/src/main/java/com/cleanroommc/groovyscript/sandbox/expand/ExpansionHelper.java
+++ b/src/main/java/com/cleanroommc/groovyscript/sandbox/expand/ExpansionHelper.java
@@ -74,15 +74,15 @@ public class ExpansionHelper {
     private static boolean isValidProperty(MetaProperty prop) {
         if (prop instanceof MetaBeanProperty beanProperty) {
             if (!isValid(beanProperty.getField())) return false;
-            if (!(beanProperty.getGetter() instanceof CachedMethod) || isValid((CachedMethod) beanProperty.getGetter()))
+            if (!(beanProperty.getGetter() instanceof CachedMethod method) || isValid(method))
                 return false;
-            return beanProperty.getSetter() instanceof CachedMethod && !isValid((CachedMethod) beanProperty.getSetter());
+            return beanProperty.getSetter() instanceof CachedMethod cachedMethod && !isValid(cachedMethod);
         }
-        if (prop instanceof MethodMetaProperty && ((MethodMetaProperty) prop).getMetaMethod() instanceof CachedMethod) {
+        if (prop instanceof MethodMetaProperty methodMetaProperty && methodMetaProperty.getMetaMethod() instanceof CachedMethod) {
             return isValid((CachedMethod) ((MethodMetaProperty) prop).getMetaMethod());
         }
-        if (prop instanceof CachedField) {
-            return isValid((CachedField) prop);
+        if (prop instanceof CachedField cachedField) {
+            return isValid(cachedField);
         }
         return false;
     }
@@ -104,8 +104,8 @@ public class ExpansionHelper {
         MetaClass other = GroovySystem.getMetaClassRegistry().getMetaClass(clazz);
         mixinProperties(emc, other, mixin);
         for (MetaMethod method : other.getMethods()) {
-            if (method instanceof CachedMethod && clazz == ((CachedMethod) method).getCachedMethod().getDeclaringClass()) {
-                mixinMethod(emc, (CachedMethod) method, mixin);
+            if (method instanceof CachedMethod cachedMethod && clazz == cachedMethod.getCachedMethod().getDeclaringClass()) {
+                mixinMethod(emc, cachedMethod, mixin);
             }
         }
     }

--- a/src/main/java/com/cleanroommc/groovyscript/sandbox/mapper/GroovyDeobfMapper.java
+++ b/src/main/java/com/cleanroommc/groovyscript/sandbox/mapper/GroovyDeobfMapper.java
@@ -95,13 +95,11 @@ public class GroovyDeobfMapper {
         }
     }
 
-    @Nullable
-    public static String getDeobfMethod(Class<?> clazz, String obfMethod) {
+    public static @Nullable String getDeobfMethod(Class<?> clazz, String obfMethod) {
         return DEOBF_METHODS.getOrDefault(clazz.getName(), Object2ObjectMaps.emptyMap()).get(obfMethod);
     }
 
-    @Nullable
-    public static String getDeobfField(Class<?> clazz, String obfField) {
+    public static @Nullable String getDeobfField(Class<?> clazz, String obfField) {
         return DEOBF_FIELDS.getOrDefault(clazz.getName(), Object2ObjectMaps.emptyMap()).get(obfField);
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/sandbox/transformer/AsmDecompileHelper.java
+++ b/src/main/java/com/cleanroommc/groovyscript/sandbox/transformer/AsmDecompileHelper.java
@@ -77,8 +77,8 @@ public class AsmDecompileHelper {
                         Object key = ann.values.get(x);
                         Object value = ann.values.get(x + 1);
                         if (key instanceof String && key.equals("value")) {
-                            if (value instanceof String[]) {
-                                if (!((String[]) value)[1].equals(side)) {
+                            if (value instanceof String[]strings) {
+                                if (!strings[1].equals(side)) {
                                     return true;
                                 }
                             }

--- a/src/main/java/net/prominic/groovyls/GroovyLanguageServer.java
+++ b/src/main/java/net/prominic/groovyls/GroovyLanguageServer.java
@@ -40,8 +40,7 @@ public class GroovyLanguageServer<T extends GroovyServices> implements LanguageS
         this.groovyServices = createGroovyServices(compilationUnitFactory, languageServerContext);
     }
 
-    @NotNull
-    protected T createGroovyServices(ICompilationUnitFactory compilationUnitFactory, ILanguageServerContext languageServerContext) {
+    protected @NotNull T createGroovyServices(ICompilationUnitFactory compilationUnitFactory, ILanguageServerContext languageServerContext) {
         return (T) new GroovyServices(compilationUnitFactory, languageServerContext);
     }
 

--- a/src/main/java/net/prominic/groovyls/GroovyServices.java
+++ b/src/main/java/net/prominic/groovyls/GroovyServices.java
@@ -349,8 +349,7 @@ public class GroovyServices implements TextDocumentService, WorkspaceService, La
         return provider.provideRename(params);
     }
 
-    @Nullable
-    protected ASTNodeVisitor compileAndVisitAST(GroovyLSCompilationUnit compilationUnit, URI context) {
+    protected @Nullable ASTNodeVisitor compileAndVisitAST(GroovyLSCompilationUnit compilationUnit, URI context) {
         if (!isInGroovyWorkspace(context)) {
             return null;
         }

--- a/src/main/java/net/prominic/groovyls/compiler/control/GroovyLSCompilationUnit.java
+++ b/src/main/java/net/prominic/groovyls/compiler/control/GroovyLSCompilationUnit.java
@@ -39,11 +39,9 @@ import java.util.stream.Collectors;
 public class GroovyLSCompilationUnit extends CompilationUnit {
 
     private final ILanguageServerContext languageServerContext;
-    @Nullable
-    private ASTNodeVisitor visitor;
+    private @Nullable ASTNodeVisitor visitor;
 
-    @Nullable
-    private URI previousContext;
+    private @Nullable URI previousContext;
 
     public GroovyLSCompilationUnit(
             CompilerConfiguration config,

--- a/src/main/java/net/prominic/groovyls/compiler/util/GroovyASTUtils.java
+++ b/src/main/java/net/prominic/groovyls/compiler/util/GroovyASTUtils.java
@@ -524,8 +524,7 @@ public class GroovyASTUtils {
         }
     }
 
-    @NotNull
-    private static PropertyNode makeProperty(ClassNode classNode, FieldNode field, int m) {
+    private static @NotNull PropertyNode makeProperty(ClassNode classNode, FieldNode field, int m) {
         PropertyNode property = new PropertyNode(field, m, null, null);
         property.setDeclaringClass(classNode);
         // remove any previous set fields and properties with the same name

--- a/src/main/java/net/prominic/groovyls/compiler/util/GroovyReflectionUtils.java
+++ b/src/main/java/net/prominic/groovyls/compiler/util/GroovyReflectionUtils.java
@@ -11,8 +11,7 @@ import java.util.function.Function;
 
 public class GroovyReflectionUtils {
 
-    @Nullable
-    public static Method resolveMethodFromMethodNode(MethodNode methodNode, ASTContext context) {
+    public static @Nullable Method resolveMethodFromMethodNode(MethodNode methodNode, ASTContext context) {
         for (Method m : methodNode.getDeclaringClass().getTypeClass().getMethods()) {
             if (!GroovySecurityManager.INSTANCE.isValid(m) || !methodNode.getName().equals(m.getName()) || methodNode.getParameters().length != m.getParameterCount()) {
                 continue;
@@ -24,8 +23,7 @@ public class GroovyReflectionUtils {
         return null;
     }
 
-    @Nullable
-    public static Method resolveMethodFromMethodInfo(MethodInfo methodInfo, ASTContext context) {
+    public static @Nullable Method resolveMethodFromMethodInfo(MethodInfo methodInfo, ASTContext context) {
         for (Method m : methodInfo.getClassInfo().loadClass().getMethods()) {
             if (!GroovySecurityManager.INSTANCE.isValid(m) || !methodInfo.getName().equals(m.getName()) || methodInfo.getParameterInfo().length != m.getParameterCount()) {
                 continue;

--- a/src/main/java/net/prominic/groovyls/providers/CompletionProvider.java
+++ b/src/main/java/net/prominic/groovyls/providers/CompletionProvider.java
@@ -448,15 +448,13 @@ public class CompletionProvider extends DocProvider {
         return builder;
     }
 
-    @NotNull
-    private static CompletionItemLabelDetails getMethodNodeDetails(MethodNode method) {
+    private static @NotNull CompletionItemLabelDetails getMethodNodeDetails(MethodNode method) {
         var details = new CompletionItemLabelDetails();
         details.setDetail(getDescriptor(method, false, true, true));
         return details;
     }
 
-    @NotNull
-    private static CompletionItemLabelDetails getMethodInfoDetails(MethodInfo methodInfo) {
+    private static @NotNull CompletionItemLabelDetails getMethodInfoDetails(MethodInfo methodInfo) {
         var details = new CompletionItemLabelDetails();
         details.setDetail(getDescriptor(methodInfo, false, true, true));
         return details;


### PR DESCRIPTION
changes in this PR:
- make a significant number of places use a pattern variable.
- fix `accessoryType` validation null check promptly throwing a NPE.
- sort modifiers so that `@NotNull` and `@Nullable` are just before the return type instead of on the line prior.
- add `@Override` annotations to methods missing them.
- replace `"".equals(String)` with `String#isEmpty()`.
- use the canonical forms of floats (`1.0f` instead of `1f`).
- fix a `ObjectMapper.Builder` having a field with the type `TextureBinder` instead of `TextureBinder<T>` when the only way to set it is via calling the method `textureBinder(TextureBinder<T>)`.
- add a `@NotNull` annotation to the parameter of a method in the `JeiPlugin`.
- suppress `ClassCanBeRecord` warnings, as we have decided not to use those.
- suppress `unchecked` warnings for cases in which the entity class in a RecipeBuilder/removal.

basically all of these are just inspection stuff, with the exception of the fixing an NPE when validating `accessoryType`.