### PR TITLE
Fix GroovyScript crashing on servers

### DIFF
--- a/src/main/java/com/cleanroommc/groovyscript/GroovyScript.java
+++ b/src/main/java/com/cleanroommc/groovyscript/GroovyScript.java
@@ -55,7 +55,6 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.InputEvent;
 import net.minecraftforge.fml.relauncher.FMLInjectionData;
 import net.minecraftforge.fml.relauncher.FMLLaunchHandler;
-import net.minecraftforge.fml.relauncher.Side;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.ApiStatus;
@@ -102,8 +101,7 @@ public class GroovyScript {
 
     @Mod.EventHandler
     public void onConstruction(FMLConstructionEvent event) {
-        int jv = getJavaVersion();
-        if (jv > 21) handleJavaVersionException(jv, event.getSide());
+        JavaVersionCheck.validateJavaVersion(event.getSide());
         if (!SandboxData.isInitialised()) {
             LOGGER.throwing(new IllegalStateException("Sandbox data should have been initialised by now, but isn't! Trying to initialize again."));
             SandboxData.initialize((File) FMLInjectionData.data()[6], LOGGER);
@@ -128,17 +126,6 @@ public class GroovyScript {
 
         FluidRegistry.enableUniversalBucket();
         getRunConfig().initPackmode();
-    }
-
-    private static void handleJavaVersionException(int version, Side side) {
-        String msg1 = "Groovy does not work with Java versions greater than 21 currently.";
-        String msg2 = "Please downgrade to Java 21 or lower. Your current Java version is " + version + ".";
-        if (side.isClient()) {
-            // the super class of this exception is client only (since the screen only works on client)
-            throw new IncompatibleJavaException(msg1 + "\n" + msg2);
-        } else {
-            throw new IllegalStateException(msg1 + " " + msg2);
-        }
     }
 
     @Mod.EventHandler
@@ -324,17 +311,5 @@ public class GroovyScript {
         Loader.instance().setActiveModContainer(grsContainer);
         runnable.run();
         Loader.instance().setActiveModContainer(current);
-    }
-
-    public static int getJavaVersion() {
-        // from stack overflow
-        String version = System.getProperty("java.version");
-        if (version.startsWith("1.")) {
-            version = version.substring(2, 3);
-        } else {
-            int dot = version.indexOf(".");
-            if (dot != -1) version = version.substring(0, dot);
-        }
-        return Integer.parseInt(version);
     }
 }

--- a/src/main/java/com/cleanroommc/groovyscript/IncompatibleJavaException.java
+++ b/src/main/java/com/cleanroommc/groovyscript/IncompatibleJavaException.java
@@ -3,9 +3,12 @@ package com.cleanroommc.groovyscript;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.GuiErrorScreen;
 import net.minecraftforge.fml.client.CustomModLoadingErrorDisplayException;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 
 import java.util.List;
 
+@SideOnly(Side.CLIENT)
 public class IncompatibleJavaException extends CustomModLoadingErrorDisplayException {
 
     private final String msg;

--- a/src/main/java/com/cleanroommc/groovyscript/JavaVersionCheck.java
+++ b/src/main/java/com/cleanroommc/groovyscript/JavaVersionCheck.java
@@ -23,10 +23,19 @@ public class JavaVersionCheck {
         String msg1 = "GroovyScript's version of Groovy does not work with Java versions greater than " + MAXIMUM_VERSION + " currently.";
         String msg2 = "Please downgrade to Java " + MAXIMUM_VERSION + " or lower. Your current Java version is " + version + ".";
         if (side.isClient()) {
-            throw new IncompatibleJavaException(msg1 + "\n" + msg2);
+            throwIncompatibleJavaException(msg1 + "\n" + msg2);
         } else {
             throw new IllegalStateException(msg1 + " " + msg2);
         }
+    }
+
+    /**
+     * Because the super class of this exception is client only (since the screen only works on client)
+     * this has to be in a separate method.
+     */
+    @SideOnly(Side.CLIENT)
+    private static void throwIncompatibleJavaException(String msg) {
+        throw new IncompatibleJavaException(msg);
     }
 
     /**

--- a/src/main/java/com/cleanroommc/groovyscript/JavaVersionCheck.java
+++ b/src/main/java/com/cleanroommc/groovyscript/JavaVersionCheck.java
@@ -1,0 +1,59 @@
+package com.cleanroommc.groovyscript;
+
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
+/**
+ * Checks that the Java version being used can be used by the Groovy that GroovyScript uses.
+ * Our version of Groovy is currently not compatible with java versions above 21.
+ */
+public class JavaVersionCheck {
+
+    private static final int MAXIMUM_VERSION = 21;
+
+    /**
+     * Checks that the Java version being used can run GroovyScript scripts.
+     */
+    public static void validateJavaVersion(Side side) {
+        int version = getJavaVersion();
+        if (version > MAXIMUM_VERSION) handleJavaVersionException(version, side);
+    }
+
+    private static void handleJavaVersionException(int version, Side side) {
+        String msg1 = "GroovyScript's version of Groovy does not work with Java versions greater than " + MAXIMUM_VERSION + " currently.";
+        String msg2 = "Please downgrade to Java " + MAXIMUM_VERSION + " or lower. Your current Java version is " + version + ".";
+        if (side.isClient()) {
+            throw new IncompatibleJavaException(msg1 + "\n" + msg2);
+        } else {
+            throw new IllegalStateException(msg1 + " " + msg2);
+        }
+    }
+
+    /**
+     * Gets the major version of Java currently running.
+     * <table>
+     *  <tr>
+     *   <th>1.8.0_51</th>
+     *   <th>=</th>
+     *   <th>8</th>
+     *  </tr>
+     *  <tr>
+     *   <th>21.0.6</th>
+     *   <th>=</th>
+     *   <th>21</th>
+     *  </tr>
+     * </table>
+     * Code comes from
+     * <a href="https://stackoverflow.com/questions/2591083/getting-java-version-at-runtime">Stack Overflow</a>.
+     */
+    private static int getJavaVersion() {
+        String version = System.getProperty("java.version");
+        if (version.startsWith("1.")) {
+            version = version.substring(2, 3);
+        } else {
+            int dot = version.indexOf(".");
+            if (dot != -1) version = version.substring(0, dot);
+        }
+        return Integer.parseInt(version);
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/mapper/TextureBinder.java
+++ b/src/main/java/com/cleanroommc/groovyscript/mapper/TextureBinder.java
@@ -10,6 +10,9 @@ import net.minecraft.client.renderer.texture.TextureMap;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fml.common.FMLCommonHandler;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 import org.jetbrains.annotations.ApiStatus;
 
 import java.util.List;
@@ -46,6 +49,7 @@ public interface TextureBinder<T> {
     }
 
     static TextureBinder<ItemStack> ofItem() {
+        if (FMLCommonHandler.instance().getSide().isServer()) return x -> {};
         return item -> {
             GlStateManager.enableDepth();
             RenderHelper.enableGUIStandardItemLighting();
@@ -63,6 +67,7 @@ public interface TextureBinder<T> {
     }
 
     static TextureBinder<FluidStack> ofFluid() {
+        if (FMLCommonHandler.instance().getSide().isServer()) return x -> {};
         return fluid -> {
             GlStateManager.enableBlend();
             GlStateManager.enableAlpha();
@@ -79,6 +84,7 @@ public interface TextureBinder<T> {
         };
     }
 
+    @SideOnly(Side.CLIENT)
     static void drawSprite(TextureAtlasSprite textureSprite) {
         double uMin = textureSprite.getMinU();
         double uMax = textureSprite.getMaxU();


### PR DESCRIPTION
changes in this PR:
- extract java version checking to its own class to declutter the GroovyScript class.
	- add some javadocs explaining it.
- annotate `TextureBinder.drawSprite` as client-only and return empty functional interfaces so the method isnt called.
- separate the reference to the client-only class `IncompatibleJavaException` into its own method.


resolves #292