### PR TITLE
Fix info command copying formatting

### DIFF
--- a/src/main/java/com/cleanroommc/groovyscript/api/infocommand/InfoParser.java
+++ b/src/main/java/com/cleanroommc/groovyscript/api/infocommand/InfoParser.java
@@ -16,7 +16,8 @@ public interface InfoParser {
     /**
      * Priority of the parser for determining the order they are logged in chat,
      * with lowest being first and highest being last.
-     * The is 100, and {@link com.cleanroommc.groovyscript.compat.vanilla.command.infoparser.InfoParserItem#priority()} is set to 1.
+     * The default for {@link com.cleanroommc.groovyscript.compat.vanilla.command.infoparser.GenericInfoParser GenericInfoParser} 100,
+     * and {@link com.cleanroommc.groovyscript.compat.vanilla.command.infoparser.InfoParserItem#priority() InfoParserItem.priority()} is set to 1.
      *
      * @return the priority of the Parser
      */

--- a/src/main/java/com/cleanroommc/groovyscript/api/infocommand/InfoParserRegistry.java
+++ b/src/main/java/com/cleanroommc/groovyscript/api/infocommand/InfoParserRegistry.java
@@ -1,23 +1,51 @@
 package com.cleanroommc.groovyscript.api.infocommand;
 
+import com.google.common.collect.ImmutableList;
+
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
 
+/**
+ * To help gather information about items, blocks, the world, etc.
+ * GroovyScript adds {@link InfoParser}s, which will provide information to the player
+ * using data from an {@link InfoParserPackage}.
+ * <p>
+ * This is currently only used for commands related to {@link com.cleanroommc.groovyscript.command.BaseInfoCommand BaseInfoCommand}.
+ *
+ * @see com.cleanroommc.groovyscript.compat.vanilla.command.infoparser.StandardInfoParserRegistry StandardInfoParserRegistry
+ */
 public class InfoParserRegistry {
 
     private static final List<InfoParser> INFO_PARSERS = new ArrayList<>();
+    private static final List<String> IDS = new ArrayList<>();
 
-    public static void addInfoParser(InfoParser command) {
-        INFO_PARSERS.add(command);
+    /**
+     * Register the given info parser.
+     */
+    public static void addInfoParser(InfoParser parser) {
+        INFO_PARSERS.add(parser);
+        INFO_PARSERS.sort(Comparator.comparing(InfoParser::priority));
     }
 
+    /**
+     * @return all registered info parsers
+     */
     public static List<InfoParser> getInfoParsers() {
-        return INFO_PARSERS.stream().sorted(Comparator.comparing(InfoParser::priority)).collect(Collectors.toList());
+        return ImmutableList.copyOf(INFO_PARSERS);
     }
 
+    /**
+     * @return the ids of all registered info parsers
+     */
     public static List<String> getIds() {
-        return INFO_PARSERS.stream().sorted(Comparator.comparing(InfoParser::priority)).map(InfoParser::id).collect(Collectors.toList());
+        // generate the list
+        if (IDS.size() != INFO_PARSERS.size()) {
+            IDS.clear();
+            for (var parser : INFO_PARSERS) {
+                IDS.add(parser.id());
+            }
+        }
+        return ImmutableList.copyOf(IDS);
     }
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/InfoParserTab.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/InfoParserTab.java
@@ -1,11 +1,13 @@
 package com.cleanroommc.groovyscript.compat.mods.jei;
 
+import com.cleanroommc.groovyscript.api.GroovyLog;
 import com.cleanroommc.groovyscript.api.infocommand.InfoParserPackage;
 import com.cleanroommc.groovyscript.compat.vanilla.command.infoparser.GenericInfoParser;
 import com.cleanroommc.groovyscript.core.mixin.jei.ModRegistryAccessor;
 import com.cleanroommc.groovyscript.helper.StyleConstant;
 import mezz.jei.api.recipe.IRecipeCategory;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.oredict.OreDictionary;
 import org.jetbrains.annotations.NotNull;
 
@@ -36,6 +38,11 @@ public class InfoParserTab extends GenericInfoParser<IRecipeCategory> {
     @Override
     @SuppressWarnings("rawtypes")
     public void parse(InfoParserPackage info) {
+        // only runs client-side
+        if (!FMLCommonHandler.instance().getSide().isClient()) {
+            GroovyLog.get().debug("Attempted to check the JEI tab via info parser server-side");
+            return;
+        }
         if (info.getStack().isEmpty()) return;
 
         // this gets all categories the item appears on - and there isn't any inbuilt method to get *just* catalysts.

--- a/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/command/infoparser/InfoParserItem.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/command/infoparser/InfoParserItem.java
@@ -5,6 +5,7 @@ import com.cleanroommc.groovyscript.helper.ingredient.GroovyScriptCodeConverter;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.text.ITextComponent;
+import net.minecraftforge.fml.common.FMLCommonHandler;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Iterator;
@@ -13,6 +14,10 @@ import java.util.List;
 public class InfoParserItem extends GenericInfoParser<ItemStack> {
 
     public static final InfoParserItem instance = new InfoParserItem();
+
+    private static void copyToClipboard(String text) {
+        GuiScreen.setClipboardString(text);
+    }
 
     @Override
     public int priority() {
@@ -39,7 +44,8 @@ public class InfoParserItem extends GenericInfoParser<ItemStack> {
         if (entries.hasNext()) {
             ItemStack entry = entries.next();
             messages.add(information(entry, prettyNbt));
-            GuiScreen.setClipboardString(copyText(entry, prettyNbt));
+            // can only copy to clipboard if a client is running this
+            if (FMLCommonHandler.instance().getSide().isClient()) copyToClipboard(copyText(entry, false));
         }
         while (entries.hasNext()) {
             messages.add(information(entries.next(), prettyNbt));


### PR DESCRIPTION
changes in this PR:
- fix formatting characters being copied to hand.
- move client-only copying to only run on the client.
- only run the jei tab parser if its clientside (avoid crashing).
- add comments to `InfoParserRegistry` and adjust some logic to not make streams constantly.