### PR TITLE
Fix EnderIO Inventory Panel Crafting Crash

### DIFF
--- a/src/main/java/com/cleanroommc/groovyscript/event/EventHandler.java
+++ b/src/main/java/com/cleanroommc/groovyscript/event/EventHandler.java
@@ -127,8 +127,8 @@ public class EventHandler {
             Container container = ((InventoryCraftingAccess) inventoryCrafting).getEventHandler();
             if (container != null) {
                 for (Slot slot : container.inventorySlots) {
-                    if (slot instanceof SlotCrafting) {
-                        craftResult = (InventoryCraftResult) slot.inventory;
+                    if (slot instanceof SlotCrafting && slot.inventory instanceof InventoryCraftResult result) {
+                        craftResult = result;
                         player = ((SlotCraftingAccess) slot).getPlayer();
                         break;
                     }


### PR DESCRIPTION
changes in this PR:
- check that the inventory is an instanceof `InventoryCraftResult` before casting to it.

this resolves https://github.com/FTBTeam/FTB-Modpack-Issues/issues/6310