### PR TITLE
Minor fixes for documentation

### DIFF
--- a/examples/postInit/botania_tweaks.groovy
+++ b/examples/postInit/botania_tweaks.groovy
@@ -9,7 +9,7 @@ log.info 'mod \'botania_tweaks\' detected, running script'
 // Terrestrial Agglomeration Plate place on top of a small 3x3 multiblock, of which the center, sides, and corners may be
 // set to require specific blockstates. While the recipe is running, particles will gradually change color until the recipe
 // is finished. Upon finishing the recipe, the center, sides, and corners can each be converted into a replacement
-// blockstate.
+// blockstate, if a replacement blockstate was set.
 
 // mods.botania_tweaks.agglomeration_plate.removeByCenter(blockstate('botania:livingrock'))
 // mods.botania_tweaks.agglomeration_plate.removeByCorner(blockstate('botania:livingrock'))

--- a/examples/postInit/quarryplus.groovy
+++ b/examples/postInit/quarryplus.groovy
@@ -4,13 +4,13 @@
 
 log.info 'mod \'quarryplus\' detected, running script'
 
-// Work bench:
-// Workbench for crafting items using electricity.
+// Workbench Plus:
+// Converts up to 27 itemstacks into an output itemstack at the cost of power.
 
-mods.quarryplus.work_bench_plus.removeByOutput(item('quarryplus:quarry'))
-// mods.quarryplus.work_bench_plus.removeAll()
+mods.quarryplus.workbench_plus.removeByOutput(item('quarryplus:quarry'))
+// mods.quarryplus.workbench_plus.removeAll()
 
-mods.quarryplus.work_bench_plus.recipeBuilder()
+mods.quarryplus.workbench_plus.recipeBuilder()
     .output(item('minecraft:nether_star'))
     .input(item('minecraft:diamond'),item('minecraft:gold_ingot'))
     .energy(10000)

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/additionalenchantedminer/AdditionalEnchantedMiner.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/additionalenchantedminer/AdditionalEnchantedMiner.java
@@ -4,5 +4,5 @@ import com.cleanroommc.groovyscript.compat.mods.GroovyPropertyContainer;
 
 public class AdditionalEnchantedMiner extends GroovyPropertyContainer {
 
-    public final WorkBenchPlus workBenchPlus = new WorkBenchPlus();
+    public final WorkbenchPlus workbenchPlus = new WorkbenchPlus();
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/additionalenchantedminer/WorkbenchPlus.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/additionalenchantedminer/WorkbenchPlus.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @RegistryDescription
-public class WorkBenchPlus extends VirtualizedRegistry<IngredientRecipe> {
+public class WorkbenchPlus extends VirtualizedRegistry<IngredientRecipe> {
 
     @Override
     public void onReload() {
@@ -83,12 +83,12 @@ public class WorkBenchPlus extends VirtualizedRegistry<IngredientRecipe> {
 
         @Override
         public String getRecipeNamePrefix() {
-            return "additionalenchantedminer_workbenchplus_";
+            return "additionalenchantedminer_workbench_";
         }
 
         @Override
         public String getErrorMsg() {
-            return "Error adding Additional Enchanted Miner WorkbenchPlus recipe";
+            return "Error adding Additional Enchanted Miner Workbench recipe";
         }
 
         @Override
@@ -116,7 +116,7 @@ public class WorkBenchPlus extends VirtualizedRegistry<IngredientRecipe> {
                             .map(SeqLike::toSeq)
                             .collect(Collectors.toList())).asScala().toSeq();
             IngredientRecipe recipe = new IngredientRecipe(this.name, output.get(0), energy, true, inputScalaList, true);
-            ModSupport.ADDITIONAL_ENCHANTED_MINER.get().workBenchPlus.add(recipe);
+            ModSupport.ADDITIONAL_ENCHANTED_MINER.get().workbenchPlus.add(recipe);
             return recipe;
         }
     }

--- a/src/main/java/com/cleanroommc/groovyscript/documentation/Registry.java
+++ b/src/main/java/com/cleanroommc/groovyscript/documentation/Registry.java
@@ -13,12 +13,14 @@ import org.apache.commons.lang3.text.WordUtils;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.util.*;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 
 public class Registry {
 
+    private static final Pattern PERIOD_END_PATTERN = Pattern.compile("\\.$");
     private final GroovyContainer<? extends GroovyPropertyContainer> mod;
     private final INamed registry;
     private final String baseTranslationKey;
@@ -339,7 +341,7 @@ public class Registry {
 
         return String.format(
                 "- %s:\n\n%s",
-                Documentation.translate(lang),
+                PERIOD_END_PATTERN.matcher(Documentation.translate(lang)).replaceAll(""),
                 new CodeBlockBuilder()
                         .line(methodExample(method, Exporter.simpleSignature(method, types)))
                         .indentation(1)

--- a/src/main/resources/assets/groovyscript/lang/en_us.lang
+++ b/src/main/resources/assets/groovyscript/lang/en_us.lang
@@ -174,9 +174,12 @@ groovyscript.wiki.actuallyadditions.treasure_chest.min.required=less than or equ
 groovyscript.wiki.actuallyadditions.treasure_chest.max.value=Sets the maximum stack size given when rolled
 groovyscript.wiki.actuallyadditions.treasure_chest.max.required=greater than or equal to the size of min
 
-#Additional Enchanted Miner
-groovyscript.wiki.quarryplus.work_bench_plus.title=Work bench
-groovyscript.wiki.quarryplus.work_bench_plus.description=Workbench for crafting items using electricity.
+
+# Additional Enchanted Miner
+groovyscript.wiki.quarryplus.workbench_plus.title=Workbench Plus
+groovyscript.wiki.quarryplus.workbench_plus.description=Converts up to 27 itemstacks into an output itemstack at the cost of power.
+groovyscript.wiki.quarryplus.workbench_plus.energy.value=Sets the amount of energy consumed to craft the recipe.
+
 
 # Advanced Mortars
 groovyscript.wiki.advancedmortars.mortar.title=Mortar
@@ -188,6 +191,7 @@ groovyscript.wiki.advancedmortars.mortar.types.required=a list of Strings that a
 groovyscript.wiki.advancedmortars.mortar.duration.value=Sets how many interactions are required to process the recipe
 groovyscript.wiki.advancedmortars.mortar.secondaryOutput.value=Sets the additional output itemstack
 groovyscript.wiki.advancedmortars.mortar.secondaryOutputChance.value=Sets the chance of the additional output itemstack being output
+
 
 # Advanced Rocketry
 groovyscript.wiki.advancedrocketry.admonition.weights=The 'chances' used with the recipe outputs are actually output weights. For example, setting 'chance' to 0.1 will set the output's chance to 1, unless other outputs add up to the weight of 0.9. The output chances will also not do anything unless 'outputSize' is set to a number greater than 0.


### PR DESCRIPTION
changes in this PR:
- fix quarryplus (AdditionalEnchantedMiner) missing a lang key and not being properly formatted.
- update `botania_tweaks.groovy` with the "latest" examples (i think this is actually pre-1.2.0).
- strip the closing period `.` in situations where the line would be immediately followed by a `:` (ie `Cool method.:`)