### PR TITLE
add Silent's Gems compat

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -101,6 +101,8 @@ final def mod_dependencies = [
         'prodigytech-297414:2769520'                          : [project.debug_prodigytech],
         'roots-246183:3905074'                                : [project.debug_roots],
         'rustic-256141:3107974'                               : [project.debug_rustic],
+        'silents-gems-220311:2804966'                         : [project.debug_silents_gems],
+        'silents-lib-242998:2851111'                          : [project.debug_silents_gems],
         'reborncore-237903:3330308'                           : [project.debug_tech_reborn],
         'techreborn-233564:2966851'                           : [project.debug_tech_reborn],
         'thaumcraft-223628:2629023'                           : [project.debug_thaum],

--- a/examples/postInit/silentgems.groovy
+++ b/examples/postInit/silentgems.groovy
@@ -1,0 +1,29 @@
+
+// Auto generated groovyscript example file
+// MODS_LOADED: silentgems
+
+log.info 'mod \'silentgems\' detected, running script'
+
+// Chaos Altar:
+// Converts an input item into an output itemstack with an optional catalyst, consuming a specified amount of Chaos from a
+// Chaos Altar. Chaos is consumed at a maximum of 400 per tick, meaning the time taken corresponds to the Chaos cost.
+
+mods.silentgems.chaos_altar.removeByCatalyst(item('minecraft:slime_ball'))
+mods.silentgems.chaos_altar.removeByInput(item('silentgems:gem'))
+mods.silentgems.chaos_altar.removeByOutput(item('silentgems:craftingmaterial'))
+// mods.silentgems.chaos_altar.removeAll()
+
+mods.silentgems.chaos_altar.recipeBuilder()
+    .input(item('minecraft:clay'))
+    .output(item('minecraft:diamond'))
+    .cost(5)
+    .register()
+
+mods.silentgems.chaos_altar.recipeBuilder()
+    .input(item('minecraft:gold_ingot'))
+    .output(item('minecraft:clay'))
+    .catalyst(item('minecraft:diamond'))
+    .cost(5000)
+    .register()
+
+

--- a/examples/postInit/silentgems.groovy
+++ b/examples/postInit/silentgems.groovy
@@ -5,8 +5,9 @@
 log.info 'mod \'silentgems\' detected, running script'
 
 // Chaos Altar:
-// Converts an input item into an output itemstack with an optional catalyst, consuming a specified amount of Chaos from a
-// Chaos Altar. Chaos is consumed at a maximum of 400 per tick, meaning the time taken corresponds to the Chaos cost.
+// Converts an input itemstack into an output itemstack with an optional catalyst, consuming a specified amount of Chaos
+// from a Chaos Altar. Chaos is consumed at a maximum of 400 per tick, meaning the time taken corresponds to the Chaos
+// cost.
 
 mods.silentgems.chaos_altar.removeByCatalyst(item('minecraft:slime_ball'))
 mods.silentgems.chaos_altar.removeByInput(item('silentgems:gem'))
@@ -20,7 +21,7 @@ mods.silentgems.chaos_altar.recipeBuilder()
     .register()
 
 mods.silentgems.chaos_altar.recipeBuilder()
-    .input(item('minecraft:gold_ingot'))
+    .input(item('minecraft:gold_ingot') * 2)
     .output(item('minecraft:clay'))
     .catalyst(item('minecraft:diamond'))
     .cost(5000)

--- a/gradle.properties
+++ b/gradle.properties
@@ -79,6 +79,8 @@ debug_random_things = false
 debug_roots = false
 debug_rustic = false
 
+debug_silents_gems = false
+
 debug_tech_reborn = false
 debug_thaum = false
 debug_thermal = false

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ModSupport.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ModSupport.java
@@ -54,6 +54,7 @@ import com.cleanroommc.groovyscript.compat.mods.pyrotech.PyroTech;
 import com.cleanroommc.groovyscript.compat.mods.randomthings.RandomThings;
 import com.cleanroommc.groovyscript.compat.mods.roots.Roots;
 import com.cleanroommc.groovyscript.compat.mods.rustic.Rustic;
+import com.cleanroommc.groovyscript.compat.mods.silentsgems.SilentGems;
 import com.cleanroommc.groovyscript.compat.mods.tcomplement.TinkersComplement;
 import com.cleanroommc.groovyscript.compat.mods.techreborn.TechReborn;
 import com.cleanroommc.groovyscript.compat.mods.thaumcraft.Thaumcraft;
@@ -132,6 +133,7 @@ public class ModSupport {
     public static final GroovyContainer<RandomThings> RANDOM_THINGS = new InternalModContainer<>("randomthings", "Random Things", RandomThings::new);
     public static final GroovyContainer<Roots> ROOTS = new InternalModContainer<>("roots", "Roots 3", Roots::new);
     public static final GroovyContainer<Rustic> RUSTIC = new InternalModContainer<>("rustic", "Rustic", Rustic::new);
+    public static final GroovyContainer<SilentGems> SILENT_GEMS = new InternalModContainer<>("silentgems", "Silent's Gems", SilentGems::new);
     public static final GroovyContainer<TechReborn> TECH_REBORN = new InternalModContainer<>("techreborn", "Tech Reborn", TechReborn::new);
     public static final GroovyContainer<Thaumcraft> THAUMCRAFT = new InternalModContainer<>("thaumcraft", "Thaumcraft", Thaumcraft::new, "tc", "thaum");
     public static final GroovyContainer<TheAurorian> THE_AURORIAN = new InternalModContainer<>("theaurorian", "The Aurorian", TheAurorian::new, "aurorian");

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/silentsgems/ChaosAltar.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/silentsgems/ChaosAltar.java
@@ -17,7 +17,7 @@ public class ChaosAltar extends StandardListRegistry<RecipeChaosAltar> {
 
     @RecipeBuilderDescription(example = {
             @Example(".input(item('minecraft:clay')).output(item('minecraft:diamond')).cost(5)"),
-            @Example(".input(item('minecraft:gold_ingot')).output(item('minecraft:clay')).catalyst(item('minecraft:diamond')).cost(5000)")
+            @Example(".input(item('minecraft:gold_ingot') * 2).output(item('minecraft:clay')).catalyst(item('minecraft:diamond')).cost(5000)")
     })
     public static RecipeBuilder recipeBuilder() {
         return new RecipeBuilder();
@@ -67,11 +67,6 @@ public class ChaosAltar extends StandardListRegistry<RecipeChaosAltar> {
         @Override
         public String getErrorMsg() {
             return "Error adding Silents Gems Chaos Altar recipe";
-        }
-
-        @Override
-        protected int getMaxItemInput() {
-            return 1;
         }
 
         @Override

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/silentsgems/ChaosAltar.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/silentsgems/ChaosAltar.java
@@ -1,0 +1,97 @@
+package com.cleanroommc.groovyscript.compat.mods.silentsgems;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import com.cleanroommc.groovyscript.registry.StandardListRegistry;
+import net.minecraft.item.ItemStack;
+import net.silentchaos512.gems.api.recipe.altar.RecipeChaosAltar;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+
+@RegistryDescription(admonition = @Admonition(value = "groovyscript.wiki.silentgems.chaos_altar.note0", type = Admonition.Type.WARNING))
+public class ChaosAltar extends StandardListRegistry<RecipeChaosAltar> {
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:clay')).output(item('minecraft:diamond')).cost(5)"),
+            @Example(".input(item('minecraft:gold_ingot')).output(item('minecraft:clay')).catalyst(item('minecraft:diamond')).cost(5000)")
+    })
+    public static RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @Override
+    public Collection<RecipeChaosAltar> getRecipes() {
+        return RecipeChaosAltar.ALL_RECIPES;
+    }
+
+    @MethodDescription(example = @Example("item('silentgems:gem')"))
+    public boolean removeByInput(IIngredient input) {
+        return getRecipes().removeIf(r -> input.test(r.getInput()) && doAddBackup(r));
+    }
+
+    @MethodDescription(example = @Example("item('minecraft:slime_ball')"))
+    public boolean removeByCatalyst(IIngredient catalyst) {
+        return getRecipes().removeIf(r -> catalyst.test(r.getCatalyst()) && doAddBackup(r));
+    }
+
+    @MethodDescription(example = @Example("item('silentgems:craftingmaterial')"))
+    public boolean removeByOutput(IIngredient output) {
+        return getRecipes().removeIf(r -> output.test(r.getOutput()) && doAddBackup(r));
+    }
+
+    @Property(property = "input", comp = @Comp(eq = 1))
+    @Property(property = "output", comp = @Comp(eq = 1))
+    public static class RecipeBuilder extends AbstractRecipeBuilder<RecipeChaosAltar> {
+
+        @Property(defaultValue = "ItemStack.EMPTY", comp = @Comp(not = "null"))
+        private ItemStack catalyst = ItemStack.EMPTY;
+        @Property(comp = @Comp(gt = 0))
+        private int cost;
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder catalyst(ItemStack catalyst) {
+            this.catalyst = catalyst;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder cost(int cost) {
+            this.cost = cost;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Silents Gems Chaos Altar recipe";
+        }
+
+        @Override
+        protected int getMaxItemInput() {
+            return 1;
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 1, 1, 1, 1);
+            validateFluids(msg);
+            msg.add(catalyst == null, "catalyst must be defined");
+            msg.add(cost <= 0, "cost must be greater than 0, yet it was {}", cost);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable RecipeChaosAltar register() {
+            if (!validate()) return null;
+            RecipeChaosAltar recipe = null;
+            for (var stack : input.get(0).getMatchingStacks()) {
+                recipe = new RecipeChaosAltar(output.get(0), stack, cost, catalyst);
+                ModSupport.SILENT_GEMS.get().chaosAltar.add(recipe);
+            }
+            return recipe;
+        }
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/silentsgems/SilentGems.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/silentsgems/SilentGems.java
@@ -5,5 +5,4 @@ import com.cleanroommc.groovyscript.compat.mods.GroovyPropertyContainer;
 public class SilentGems extends GroovyPropertyContainer {
 
     public final ChaosAltar chaosAltar = new ChaosAltar();
-
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/silentsgems/SilentGems.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/silentsgems/SilentGems.java
@@ -1,0 +1,9 @@
+package com.cleanroommc.groovyscript.compat.mods.silentsgems;
+
+import com.cleanroommc.groovyscript.compat.mods.GroovyPropertyContainer;
+
+public class SilentGems extends GroovyPropertyContainer {
+
+    public final ChaosAltar chaosAltar = new ChaosAltar();
+
+}

--- a/src/main/resources/assets/groovyscript/lang/en_us.lang
+++ b/src/main/resources/assets/groovyscript/lang/en_us.lang
@@ -2100,6 +2100,14 @@ groovyscript.wiki.rustic.evaporating_basin.description=Converts fluids into item
 groovyscript.wiki.rustic.evaporating_basin.time.value=Sets the time in ticks the recipe will take
 
 
+# Silent's Gems
+groovyscript.wiki.silentgems.chaos_altar.title=Chaos Altar
+groovyscript.wiki.silentgems.chaos_altar.description=Converts an input item into an output itemstack with an optional catalyst, consuming a specified amount of Chaos from a Chaos Altar. Chaos is consumed at a maximum of 400 per tick, meaning the time taken corresponds to the Chaos cost.
+groovyscript.wiki.silentgems.chaos_altar.note0=If no catalyst is required by the recipe, the Chaos Altar must have no item in the catalyst slot to be valid.
+groovyscript.wiki.silentgems.chaos_altar.cost.value=Sets the total amount of Chaos required
+groovyscript.wiki.silentgems.chaos_altar.catalyst.value=Sets the catalyst itemstack
+
+
 # Tech Reborn
 groovyscript.wiki.techreborn.alloy_smelter.title=Alloy Smelter
 groovyscript.wiki.techreborn.alloy_smelter.description=Converts two itemstack inputs into an itemstack output after a given process time, consuming energy per tick.

--- a/src/main/resources/assets/groovyscript/lang/en_us.lang
+++ b/src/main/resources/assets/groovyscript/lang/en_us.lang
@@ -2102,7 +2102,7 @@ groovyscript.wiki.rustic.evaporating_basin.time.value=Sets the time in ticks the
 
 # Silent's Gems
 groovyscript.wiki.silentgems.chaos_altar.title=Chaos Altar
-groovyscript.wiki.silentgems.chaos_altar.description=Converts an input item into an output itemstack with an optional catalyst, consuming a specified amount of Chaos from a Chaos Altar. Chaos is consumed at a maximum of 400 per tick, meaning the time taken corresponds to the Chaos cost.
+groovyscript.wiki.silentgems.chaos_altar.description=Converts an input itemstack into an output itemstack with an optional catalyst, consuming a specified amount of Chaos from a Chaos Altar. Chaos is consumed at a maximum of 400 per tick, meaning the time taken corresponds to the Chaos cost.
 groovyscript.wiki.silentgems.chaos_altar.note0=If no catalyst is required by the recipe, the Chaos Altar must have no item in the catalyst slot to be valid.
 groovyscript.wiki.silentgems.chaos_altar.cost.value=Sets the total amount of Chaos required
 groovyscript.wiki.silentgems.chaos_altar.catalyst.value=Sets the catalyst itemstack


### PR DESCRIPTION
changes in this PR:
- adds compat with Silent's Gems `chaosAltar`. examples and i18n for that.
- does **_not_** add anything else for any other feature of Silent's Gems. 