### PR TITLE
Fix Java 24 incompatibility

### DIFF
--- a/src/main/java/com/cleanroommc/groovyscript/GroovyScript.java
+++ b/src/main/java/com/cleanroommc/groovyscript/GroovyScript.java
@@ -101,7 +101,7 @@ public class GroovyScript {
 
     @Mod.EventHandler
     public void onConstruction(FMLConstructionEvent event) {
-        JavaVersionCheck.validateJavaVersion(event.getSide());
+        //JavaVersionCheck.validateJavaVersion(event.getSide());
         if (!SandboxData.isInitialised()) {
             LOGGER.throwing(new IllegalStateException("Sandbox data should have been initialised by now, but isn't! Trying to initialize again."));
             SandboxData.initialize((File) FMLInjectionData.data()[6], LOGGER);

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/groovy/AsmDecompilerMixin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/groovy/AsmDecompilerMixin.java
@@ -1,76 +1,19 @@
 package com.cleanroommc.groovyscript.core.mixin.groovy;
 
-import com.cleanroommc.groovyscript.sandbox.transformer.AsmDecompileHelper;
-import groovy.lang.GroovyRuntimeException;
 import org.codehaus.groovy.ast.decompiled.AsmDecompiler;
 import org.codehaus.groovy.ast.decompiled.ClassStub;
-import org.codehaus.groovy.util.URLStreams;
-import org.objectweb.asm.ClassReader;
-import org.objectweb.asm.ClassWriter;
-import org.objectweb.asm.tree.ClassNode;
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import java.io.BufferedInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.lang.ref.SoftReference;
-import java.lang.reflect.InvocationTargetException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.Map;
 
 @Mixin(value = AsmDecompiler.class, remap = false)
 public class AsmDecompilerMixin {
 
-    @Shadow
-    @Final
-    private static Map<URI, SoftReference<ClassStub>> stubCache;
-
-    @Inject(method = "parseClass", at = @At("HEAD"), cancellable = true)
+    @Inject(method = "parseClass", at = @At("HEAD"))
     private static void parseClass(URL url, CallbackInfoReturnable<ClassStub> cir) {
-        URI uri;
-        try {
-            uri = url.toURI();
-        } catch (URISyntaxException e) {
-            throw new GroovyRuntimeException(e);
-        }
-
-        SoftReference<ClassStub> ref = stubCache.get(uri);
-        ClassStub stub = (ref != null ? ref.get() : null);
-        if (stub == null) {
-            try (InputStream stream = new BufferedInputStream(URLStreams.openUncachedStream(url))) {
-                ClassReader classReader = new ClassReader(stream);
-                ClassNode classNode = new ClassNode();
-                classReader.accept(classNode, 0);
-                ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_MAXS);
-                classNode.accept(writer);
-                byte[] bytes = writer.toByteArray();
-                if (!AsmDecompileHelper.remove(classNode.visibleAnnotations, AsmDecompileHelper.SIDE)) {
-                    bytes = AsmDecompileHelper.transform(classNode.name, bytes);
-                }
-
-                // now decompile the class normally
-                groovyjarjarasm.asm.ClassReader classReader2 = new groovyjarjarasm.asm.ClassReader(bytes);
-                groovyjarjarasm.asm.ClassVisitor decompiler = AsmDecompileHelper.makeGroovyDecompiler();
-                classReader2.accept(decompiler, ClassReader.SKIP_FRAMES);
-                stub = AsmDecompileHelper.getDecompiledClass(decompiler);
-                stubCache.put(uri, new SoftReference<>(stub));
-            } catch (IOException |
-                     ClassNotFoundException |
-                     NoSuchFieldException |
-                     NoSuchMethodException |
-                     IllegalAccessException |
-                     InvocationTargetException |
-                     InstantiationException e) {
-                throw new RuntimeException(e);
-            }
-        }
-        cir.setReturnValue(stub);
+        throw new UnsupportedOperationException();
     }
 }

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/groovy/ClassNodeResolverMixin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/groovy/ClassNodeResolverMixin.java
@@ -13,9 +13,6 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
 
-import java.net.URL;
-
-
 @Mixin(value = ClassNodeResolver.class, remap = false)
 public abstract class ClassNodeResolverMixin {
 
@@ -31,7 +28,7 @@ public abstract class ClassNodeResolverMixin {
 
     /**
      * @author brachy
-     * @reason bad
+     * @reason properly find classes
      */
     @Overwrite
     private ClassNodeResolver.LookupResult findDecompiled(final String name, final CompilationUnit compilationUnit, final GroovyClassLoader loader) {
@@ -41,11 +38,6 @@ public abstract class ClassNodeResolverMixin {
         }
 
         DecompiledClassNode asmClass = null;
-        /*URL resource = loader.getResource(name.replace('.', '/') + ".class");
-        ClassStub stub = null;
-        if (resource != null) {
-            stub = AsmDecompileHelper.legacyFindDecompiledClass(name, resource);
-        }*/
         ClassStub stub = AsmDecompileHelper.findDecompiledClass(name);
         if (stub != null) {
             asmClass = new DecompiledClassNode(stub, new AsmReferenceResolver((ClassNodeResolver) (Object) this, compilationUnit));

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/groovy/ClassNodeResolverMixin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/groovy/ClassNodeResolverMixin.java
@@ -1,0 +1,68 @@
+package com.cleanroommc.groovyscript.core.mixin.groovy;
+
+import com.cleanroommc.groovyscript.sandbox.transformer.AsmDecompileHelper;
+import groovy.lang.GroovyClassLoader;
+import org.codehaus.groovy.ast.ClassHelper;
+import org.codehaus.groovy.ast.ClassNode;
+import org.codehaus.groovy.ast.decompiled.AsmReferenceResolver;
+import org.codehaus.groovy.ast.decompiled.ClassStub;
+import org.codehaus.groovy.ast.decompiled.DecompiledClassNode;
+import org.codehaus.groovy.control.ClassNodeResolver;
+import org.codehaus.groovy.control.CompilationUnit;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+
+import java.net.URL;
+
+
+@Mixin(value = ClassNodeResolver.class, remap = false)
+public abstract class ClassNodeResolverMixin {
+
+    @Shadow
+    private static boolean isFromAnotherClassLoader(GroovyClassLoader loader, String fileName) {
+        return false;
+    }
+
+    @Shadow
+    private static ClassNodeResolver.LookupResult tryAsScript(String name, CompilationUnit compilationUnit, ClassNode oldClass) {
+        return null;
+    }
+
+    /**
+     * @author brachy
+     * @reason bad
+     */
+    @Overwrite
+    private ClassNodeResolver.LookupResult findDecompiled(final String name, final CompilationUnit compilationUnit, final GroovyClassLoader loader) {
+        ClassNode node = ClassHelper.make(name);
+        if (node.isResolved()) {
+            return new ClassNodeResolver.LookupResult(null, node);
+        }
+
+        DecompiledClassNode asmClass = null;
+        /*URL resource = loader.getResource(name.replace('.', '/') + ".class");
+        ClassStub stub = null;
+        if (resource != null) {
+            stub = AsmDecompileHelper.legacyFindDecompiledClass(name, resource);
+        }*/
+        ClassStub stub = AsmDecompileHelper.findDecompiledClass(name);
+        if (stub != null) {
+            asmClass = new DecompiledClassNode(stub, new AsmReferenceResolver((ClassNodeResolver) (Object) this, compilationUnit));
+            if (!asmClass.getName().equals(name)) {
+                // this may happen under Windows because getResource is case-insensitive under that OS!
+                asmClass = null;
+            }
+        }
+
+        if (asmClass != null) {
+            String fileName = name.replace('.', '/') + ".class";
+            if (isFromAnotherClassLoader(loader, fileName)) {
+                return tryAsScript(name, compilationUnit, asmClass);
+            }
+
+            return new ClassNodeResolver.LookupResult(null, asmClass);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/sandbox/GroovyScriptClassLoader.java
+++ b/src/main/java/com/cleanroommc/groovyscript/sandbox/GroovyScriptClassLoader.java
@@ -188,12 +188,6 @@ public abstract class GroovyScriptClassLoader extends GroovyClassLoader {
                 cls = recompile(source, name);
             } catch (IOException ioe) {
                 last = new ClassNotFoundException("IOException while opening groovy source: " + name, ioe);
-            } finally {
-                if (cls == null) {
-                    removeClassCacheEntry(name);
-                } else {
-                    setClassCacheEntry(cls);
-                }
             }
         }
 

--- a/src/main/java/com/cleanroommc/groovyscript/sandbox/transformer/AsmDecompileHelper.java
+++ b/src/main/java/com/cleanroommc/groovyscript/sandbox/transformer/AsmDecompileHelper.java
@@ -91,7 +91,7 @@ public class AsmDecompileHelper {
     }
 
     /**
-     * Finds decompiled class bytes via forge class loader.
+     * Old way of finding classes. This does read java classes and causes a crash on java 24.
      */
     public static @Nullable ClassStub legacyFindDecompiledClass(String className, URL resource) {
         SoftReference<ClassStub> ref = stubCache.get(className);

--- a/src/main/resources/mixin.groovyscript.json
+++ b/src/main/resources/mixin.groovyscript.json
@@ -23,6 +23,7 @@
     "TileEntityPistonMixin",
     "VillagerProfessionAccessor",
     "groovy.AsmDecompilerMixin",
+    "groovy.ClassNodeResolverMixin",
     "groovy.ClosureMixin",
     "groovy.CompUnitClassGenMixin",
     "groovy.Java8Mixin",


### PR DESCRIPTION
The reason for the crash is that Groovy uses its own version of ASM to read classes. In that version it can only read class files up to version 67 (java 23). Afaik only the classes from java itself have class version 68. 
This pr obtains the class bytes not by manually searching pushing an input stream through a class reader, but by using forge methods. Which for some reason doesnt return anything for java classes. I have no idea where the java classes come from because they obviously work.

This likely will become a problem again once mods start to compile for java 24 and higher. At that point we will have to pull to a few classes from groovys asm decompiler and adjust them.