### PR TITLE
Fix GS Info Item Copying Formatting Characters

### DIFF
--- a/examples/postInit/thebetweenlands.groovy
+++ b/examples/postInit/thebetweenlands.groovy
@@ -206,3 +206,4 @@ mods.thebetweenlands.steeping_pot.recipeBuilder()
 
 
 mods.thebetweenlands.steeping_pot.addAcceptedItem(item('minecraft:gold_block'))
+

--- a/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/command/infoparser/InfoParserItem.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/command/infoparser/InfoParserItem.java
@@ -45,7 +45,7 @@ public class InfoParserItem extends GenericInfoParser<ItemStack> {
             ItemStack entry = entries.next();
             messages.add(information(entry, prettyNbt));
             // can only copy to clipboard if a client is running this
-            if (FMLCommonHandler.instance().getSide().isClient()) copyToClipboard(copyText(entry, false));
+            if (FMLCommonHandler.instance().getSide().isClient()) copyToClipboard(text(entry, false, prettyNbt));
         }
         while (entries.hasNext()) {
             messages.add(information(entries.next(), prettyNbt));


### PR DESCRIPTION
changes in this PR:
- fix formatting characters being copied when running an info parser
- ran docgen and it added a line of whitespace to `thebetweenlands.groovy`

didnt do things correctly in #305