### PR TITLE
Add Groovy call operator to log

### DIFF
--- a/examples/postInit/custom/experiments.groovy
+++ b/examples/postInit/custom/experiments.groovy
@@ -3,13 +3,13 @@
 
 def ore_iron = ore('ingotIron')
 def item_iron = item('minecraft:iron_ingot')
-log.info(item_iron in ore_iron) // true
-log.info(item_iron in item_iron) // true
-log.info(ore_iron in item_iron) // false
-log.info(item_iron << ore_iron) // true
-log.info((item_iron * 3) << ore_iron) // false
-log.info(ore_iron >> item_iron) // true
-log.info(ore_iron >> (item_iron * 3)) // false
+log(item_iron in ore_iron) // true
+log(item_iron in item_iron) // true
+log(ore_iron in item_iron) // false
+log(item_iron << ore_iron) // true
+log((item_iron * 3) << ore_iron) // false
+log(ore_iron >> item_iron) // true
+log(ore_iron >> (item_iron * 3)) // false
 
 file('config/').eachFile { file ->
     println file.path

--- a/src/main/java/com/cleanroommc/groovyscript/api/GroovyLog.java
+++ b/src/main/java/com/cleanroommc/groovyscript/api/GroovyLog.java
@@ -57,6 +57,10 @@ public interface GroovyLog {
 
     /**
      * Allows Groovy to use {@code log('text')} to print an info message by using Groovy's call operator overloading.
+     * <p>
+     * Should be avoided in Java code.
+     *
+     * @see #info(String, Object...)
      */
     default void call(String msg, Object... args) {
         info(msg, args);
@@ -64,6 +68,10 @@ public interface GroovyLog {
 
     /**
      * Allows Groovy to use {@code log('text')} to print an info message by using Groovy's call operator overloading.
+     * <p>
+     * Should be avoided in Java code.
+     *
+     * @see #info(Object)
      */
     default void call(Object obj) {
         info(obj);

--- a/src/main/java/com/cleanroommc/groovyscript/api/GroovyLog.java
+++ b/src/main/java/com/cleanroommc/groovyscript/api/GroovyLog.java
@@ -56,6 +56,20 @@ public interface GroovyLog {
     }
 
     /**
+     * Allows Groovy to use {@code log('text')} to print an info message by using Groovy's call operator overloading.
+     */
+    default void call(String msg, Object... args) {
+        info(msg, args);
+    }
+
+    /**
+     * Allows Groovy to use {@code log('text')} to print an info message by using Groovy's call operator overloading.
+     */
+    default void call(Object obj) {
+        info(obj);
+    }
+
+    /**
      * Determines whether debug messages should be ignored.
      *
      * @return true if messages on debug level should be logged


### PR DESCRIPTION
changes in this PR:
- add the ability to do `log('x')` as shorthand for `log.info('x')` via a new `call` method + groovy operator overloading. add examples of this to `postInit/custom/experiments.groovy`.
