### PR TITLE
add Default GameRules

### DIFF
--- a/examples/postInit/custom/vanilla.groovy
+++ b/examples/postInit/custom/vanilla.groovy
@@ -256,3 +256,8 @@ item('minecraft:golden_apple').setRarity(textformat('-1'))
 eventManager.listen(EnderTeleportEvent) { event ->
     event.setAttackDamage 19.5f
 }
+
+// Default GameRules
+gameRule.add('doDaylightCycle', 'false')
+gameRule.add(['mobGriefing': 'false', 'keepInventory': 'true'])
+gameRule.setWarnNewGameRule(true)

--- a/src/main/java/com/cleanroommc/groovyscript/command/GSCommand.java
+++ b/src/main/java/com/cleanroommc/groovyscript/command/GSCommand.java
@@ -4,6 +4,7 @@ import com.cleanroommc.groovyscript.GroovyScript;
 import com.cleanroommc.groovyscript.api.GroovyLog;
 import com.cleanroommc.groovyscript.compat.mods.ModSupport;
 import com.cleanroommc.groovyscript.compat.mods.jei.JeiPlugin;
+import com.cleanroommc.groovyscript.compat.vanilla.VanillaModule;
 import com.cleanroommc.groovyscript.documentation.Documentation;
 import com.cleanroommc.groovyscript.helper.StyleConstant;
 import com.cleanroommc.groovyscript.network.NetworkHandler;
@@ -25,6 +26,7 @@ import org.jetbrains.annotations.NotNull;
 import java.io.File;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 public class GSCommand extends CommandTreeBase {
 
@@ -57,6 +59,11 @@ public class GSCommand extends CommandTreeBase {
         addSubcommand(new InfoHandCommand());
         addSubcommand(new InfoLookingCommand());
         addSubcommand(new InfoSelfCommand());
+
+        addSubcommand(new SimpleCommand("applyDefaultGameRules", (server, sender, args) -> {
+            VanillaModule.gameRule.setDefaultGameRules(Objects.requireNonNull(server.getServer()).getEntityWorld().getGameRules());
+            sender.sendMessage(new TextComponentString("Applied the default GameRules to the current world."));
+        }));
 
 
         addSubcommand(new SimpleCommand("wiki", (server, sender, args) -> sender.sendMessage(getTextForUrl("GroovyScript wiki", "Click to open wiki in browser", new TextComponentString("https://cleanroommc.com/groovy-script/"))), "doc", "docs", "documentation"));

--- a/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/GameRule.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/GameRule.java
@@ -5,15 +5,15 @@ import com.cleanroommc.groovyscript.api.GroovyLog;
 import com.cleanroommc.groovyscript.api.IScriptReloadable;
 import com.cleanroommc.groovyscript.api.documentation.annotations.MethodDescription;
 import com.cleanroommc.groovyscript.registry.NamedRegistry;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import net.minecraft.world.GameRules;
 
-import java.util.HashMap;
 import java.util.Map;
 
 public class GameRule extends NamedRegistry implements IScriptReloadable {
 
     private static final String LOG_MESSAGE = "Could not find an already existing rule with the name {}. This may be intentional! If it is, you can disable this via `gameRule.setWarnNewGameRule(false)`";
-    private final Map<String, String> defaultGameRules = new HashMap<>();
+    private final Map<String, String> defaultGameRules = new Object2ObjectOpenHashMap<>();
     private boolean warnNewGameRule;
 
     @GroovyBlacklist

--- a/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/GameRule.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/GameRule.java
@@ -1,0 +1,53 @@
+package com.cleanroommc.groovyscript.compat.vanilla;
+
+import com.cleanroommc.groovyscript.api.GroovyBlacklist;
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IScriptReloadable;
+import com.cleanroommc.groovyscript.api.documentation.annotations.MethodDescription;
+import com.cleanroommc.groovyscript.registry.NamedRegistry;
+import net.minecraft.world.GameRules;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class GameRule extends NamedRegistry implements IScriptReloadable {
+
+    private static final String LOG_MESSAGE = "Could not find an already existing rule with the name {}. This may be intentional! If it is, you can disable this via `gameRule.setWarnNewGameRule(false)`";
+    private final Map<String, String> defaultGameRules = new HashMap<>();
+    private boolean warnNewGameRule;
+
+    @GroovyBlacklist
+    public void setDefaultGameRules(GameRules gameRules) {
+        defaultGameRules.forEach((k, v) -> {
+            if (warnNewGameRule && !gameRules.hasRule(k)) {
+                GroovyLog.get().warn(LOG_MESSAGE, k);
+            }
+            gameRules.setOrCreateGameRule(k, v);
+        });
+    }
+
+    @MethodDescription
+    public void add(String gameRule, String value) {
+        defaultGameRules.put(gameRule, value);
+    }
+
+    @MethodDescription
+    public void add(Map<String, String> gameRules) {
+        defaultGameRules.putAll(gameRules);
+    }
+
+    @MethodDescription
+    public void setWarnNewGameRule(boolean value) {
+        warnNewGameRule = value;
+    }
+
+    @Override
+    @GroovyBlacklist
+    public void onReload() {
+        defaultGameRules.clear();
+    }
+
+    @Override
+    @GroovyBlacklist
+    public void afterScriptLoad() {}
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/GameRule.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/GameRule.java
@@ -19,11 +19,11 @@ public class GameRule extends NamedRegistry implements IScriptReloadable {
     @GroovyBlacklist
     public void setDefaultGameRules(GameRules gameRules) {
         defaultGameRules.forEach((k, v) -> {
-            if (warnNewGameRule && !gameRules.hasRule(k)) {
-                GroovyLog.get().warn(LOG_MESSAGE, k);
-            }
+            if (warnNewGameRule && !gameRules.hasRule(k)) GroovyLog.get().warn(LOG_MESSAGE, k);
+            GroovyLog.get().debug("Setting the GameRule '{}' to the value '{}'", k, v);
             gameRules.setOrCreateGameRule(k, v);
         });
+        GroovyLog.get().debug("Set or created {} GameRules", defaultGameRules.size());
     }
 
     @MethodDescription

--- a/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/GameRule.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/GameRule.java
@@ -45,6 +45,7 @@ public class GameRule extends NamedRegistry implements IScriptReloadable {
     @GroovyBlacklist
     public void onReload() {
         defaultGameRules.clear();
+        warnNewGameRule = false;
     }
 
     @Override

--- a/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/VanillaModule.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/VanillaModule.java
@@ -25,6 +25,7 @@ public class VanillaModule extends GroovyPropertyContainer implements IScriptRel
     public static final Content content = new Content();
     public static final Rarity rarity = new Rarity();
     public static final InWorldCrafting inWorldCrafting = new InWorldCrafting();
+    public static final GameRule gameRule = new GameRule();
 
     public static void initializeBinding() {
         GroovyScript.getSandbox().registerBinding(crafting);
@@ -35,6 +36,7 @@ public class VanillaModule extends GroovyPropertyContainer implements IScriptRel
         GroovyScript.getSandbox().registerBinding(content);
         GroovyScript.getSandbox().registerBinding(rarity);
         GroovyScript.getSandbox().registerBinding(inWorldCrafting);
+        GroovyScript.getSandbox().registerBinding(gameRule);
 
         ExpansionHelper.mixinClass(ItemStack.class, ItemStackExpansion.class);
     }
@@ -49,6 +51,7 @@ public class VanillaModule extends GroovyPropertyContainer implements IScriptRel
         rarity.onReload();
         player.onReload();
         inWorldCrafting.onReload();
+        gameRule.onReload();
     }
 
     @Override

--- a/src/main/java/com/cleanroommc/groovyscript/event/EventHandler.java
+++ b/src/main/java/com/cleanroommc/groovyscript/event/EventHandler.java
@@ -37,6 +37,7 @@ import net.minecraftforge.common.config.Config;
 import net.minecraftforge.common.config.ConfigManager;
 import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.event.world.ExplosionEvent;
+import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.fml.client.event.ConfigChangedEvent;
 import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
@@ -76,6 +77,11 @@ public class EventHandler {
     @SideOnly(Side.CLIENT)
     public static void registerTextures(TextureStitchEvent.Post event) {
         GroovyFluid.initTextures(event.getMap());
+    }
+
+    @SubscribeEvent
+    public static void createSpawnPosition(WorldEvent.CreateSpawnPosition event) {
+        VanillaModule.gameRule.setDefaultGameRules(event.getWorld().getGameRules());
     }
 
     @SubscribeEvent

--- a/src/main/java/com/cleanroommc/groovyscript/sandbox/SandboxData.java
+++ b/src/main/java/com/cleanroommc/groovyscript/sandbox/SandboxData.java
@@ -51,9 +51,9 @@ public class SandboxData {
         cachePath = new File(SandboxData.minecraftHome, "cache" + File.separator + "groovy");
         // If we are launching with the environment variable set to use the examples folder, use the examples folder for easy and consistent testing.
         if (Boolean.parseBoolean(System.getProperty("groovyscript.use_examples_folder"))) {
-            scriptPath = new File(minecraftHome.getParentFile(), "examples");
+            scriptPath = new File(SandboxData.minecraftHome.getParentFile(), "examples");
         } else {
-            scriptPath = new File(minecraftHome, "groovy");
+            scriptPath = new File(SandboxData.minecraftHome, "groovy");
         }
         try {
             scriptPath = scriptPath.getCanonicalFile();


### PR DESCRIPTION
changes in this PR:
- add the ability to set the default GameRules. can be done one-by-one or en-mass. 
- when a gamerule that doesnt exist tries to be added, log a warning unless the user has run `gameRule.setWarnNewGameRule(false)`.
- add a command `/gs applyDefaultGameRules` to apply these in-game.
- add examples for this
- the default gamerules are applied when `WorldEvent.CreateSpawnPosition` is fired - as far as i can tell, it is only fired once, when the world is created. other places that do similar things listen to `FMLServerStartingEvent` (applies on every load), `WorldEvent.Load` (applies on every load), and a particularly daring one did `EntityJoinWorldEvent`. 
	- i tested `WorldEvent.CreateSpawnPosition` on both client and server, and it only runs if the `level.dat` does not exist (something which tripped me up on the server for a bit due to always terminating the run instead of stopping the server).
- fix the server using the `run/examples` folder instead of `examples` when `groovyscript.use_examples_folder` is set to true. bug only affects us.