### PR TITLE
Require Extended Crafting: Nomi Edition

### DIFF
--- a/src/main/java/com/cleanroommc/groovyscript/GroovyScript.java
+++ b/src/main/java/com/cleanroommc/groovyscript/GroovyScript.java
@@ -74,7 +74,7 @@ import java.util.Random;
         modid = GroovyScript.ID,
         name = GroovyScript.NAME,
         version = GroovyScript.VERSION,
-        dependencies = "after:mixinbooter@[8.0,);",
+        dependencies = "after:mixinbooter@[8.0,);after:extendedcrafting@[1.6.0,);",
         guiFactory = "com.cleanroommc.groovyscript.DisabledConfigGui")
 @Mod.EventBusSubscriber(modid = GroovyScript.ID)
 public class GroovyScript {


### PR DESCRIPTION
changes in this PR:
- GroovyScript is not compatible with Extended Crafting, and is only compatible with Extended Crafting: Nomifactory Edition. this updated the `@Mod#dependencies` with `after:extendedcrafting@[1.6.0,);` to ensure this is followed.
- `1.5.6` is the last version of extended crafting, and `1.6.0` is the first version of the nomi fork.

reasoning:
- the mixin `ItemRecipeMakerMixin` is written for Nomi, and the Compression Crafting compat errors outside of the Nomi version.
	- this is because base extended crafting has a return value of `ArrayList` for `getRecipes`, while nomi fork returns a `List`. this could be fixed via reflection.

test via adding this to `dependencies.gradle`:
```
runtimeOnly(rfg.deobf('curse.maven:cucumber-272335:2645867'))
runtimeOnly(rfg.deobf('curse.maven:extended-crafting-268387:2777071'))
```


related to #267 