### PR TITLE
Mod Object Mapper and Ingredient

### DIFF
--- a/src/main/java/com/cleanroommc/groovyscript/helper/ingredient/ModItemsIngredient.java
+++ b/src/main/java/com/cleanroommc/groovyscript/helper/ingredient/ModItemsIngredient.java
@@ -1,0 +1,56 @@
+package com.cleanroommc.groovyscript.helper.ingredient;
+
+import com.cleanroommc.groovyscript.api.IIngredient;
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.NonNullList;
+import net.minecraftforge.fml.common.ModContainer;
+import net.minecraftforge.fml.common.registry.ForgeRegistries;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ModItemsIngredient extends ItemsIngredient {
+
+    private static final Map<String, List<ItemStack>> CACHE = new HashMap<>();
+
+    private final String modName;
+
+    public ModItemsIngredient(String modName, List<ItemStack> itemStacks) {
+        super(itemStacks);
+        this.modName = modName;
+    }
+
+    public static ModItemsIngredient of(ModContainer mod) {
+        return of(mod.getModId());
+    }
+
+    public static ModItemsIngredient of(String modId) {
+        return new ModItemsIngredient(modId, new ArrayList<>(CACHE.computeIfAbsent(modId, ModItemsIngredient::itemStacksFromLocation)));
+    }
+
+    private static List<ItemStack> itemStacksFromLocation(String namespace) {
+        NonNullList<ItemStack> stacks = NonNullList.create();
+        ForgeRegistries.ITEMS.getEntries()
+                .stream()
+                .filter(entry -> entry.getValue() != null)
+                .filter(entry -> namespace.equals(entry.getKey().getNamespace()))
+                .forEach(entry -> entry.getValue().getSubItems(CreativeTabs.SEARCH, stacks));
+        return stacks;
+    }
+
+    public String getModName() {
+        return modName;
+    }
+
+    @Override
+    public IIngredient exactCopy() {
+        var mii = new ModItemsIngredient(this.modName, getItemStacks());
+        mii.setAmount(getAmount());
+        mii.transformer = transformer;
+        mii.matchCondition = matchCondition;
+        return mii;
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/helper/ingredient/ModItemsIngredient.java
+++ b/src/main/java/com/cleanroommc/groovyscript/helper/ingredient/ModItemsIngredient.java
@@ -28,7 +28,7 @@ public class ModItemsIngredient extends ItemsIngredient {
     }
 
     public static ModItemsIngredient of(String modId) {
-        return new ModItemsIngredient(modId, new ArrayList<>(CACHE.computeIfAbsent(modId, ModItemsIngredient::itemStacksFromLocation)));
+        return new ModItemsIngredient(modId, CACHE.computeIfAbsent(modId, ModItemsIngredient::itemStacksFromLocation));
     }
 
     private static List<ItemStack> itemStacksFromLocation(String namespace) {
@@ -38,7 +38,7 @@ public class ModItemsIngredient extends ItemsIngredient {
                 .filter(entry -> entry.getValue() != null)
                 .filter(entry -> namespace.equals(entry.getKey().getNamespace()))
                 .forEach(entry -> entry.getValue().getSubItems(CreativeTabs.SEARCH, stacks));
-        return stacks;
+        return new ArrayList<>(stacks);
     }
 
     public String getModName() {

--- a/src/main/java/com/cleanroommc/groovyscript/helper/ingredient/ModItemsIngredient.java
+++ b/src/main/java/com/cleanroommc/groovyscript/helper/ingredient/ModItemsIngredient.java
@@ -1,6 +1,7 @@
 package com.cleanroommc.groovyscript.helper.ingredient;
 
 import com.cleanroommc.groovyscript.api.IIngredient;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.NonNullList;
@@ -8,13 +9,12 @@ import net.minecraftforge.fml.common.ModContainer;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public class ModItemsIngredient extends ItemsIngredient {
 
-    private static final Map<String, List<ItemStack>> CACHE = new HashMap<>();
+    private static final Map<String, List<ItemStack>> CACHE = new Object2ObjectOpenHashMap<>();
 
     private final String modName;
 

--- a/src/main/java/com/cleanroommc/groovyscript/mapper/ObjectMapperManager.java
+++ b/src/main/java/com/cleanroommc/groovyscript/mapper/ObjectMapperManager.java
@@ -32,6 +32,7 @@ import net.minecraft.world.DimensionType;
 import net.minecraft.world.biome.Biome;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fml.common.ModContainer;
 import net.minecraftforge.fml.common.registry.EntityEntry;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
 import net.minecraftforge.fml.common.registry.VillagerRegistry;
@@ -198,6 +199,10 @@ public class ObjectMapperManager {
                 .parser(ObjectMappers::parseNBT)
                 .defaultValue(NBTTagCompound::new)
                 .docOfType("nbt tag")
+                .register();
+        ObjectMapper.builder("mod", ModContainer.class)
+                .parser(ObjectMappers::parseMod)
+                .docOfType("mod")
                 .register();
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/mapper/ObjectMappers.java
+++ b/src/main/java/com/cleanroommc/groovyscript/mapper/ObjectMappers.java
@@ -22,6 +22,8 @@ import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fml.common.Loader;
+import net.minecraftforge.fml.common.ModContainer;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
 import net.minecraftforge.fml.common.registry.VillagerRegistry;
 import org.jetbrains.annotations.NotNull;
@@ -227,5 +229,11 @@ public class ObjectMappers {
         } catch (NBTException e) {
             return Result.error("unable to parse provided nbt string");
         }
+    }
+
+    public static @NotNull Result<ModContainer> parseMod(String mainArg, Object... args) {
+        ModContainer mod = Loader.instance().getIndexedModList().get(mainArg);
+        if (mod == null) return Result.error("unable to identify mod with the name", mainArg);
+        return Result.some(mod);
     }
 }


### PR DESCRIPTION
changes in this PR:
- add a mod Object Mapper. returns `ModContainer`.
- add `ModItemsIngredient` to get all ItemStacks associated with a given mod.
  - added cache functionality in there. not totally sure if its needed?