### PR TITLE
add Arcane World compat

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -39,6 +39,8 @@ final def mod_dependencies = [
         'arcane-archives-311357:3057332'                      : [project.debug_arcane_archives],
         'guidebook-253874:2989594'                            : [project.debug_arcane_archives],
         'mystical_lib-277064:3483816'                         : [project.debug_arcane_archives, project.debug_roots],
+        'lemonlib-306926:2639879'                             : [project.debug_arcane_world],
+        'arcane-world-302852:2972860'                         : [project.debug_arcane_world],
         'astralsorcery-sorcery-241721:3044416'                : [project.debug_astral],
         'baubles-227083:2518667'                              : [project.debug_astral, project.debug_botania, project.debug_botania_tweaks, project.debug_botanic_additions, project.debug_essentialcraft_4, project.debug_extra_botany, project.debug_thaum],
         'the-aurorian-352137:4981736'                         : [project.debug_aurorian],

--- a/examples/postInit/arcaneworld.groovy
+++ b/examples/postInit/arcaneworld.groovy
@@ -1,0 +1,89 @@
+
+// Auto generated groovyscript example file
+// MODS_LOADED: arcaneworld
+
+log.info 'mod \'arcaneworld\' detected, running script'
+
+// Ritual:
+// Converts up to 5 input itemstacks into a wide number of possible effects, including spawning entities, opening a portal
+// to a dungeon dimension to fight a mob, awarding an output itemstack, running commands, and even entirely customized
+// effects.
+
+mods.arcaneworld.ritual.removeByInput(item('minecraft:gold_nugget'))
+mods.arcaneworld.ritual.removeByOutput(item('arcaneworld:biome_crystal'))
+// mods.arcaneworld.ritual.removeAll()
+
+mods.arcaneworld.ritual.recipeBuilder()
+    .ritualCreateItem()
+    .input(item('minecraft:stone') * 5, item('minecraft:diamond'), item('minecraft:clay'))
+    .output(item('minecraft:clay'))
+    .translationKey('groovyscript.demo_output')
+    .name('groovyscript:custom_name')
+    .register()
+
+mods.arcaneworld.ritual.recipeBuilderArena()
+    .input(item('minecraft:stone'), item('minecraft:stone'), item('minecraft:clay'))
+    .translationKey('groovyscript.demo_arena')
+    .entity(entity('minecraft:chicken'))
+    .register()
+
+mods.arcaneworld.ritual.recipeBuilderCommand()
+    .input(item('minecraft:diamond'), item('minecraft:diamond'), item('minecraft:clay'))
+    .translationKey('groovyscript.demo_command')
+    .command('say hi',
+             'give @p minecraft:coal 5')
+    .register()
+
+mods.arcaneworld.ritual.recipeBuilderCreateItem()
+    .input(item('minecraft:diamond'), item('minecraft:diamond'), item('minecraft:diamond'))
+    .translationKey('groovyscript.demo_create_item')
+    .output(item('minecraft:diamond'))
+    .register()
+
+mods.arcaneworld.ritual.recipeBuilderCustom()
+    .input(item('minecraft:diamond'), item('minecraft:diamond'), item('minecraft:clay'), item('minecraft:clay'))
+    .translationKey('groovyscript.demo_custom')
+    .onActivate({ World world, BlockPos blockPos, EntityPlayer player, ItemStack... itemStacks -> { log.info blockPos } })
+    .register()
+
+mods.arcaneworld.ritual.recipeBuilderDragonBreath()
+    .input(item('minecraft:clay'), item('minecraft:clay'), item('minecraft:clay'), item('minecraft:clay'), item('minecraft:clay'))
+    .translationKey('groovyscript.demo_dragon_breath')
+    .register()
+
+mods.arcaneworld.ritual.recipeBuilderDungeon()
+    .input(item('minecraft:diamond'), item('minecraft:clay'), item('minecraft:clay'))
+    .translationKey('groovyscript.demo_dungeon')
+    .register()
+
+mods.arcaneworld.ritual.recipeBuilderSummon()
+    .input(item('minecraft:stone'), item('minecraft:clay'), item('minecraft:clay'))
+    .translationKey('groovyscript.demo_summon')
+    .entity(entity('minecraft:chicken'))
+    .register()
+
+mods.arcaneworld.ritual.recipeBuilderTime()
+    .input(item('minecraft:diamond'), item('minecraft:clay'), item('minecraft:clay'), item('minecraft:clay'))
+    .translationKey('groovyscript.demo_time')
+    .time(5000)
+    .register()
+
+mods.arcaneworld.ritual.recipeBuilderWeather()
+    .input(item('minecraft:diamond'), item('minecraft:gold_ingot'), item('minecraft:clay'))
+    .translationKey('groovyscript.demo_weather_clear')
+    .weatherClear()
+    .register()
+
+mods.arcaneworld.ritual.recipeBuilderWeather()
+    .input(item('minecraft:gold_ingot'), item('minecraft:diamond'), item('minecraft:clay'))
+    .translationKey('groovyscript.demo_weather_rain')
+    .weatherRain()
+    .register()
+
+mods.arcaneworld.ritual.recipeBuilderWeather()
+    .input(item('minecraft:diamond'), item('minecraft:diamond'), item('minecraft:gold_ingot'))
+    .translationKey('groovyscript.demo_weather_thunder')
+    .weatherThunder()
+    .register()
+
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,8 @@
 debug_run_ls = false
 debug_use_examples_folder = true
 debug_log_missing_lang_keys = true
-debug_generate_examples = false
-debug_generate_wiki = false
+debug_generate_examples = true
+debug_generate_wiki = true
 debug_generate_and_crash = false
 
 # END SECTION: development environment settings
@@ -19,6 +19,7 @@ debug_aether = false
 debug_alchemistry = false
 debug_applied_energistics_2 = false
 debug_arcane_archives = false
+debug_arcane_world = true
 debug_astral = false
 debug_atum = false
 debug_aurorian = false

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,8 @@
 debug_run_ls = false
 debug_use_examples_folder = true
 debug_log_missing_lang_keys = true
-debug_generate_examples = true
-debug_generate_wiki = true
+debug_generate_examples = false
+debug_generate_wiki = false
 debug_generate_and_crash = false
 
 # END SECTION: development environment settings
@@ -19,7 +19,7 @@ debug_aether = false
 debug_alchemistry = false
 debug_applied_energistics_2 = false
 debug_arcane_archives = false
-debug_arcane_world = true
+debug_arcane_world = false
 debug_astral = false
 debug_atum = false
 debug_aurorian = false

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ModSupport.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ModSupport.java
@@ -10,6 +10,7 @@ import com.cleanroommc.groovyscript.compat.mods.aetherlegacy.Aether;
 import com.cleanroommc.groovyscript.compat.mods.alchemistry.Alchemistry;
 import com.cleanroommc.groovyscript.compat.mods.appliedenergistics2.AppliedEnergistics2;
 import com.cleanroommc.groovyscript.compat.mods.arcanearchives.ArcaneArchives;
+import com.cleanroommc.groovyscript.compat.mods.arcaneworld.ArcaneWorld;
 import com.cleanroommc.groovyscript.compat.mods.astralsorcery.AstralSorcery;
 import com.cleanroommc.groovyscript.compat.mods.atum.Atum;
 import com.cleanroommc.groovyscript.compat.mods.avaritia.Avaritia;
@@ -88,6 +89,7 @@ public class ModSupport {
     public static final GroovyContainer<Alchemistry> ALCHEMISTRY = new InternalModContainer<>("alchemistry", "Alchemistry", Alchemistry::new);
     public static final GroovyContainer<AppliedEnergistics2> APPLIED_ENERGISTICS_2 = new InternalModContainer<>("appliedenergistics2", "Applied Energistics 2", AppliedEnergistics2::new, "ae2");
     public static final GroovyContainer<ArcaneArchives> ARCANE_ARCHIVES = new InternalModContainer<>("arcanearchives", "Arcane Archives", ArcaneArchives::new);
+    public static final GroovyContainer<ArcaneWorld> ARCANE_WORLD = new InternalModContainer<>("arcaneworld", "Arcane World", ArcaneWorld::new);
     public static final GroovyContainer<AstralSorcery> ASTRAL_SORCERY = new InternalModContainer<>("astralsorcery", "Astral Sorcery", AstralSorcery::new, "astral");
     public static final GroovyContainer<Atum> ATUM = new InternalModContainer<>("atum", "Atum 2", Atum::new);
     public static final GroovyContainer<Avaritia> AVARITIA = new InternalModContainer<>("avaritia", "Avaritia", Avaritia::new);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/arcaneworld/ArcaneWorld.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/arcaneworld/ArcaneWorld.java
@@ -1,0 +1,8 @@
+package com.cleanroommc.groovyscript.compat.mods.arcaneworld;
+
+import com.cleanroommc.groovyscript.compat.mods.GroovyPropertyContainer;
+
+public class ArcaneWorld extends GroovyPropertyContainer {
+
+    public final RitualWrapper ritual = new RitualWrapper();
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/arcaneworld/RitualWrapper.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/arcaneworld/RitualWrapper.java
@@ -1,0 +1,374 @@
+package com.cleanroommc.groovyscript.compat.mods.arcaneworld;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.Alias;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import com.cleanroommc.groovyscript.registry.ForgeRegistryWrapper;
+import com.cleanroommc.groovyscript.sandbox.ClosureHelper;
+import groovy.lang.Closure;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.Ingredient;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.fml.common.registry.EntityEntry;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import party.lemons.arcaneworld.crafting.ritual.Ritual;
+import party.lemons.arcaneworld.crafting.ritual.RitualRegistry;
+import party.lemons.arcaneworld.crafting.ritual.impl.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+@RegistryDescription
+public class RitualWrapper extends ForgeRegistryWrapper<Ritual> {
+
+    public RitualWrapper() {
+        super(RitualRegistry.REGISTRY, Alias.generateOf("Ritual"));
+    }
+
+    // TODO
+    //  not super happy with the wiki gen this creates, as
+    //  theres a fair amount of duplication of code and information.
+    //  Perhaps something like a pseudo element should be added?
+    //  ... which would merge them somehow. need to figure that out.
+    //  applies, inspirations.Cauldron, ID.*, and any new places.
+
+    @RecipeBuilderDescription(example = @Example(".ritualCreateItem().input(item('minecraft:stone') * 5, item('minecraft:diamond'), item('minecraft:clay')).output(item('minecraft:clay')).translationKey('groovyscript.demo_output').name('groovyscript:custom_name')"), requirement = {
+            @Property(property = "output"),
+            @Property(property = "entity"),
+            @Property(property = "time"),
+            @Property(property = "weatherType"),
+            @Property(property = "command"),
+            @Property(property = "onActivate"),
+            @Property(property = "ritualType"),
+    })
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    @RecipeBuilderDescription(example = @Example(".input(item('minecraft:stone'), item('minecraft:stone'), item('minecraft:clay')).translationKey('groovyscript.demo_arena').entity(entity('minecraft:chicken'))"), requirement = {
+            @Property(property = "ritualType", defaultValue = "RitualType.ARENA"),
+            @Property(property = "entity")
+    })
+    public RecipeBuilder recipeBuilderArena() {
+        return new RecipeBuilder().ritualArena();
+    }
+
+    @RecipeBuilderDescription(example = @Example(".input(item('minecraft:diamond'), item('minecraft:diamond'), item('minecraft:clay')).translationKey('groovyscript.demo_command').command('say hi', 'give @p minecraft:coal 5')"), requirement = {
+            @Property(property = "ritualType", defaultValue = "RitualType.COMMAND"),
+            @Property(property = "command")
+    })
+    public RecipeBuilder recipeBuilderCommand() {
+        return new RecipeBuilder().ritualCommand();
+    }
+
+    @RecipeBuilderDescription(example = @Example(".input(item('minecraft:diamond'), item('minecraft:diamond'), item('minecraft:diamond')).translationKey('groovyscript.demo_create_item').output(item('minecraft:diamond'))"), requirement = {
+            @Property(property = "ritualType", defaultValue = "RitualType.CREATE_ITEM"),
+            @Property(property = "output")
+    })
+    public RecipeBuilder recipeBuilderCreateItem() {
+        return new RecipeBuilder().ritualCreateItem();
+    }
+
+    @RecipeBuilderDescription(example = @Example(".input(item('minecraft:clay'), item('minecraft:clay'), item('minecraft:clay'), item('minecraft:clay'), item('minecraft:clay')).translationKey('groovyscript.demo_dragon_breath')"), requirement = {
+            @Property(property = "ritualType", defaultValue = "RitualType.DRAGON_BREATH"),
+    })
+    public RecipeBuilder recipeBuilderDragonBreath() {
+        return new RecipeBuilder().ritualDragonBreath();
+    }
+
+    @RecipeBuilderDescription(example = @Example(".input(item('minecraft:diamond'), item('minecraft:clay'), item('minecraft:clay')).translationKey('groovyscript.demo_dungeon')"), requirement = {
+            @Property(property = "ritualType", defaultValue = "RitualType.DUNGEON"),
+    })
+    public RecipeBuilder recipeBuilderDungeon() {
+        return new RecipeBuilder().ritualDungeon();
+    }
+
+    @RecipeBuilderDescription(example = @Example(".input(item('minecraft:stone'), item('minecraft:clay'), item('minecraft:clay')).translationKey('groovyscript.demo_summon').entity(entity('minecraft:chicken'))"), requirement = {
+            @Property(property = "ritualType", defaultValue = "RitualType.SUMMON"),
+            @Property(property = "entity")
+    })
+    public RecipeBuilder recipeBuilderSummon() {
+        return new RecipeBuilder().ritualSummon();
+    }
+
+    @RecipeBuilderDescription(example = @Example(".input(item('minecraft:diamond'), item('minecraft:clay'), item('minecraft:clay'), item('minecraft:clay')).translationKey('groovyscript.demo_time').time(5000)"), requirement = {
+            @Property(property = "ritualType", defaultValue = "RitualType.TIME"),
+            @Property(property = "time")
+    })
+    public RecipeBuilder recipeBuilderTime() {
+        return new RecipeBuilder().ritualTime();
+    }
+
+    @RecipeBuilderDescription(example = {
+            @Example(".input(item('minecraft:diamond'), item('minecraft:gold_ingot'), item('minecraft:clay')).translationKey('groovyscript.demo_weather_clear').weatherClear()"),
+            @Example(".input(item('minecraft:gold_ingot'), item('minecraft:diamond'), item('minecraft:clay')).translationKey('groovyscript.demo_weather_rain').weatherRain()"),
+            @Example(".input(item('minecraft:diamond'), item('minecraft:diamond'), item('minecraft:gold_ingot')).translationKey('groovyscript.demo_weather_thunder').weatherThunder()")
+    }, requirement = {
+            @Property(property = "ritualType", defaultValue = "RitualType.WEATHER"),
+            @Property(property = "weatherType")
+    })
+    public RecipeBuilder recipeBuilderWeather() {
+        return new RecipeBuilder().ritualWeather();
+    }
+
+    @RecipeBuilderDescription(example = @Example(".input(item('minecraft:diamond'), item('minecraft:diamond'), item('minecraft:clay'), item('minecraft:clay')).translationKey('groovyscript.demo_custom').onActivate({ World world, BlockPos blockPos, EntityPlayer player, ItemStack... itemStacks -> { log.info blockPos } })"), requirement = {
+            @Property(property = "ritualType", defaultValue = "RitualType.CUSTOM"),
+            @Property(property = "onActivate")
+    })
+    public RecipeBuilder recipeBuilderCustom() {
+        return new RecipeBuilder().ritualCustom();
+    }
+
+    @MethodDescription(example = @Example("item('minecraft:gold_nugget')"))
+    public void removeByInput(IIngredient input) {
+        for (var recipe : getRegistry()) {
+            if (recipe.getRequiredItems().stream().map(Ingredient::getMatchingStacks).flatMap(Arrays::stream).anyMatch(input)) {
+                remove(recipe);
+            }
+        }
+    }
+
+    @MethodDescription(example = @Example("item('arcaneworld:biome_crystal')"))
+    public void removeByOutput(IIngredient output) {
+        for (var recipe : getRegistry()) {
+            if (recipe instanceof RitualCreateItem createItem && output.test(createItem.getItemstack())) {
+                remove(recipe);
+            }
+        }
+    }
+
+    public enum RitualType {
+        ARENA,
+        COMMAND,
+        CREATE_ITEM,
+        DRAGON_BREATH,
+        DUNGEON,
+        SUMMON,
+        TIME,
+        WEATHER,
+        CUSTOM,
+    }
+
+    @Property(property = "input", comp = @Comp(gte = 1, lte = 5))
+    @Property(property = "output", comp = @Comp(eq = 1), needsOverride = true)
+    @Property(property = "name")
+    public static class RecipeBuilder extends AbstractRecipeBuilder<Ritual> {
+
+        private static final Class<?>[] ACCEPTED_CLASSES = new Class[]{
+                World.class, BlockPos.class, EntityPlayer.class, ItemStack[].class
+        };
+
+        @Property(comp = @Comp(not = "null"), needsOverride = true)
+        private final List<String> command = new ArrayList<>();
+        @Property(defaultValue = "RitualType.CUSTOM", needsOverride = true)
+        private @NotNull RitualType ritualType = RitualType.CUSTOM;
+        @Property(comp = @Comp(not = "null"), needsOverride = true)
+        private Class<? extends Entity> entity;
+        @Property(comp = @Comp(gte = 1), needsOverride = true)
+        private int time;
+        @Property(comp = @Comp(not = "null"), needsOverride = true)
+        private RitualWeather.WeatherType weatherType;
+        @Property(comp = @Comp(not = "null"), priority = 150)
+        private String translationKey;
+        @Property(comp = @Comp(not = "null"), needsOverride = true)
+        private Closure<Void> onActivate;
+
+        @RecipeBuilderMethodDescription(priority = 2000)
+        public RecipeBuilder ritualType(@NotNull RitualType ritualType) {
+            this.ritualType = ritualType;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription(field = "ritualType")
+        public RecipeBuilder ritualArena() {
+            return ritualType(RitualType.ARENA);
+        }
+
+        @RecipeBuilderMethodDescription(field = "ritualType")
+        public RecipeBuilder ritualCommand() {
+            return ritualType(RitualType.COMMAND);
+        }
+
+        @RecipeBuilderMethodDescription(field = "ritualType")
+        public RecipeBuilder ritualCreateItem() {
+            return ritualType(RitualType.CREATE_ITEM);
+        }
+
+        @RecipeBuilderMethodDescription(field = "ritualType")
+        public RecipeBuilder ritualDragonBreath() {
+            return ritualType(RitualType.DRAGON_BREATH);
+        }
+
+        @RecipeBuilderMethodDescription(field = "ritualType")
+        public RecipeBuilder ritualDungeon() {
+            return ritualType(RitualType.DUNGEON);
+        }
+
+        @RecipeBuilderMethodDescription(field = "ritualType")
+        public RecipeBuilder ritualSummon() {
+            return ritualType(RitualType.SUMMON);
+        }
+
+        @RecipeBuilderMethodDescription(field = "ritualType")
+        public RecipeBuilder ritualTime() {
+            return ritualType(RitualType.TIME);
+        }
+
+        @RecipeBuilderMethodDescription(field = "ritualType")
+        public RecipeBuilder ritualWeather() {
+            return ritualType(RitualType.WEATHER);
+        }
+
+        @RecipeBuilderMethodDescription(field = "ritualType")
+        public RecipeBuilder ritualCustom() {
+            return ritualType(RitualType.CUSTOM);
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder time(int time) {
+            this.time = time;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder entity(Class<? extends Entity> entity) {
+            this.entity = entity;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder entity(EntityEntry entity) {
+            return entity(entity.getEntityClass());
+        }
+
+        @RecipeBuilderMethodDescription(priority = 2000)
+        public RecipeBuilder weatherType(RitualWeather.WeatherType weatherType) {
+            this.weatherType = weatherType;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription(field = "weatherType")
+        public RecipeBuilder weatherClear() {
+            return weatherType(RitualWeather.WeatherType.CLEAR);
+        }
+
+        @RecipeBuilderMethodDescription(field = "weatherType")
+        public RecipeBuilder weatherRain() {
+            return weatherType(RitualWeather.WeatherType.RAIN);
+        }
+
+        @RecipeBuilderMethodDescription(field = "weatherType")
+        public RecipeBuilder weatherThunder() {
+            return weatherType(RitualWeather.WeatherType.THUNDER);
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder command(String command) {
+            this.command.add(command);
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder command(String... command) {
+            Collections.addAll(this.command, command);
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder command(List<String> command) {
+            this.command.addAll(command);
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder translationKey(String translationKey) {
+            this.translationKey = translationKey;
+            return this;
+        }
+
+        @RecipeBuilderMethodDescription
+        public RecipeBuilder onActivate(Closure<Void> onActivate) {
+            if (onActivate == null) {
+                GroovyLog.msg("Arcane World Ritual onActivate closure must be defined")
+                        .error()
+                        .post();
+                return this;
+            }
+            if (!Arrays.equals(onActivate.getParameterTypes(), ACCEPTED_CLASSES)) {
+                GroovyLog.msg("Arcane World Ritual onActivate closure should be a closure with exactly four parameters:")
+                        .add("net.minecraft.world.World world, net.minecraft.util.math.BlockPos blockPos, net.minecraft.entity.player.EntityPlayer player, net.minecraft.item.ItemStack[] itemStacks in that order.")
+                        .add("but had {}, {}, {}, {} instead", (Object[]) onActivate.getParameterTypes())
+                        .debug()
+                        .post();
+            }
+            this.onActivate = onActivate;
+            return this;
+        }
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Arcane World Ritual Recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            input.trim();
+            validateCustom(msg, input, 1, 5, "item input");
+            validateName();
+            msg.add(translationKey == null, "translationKey cannot be null.");
+
+            switch (ritualType) {
+                case ARENA, SUMMON -> msg.add(entity == null, "entity must be defined for the ritualType {}", ritualType);
+                case COMMAND -> msg.add(command.isEmpty(), "command must be defined for the ritualType {}", ritualType);
+                case CREATE_ITEM -> {
+                    output.trim();
+                    validateCustom(msg, output, 1, 1, "item output");
+                }
+                case TIME -> msg.add(time <= 0, "time must be greater than 0 for the ritualType {}, yet it was {}", ritualType, time);
+                case WEATHER -> msg.add(weatherType == null, "weatherType must be defined for the ritualType {}", ritualType);
+                case CUSTOM -> msg.add(onActivate == null, "onActivate must be defined for the ritualType {}", ritualType);
+                case DRAGON_BREATH, DUNGEON -> {
+                }
+                default -> msg.add("ritualType must be defined");
+            }
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable Ritual register() {
+            if (!validate()) return null;
+            var ingredients = input.stream().map(IIngredient::toMcIngredient).toArray(Ingredient[]::new);
+            Ritual recipe = switch (ritualType) {
+                case ARENA -> new RitualArena(entity, ingredients);
+                case COMMAND -> new RitualCommand(command.toArray(new String[0]), ingredients);
+                case CREATE_ITEM -> new RitualCreateItem(output.get(0), ingredients);
+                case DRAGON_BREATH -> new RitualDragonBreath(ingredients);
+                case DUNGEON -> new RitualDungeon(ingredients);
+                case SUMMON -> new RitualSummon(entity, ingredients);
+                case TIME -> new RitualTime(time, ingredients);
+                case WEATHER -> new RitualWeather(weatherType, ingredients);
+                case CUSTOM -> new Ritual(ingredients) {
+
+                    @Override
+                    public void onActivate(@NotNull World world, @NotNull BlockPos blockPos, EntityPlayer player, ItemStack... itemStacks) {
+                        ClosureHelper.call(onActivate, world, blockPos, player, itemStacks);
+                    }
+                };
+            };
+
+            recipe.setRegistryName(super.name);
+            recipe.setTranslationKey(translationKey);
+            ModSupport.ARCANE_WORLD.get().ritual.add(recipe);
+            return recipe;
+        }
+    }
+}

--- a/src/main/resources/assets/groovyscript/lang/en_us.lang
+++ b/src/main/resources/assets/groovyscript/lang/en_us.lang
@@ -331,6 +331,18 @@ groovyscript.wiki.arcanearchives.gem_cutting_table.description=Converts any numb
 groovyscript.wiki.arcanearchives.gem_cutting_table.note0=While more than 8 items can function as the input of a Stygian Iron Anvil recipe, only the first 8 are shown in JEI.
 
 
+# Arcane World
+groovyscript.wiki.arcaneworld.ritual.title=Ritual
+groovyscript.wiki.arcaneworld.ritual.description=Converts up to 5 input itemstacks into a wide number of possible effects, including spawning entities, opening a portal to a dungeon dimension to fight a mob, awarding an output itemstack, running commands, and even entirely customized effects.
+groovyscript.wiki.arcaneworld.ritual.time.value=Sets the amount of time that is passed when the Time Ritual is activated
+groovyscript.wiki.arcaneworld.ritual.entity.value=Sets the entity spawned when the Arena or Summon Rituals are activated
+groovyscript.wiki.arcaneworld.ritual.command.value=Sets the commands that will be run when the Command Ritual is activated
+groovyscript.wiki.arcaneworld.ritual.onActivate.value=Sets the effect that will happen when the Custom Ritual is run, with the Closure taking 4 parameters, `World world`, `BlockPos blockPos`, `EntityPlayer player`, and `ItemStack... itemStacks`
+groovyscript.wiki.arcaneworld.ritual.ritualType.value=Sets the mode of the ritual, different modes will require different values
+groovyscript.wiki.arcaneworld.ritual.weatherType.value=Sets the type of weather the world will change to when the Weather Ritual is activated
+groovyscript.wiki.arcaneworld.ritual.translationKey.value=Sets the translation key used to localize the name of the ritual
+
+
 # Astral Sorcery
 groovyscript.wiki.astralsorcery.aevitas_perk_registry.title=Aevitas Perk Registry
 groovyscript.wiki.astralsorcery.aevitas_perk_registry.description=Having the Stone Enrichment perk will convert nearby stone blocks into random ores.


### PR DESCRIPTION
changes in this PR:
- add compat with Arcane World `ritual`. examples and i18n for that.
- add a `TODO` in regards to improving the docgen for it, as the current wiki is quite verbose and repetitive. happens in a few other places - mainly the Astral Sorcery Table and Inspirations Cauldron, with maybe some Integrated Dynamics stuff. its not urgent and everything is still documented, its just documented multiple times.

RotN has a [fork](https://www.curseforge.com/minecraft/mc-mods/arcane-world-rotn-edition) of Arcane World, but it changes the signature of the `REGISTRY` field from `IForgeRegistry<Ritual>` to `IForgeRegistryModifiable<Ritual>` and so is not compatible. unsure on how this should be resolved - switching to only supporting RotN?