### PR TITLE
Adjust getMaxItemInput in missing places, fix examples 

### DIFF
--- a/examples/postInit/custom/hard_mode.groovy
+++ b/examples/postInit/custom/hard_mode.groovy
@@ -1,7 +1,7 @@
 // PACKMODE: hard
 
 crafting.shapedBuilder()
-        .output(item('placeholdername:clay_2'))
+        .output(item('groovyscriptdev:clay_2'))
         .shape([[null, item('minecraft:diamond'), null],
                 [item('minecraft:diamond'), null, item('minecraft:diamond')],
                 [null, item('minecraft:diamond'), null]])

--- a/examples/postInit/custom/normal_mode.gvy
+++ b/examples/postInit/custom/normal_mode.gvy
@@ -3,7 +3,7 @@
 
 crafting.removeByOutput(item('minecraft:furnace'))
 crafting.shapedBuilder()
-        .output(item('placeholdername:clay_2'))
+        .output(item('groovyscriptdev:clay_2'))
         .shape([[null, item('minecraft:iron_ingot'), null],
                 [item('minecraft:iron_ingot'), null, item('minecraft:iron_ingot')],
                 [null, item('minecraft:iron_ingot'), null]])

--- a/examples/postInit/custom/reloading_compat.groovy
+++ b/examples/postInit/custom/reloading_compat.groovy
@@ -6,22 +6,21 @@ import classes.GenericRecipeReloading
 import classes.SimpleConversionRecipe
 import net.minecraft.util.text.TextComponentString
 import net.minecraftforge.event.world.BlockEvent
-import com.cleanroommc.groovyscript.event.GroovyReloadEvent
+
+// only run the onReload code when reloading. must be done before any further manipulations occur
+if (isReloading()) {
+    GenericRecipeReloading.instance.onReload()
+}
 
 // add the example recipe
 GenericRecipeReloading.instance.add(new SimpleConversionRecipe(item('minecraft:clay'), item('minecraft:gold_ingot')))
-
-// reload via an event
-eventManager.listen(GroovyReloadEvent) {
-    GenericRecipeReloading.instance.onReload()
-}
 
 // use an event to demonstrate the recipe in-game
 eventManager.listen(BlockEvent.BreakEvent) {
     // get the block drop if it was silk touched
     def drop = it.getState().getBlock().getSilkTouchDrop(it.getState())
     // find if any of the recipes have an input that match the drop
-    def found = SimpleConversionRecipe.recipes.find { it.input in drop }
+    def found = SimpleConversionRecipe.recipes.find({ it.input in drop })
     if (found != null) {
         // send the player a pair of messages to demonstrate the recipe
         it.player.sendMessage(new TextComponentString("You broke a ${it.getState().getBlock().getLocalizedName()} Block!"))

--- a/examples/preInit/vanilla.groovy
+++ b/examples/preInit/vanilla.groovy
@@ -9,12 +9,12 @@ import net.minecraft.util.math.AxisAlignedBB
 import net.minecraft.world.IBlockAccess
 
 
-// Localization is done in 'assets/placeholdername/lang/[language].lang'
+// Localization is done in 'assets/groovyscriptdev/lang/[language].lang'
 
-// Textures for items are created at 'assets/placeholdername/textures/items/'.
+// Textures for items are created at 'assets/groovyscriptdev/textures/items/'.
 // Add a file called '[itemname].png' to create a static item texture, and a file called
 // '[itemname].png.mcmeta' to create an animated file.
-// A file will be created in 'assets/placeholdername/models/item/' called '[itemname].json' and point to this location in textures.
+// A file will be created in 'assets/groovyscriptdev/models/item/' called '[itemname].json' and point to this location in textures.
 
 def HOAU = content.createItem('heartofauniverse') // Set item name at 'item.[itemname].name=[desired name]'
     .setRarity(EnumRarity.EPIC) // Optional IRarity, sets the default text formatting (default none)
@@ -31,13 +31,13 @@ content.setDefaultCreativeTab(tab)
 HOAU.register()
 
 
-// Create an item at the location 'placeholdername:clay_2'
+// Create an item at the location 'groovyscriptdev:clay_2'
 content.createItem('clay_2')
     .setMaxStackSize(5) // Optional int, sets the max stack size (default 64)
     .setRarity(EnumRarity.RARE) // Optional IRarity, sets the default text formatting (default none)
     .register()
 
-// Create an item at the location 'placeholdername:clay_3'.
+// Create an item at the location 'groovyscriptdev:clay_3'.
 content.createItem('clay_3')
     .setCreativeTab(creativeTab('misc')) // Optional CreativeTab, sets the creative tab (default set via setDefaultCreativeTab)
     .setEnchantedEffect() // Optional boolean, controls if the enchanted effect plays on the item
@@ -62,17 +62,17 @@ content.registerItem('snack', (new ItemFood(20, 10, false) {
 
 // block
 
-// Textures for blocks are created at 'assets/placeholdername/textures/blocks/'.
+// Textures for blocks are created at 'assets/groovyscriptdev/textures/blocks/'.
 // Add a file called '[blockname].png' to create a static item texture, and a file called
 // '[blockname].png.mcmeta' to create an animated file.
-// A file will be created in 'assets/placeholdername/models/block/' called '[blockname].json' and point to this location in textures.
+// A file will be created in 'assets/groovyscriptdev/models/block/' called '[blockname].json' and point to this location in textures.
 
-// Create a block at the location 'placeholdername:generic_block'
+// Create a block at the location 'groovyscriptdev:generic_block'
 content.createBlock('generic_block')// Set block name at 'tile.[blockname].name=[desired name]'
     .register()
 
-// Create a custom block at the location 'placeholdername:dragon_egg_lamp'
-// Also changes the 'parent' setting in 'assets/placeholdername/models/block/[blockname].json' from 'block/cube_all' to 'block/dragon_egg'
+// Create a custom block at the location 'groovyscriptdev:dragon_egg_lamp'
+// Also changes the 'parent' setting in 'assets/groovyscriptdev/models/block/[blockname].json' from 'block/cube_all' to 'block/dragon_egg'
 content.registerBlock('dragon_egg_lamp', (new Block(Material.REDSTONE_LIGHT) {
     protected static final AxisAlignedBB DRAGON_EGG_AABB = new AxisAlignedBB(0.0625D, 0.0D, 0.0625D, 0.9375D, 1.0D, 0.9375D)
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/futuremc/BlastFurnace.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/futuremc/BlastFurnace.java
@@ -44,6 +44,11 @@ public class BlastFurnace extends StandardListRegistry<SimpleRecipe> {
     public static class RecipeBuilder extends AbstractRecipeBuilder<SimpleRecipe> {
 
         @Override
+        protected int getMaxItemInput() {
+            return 1;
+        }
+
+        @Override
         public String getErrorMsg() {
             return "Error adding FutureMC Blast Furnace recipe";
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/futuremc/Campfire.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/futuremc/Campfire.java
@@ -53,6 +53,11 @@ public class Campfire extends StandardListRegistry<CampfireRecipe> {
         }
 
         @Override
+        protected int getMaxItemInput() {
+            return 1;
+        }
+
+        @Override
         public String getErrorMsg() {
             return "Error adding FutureMC Campfire recipe";
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/futuremc/Smoker.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/futuremc/Smoker.java
@@ -44,6 +44,11 @@ public class Smoker extends StandardListRegistry<SimpleRecipe> {
     public static class RecipeBuilder extends AbstractRecipeBuilder<SimpleRecipe> {
 
         @Override
+        protected int getMaxItemInput() {
+            return 1;
+        }
+
+        @Override
         public String getErrorMsg() {
             return "Error adding FutureMC Smoker recipe";
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/futuremc/Stonecutter.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/futuremc/Stonecutter.java
@@ -44,6 +44,11 @@ public class Stonecutter extends StandardListRegistry<SimpleRecipe> {
     public static class RecipeBuilder extends AbstractRecipeBuilder<SimpleRecipe> {
 
         @Override
+        protected int getMaxItemInput() {
+            return 1;
+        }
+
+        @Override
         public String getErrorMsg() {
             return "Error adding FutureMC Stonecutter recipe";
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/horsepower/ChoppingBlock.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/horsepower/ChoppingBlock.java
@@ -101,7 +101,10 @@ public class ChoppingBlock extends StandardListRegistry<ChoppingBlockRecipe> {
             return this;
         }
 
-        // todo this can only handle an input with a size of 1, should validate that here
+        @Override
+        protected int getMaxItemInput() {
+            return 1;
+        }
 
         @Override
         public String getErrorMsg() {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/horsepower/ManualChoppingBlock.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/horsepower/ManualChoppingBlock.java
@@ -83,7 +83,10 @@ public class ManualChoppingBlock extends StandardListRegistry<ChoppingBlockRecip
             return this;
         }
 
-        // todo this can only handle an input with a size of 1, should validate that here
+        @Override
+        protected int getMaxItemInput() {
+            return 1;
+        }
 
         @Override
         public String getErrorMsg() {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/randomthings/Anvil.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/randomthings/Anvil.java
@@ -56,6 +56,11 @@ public class Anvil extends StandardListRegistry<AnvilRecipe> {
         }
 
         @Override
+        protected int getMaxItemInput() {
+            return 1;
+        }
+
+        @Override
         public String getErrorMsg() {
             return "Error adding Random Things Anvil recipe";
         }


### PR DESCRIPTION
changes in this PR:
- add `getMaxItemInput` 1 to some places missing it - currently only registries from `futuremc`, `horsepower`, `randomthings`.
- fix leftover `placeholdername:` in comments and some example files, which caused errors.
- convert the reloading example from event-based (which doesnt work) to `isReloading()`.