### PR TITLE
Fix HEI config breaking JEI compat

### DIFF
--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/jei/JeiStarterMixin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/jei/JeiStarterMixin.java
@@ -14,7 +14,7 @@ public abstract class JeiStarterMixin {
      * @reason run GroovyScript removal methods after all plugins have been registered to allow users to customize information related to all plugins
      * @see JeiPlugin#afterRegister()
      */
-    @Inject(method = "registerPlugins", at = @At(value = "INVOKE", target = "Lnet/minecraftforge/fml/common/ProgressManager;pop(Lnet/minecraftforge/fml/common/ProgressManager$ProgressBar;)V"))
+    @Inject(method = "registerPlugins", at = @At("TAIL"))
     private static void grs$onRegisterPlugins(CallbackInfo ci) {
         JeiPlugin.afterRegister();
     }
@@ -23,7 +23,7 @@ public abstract class JeiStarterMixin {
      * @reason run GroovyScript removal methods after all plugins have acted on runtime to allow users to customize information related to all plugins
      * @see JeiPlugin#afterRuntimeAvailable()
      */
-    @Inject(method = "sendRuntime", at = @At(value = "INVOKE", target = "Lnet/minecraftforge/fml/common/ProgressManager;pop(Lnet/minecraftforge/fml/common/ProgressManager$ProgressBar;)V"))
+    @Inject(method = "sendRuntime", at = @At("TAIL"))
     private static void grs$onSendRuntime(CallbackInfo ci) {
         JeiPlugin.afterRuntimeAvailable();
     }


### PR DESCRIPTION
changes in this PR:
- for adding methods post-jei-op, instead of injecting prior to the last method, inject at the tail.
	- it used to be that `ProgressManager.pop` was always the last line, but is changed in [HEI](https://github.com/CleanroomMC/HadEnoughItems/commit/e888878b95aaadcf80f23aaca7ca0a4982f9aef0) and made configurable.
