### PR TITLE
Improve VanillaModule design

### DIFF
--- a/src/main/java/com/cleanroommc/groovyscript/GroovyScript.java
+++ b/src/main/java/com/cleanroommc/groovyscript/GroovyScript.java
@@ -191,7 +191,7 @@ public class GroovyScript {
     @Mod.EventHandler
     public void onServerLoad(FMLServerStartingEvent event) {
         event.registerServerCommand(new GSCommand());
-        VanillaModule.command.onStartServer(event.getServer());
+        VanillaModule.INSTANCE.command.onStartServer(event.getServer());
     }
 
     @SubscribeEvent

--- a/src/main/java/com/cleanroommc/groovyscript/command/GSCommand.java
+++ b/src/main/java/com/cleanroommc/groovyscript/command/GSCommand.java
@@ -61,7 +61,7 @@ public class GSCommand extends CommandTreeBase {
         addSubcommand(new InfoSelfCommand());
 
         addSubcommand(new SimpleCommand("applyDefaultGameRules", (server, sender, args) -> {
-            VanillaModule.gameRule.applyDefaultGameRules(Objects.requireNonNull(server.getServer()).getWorld(0).getGameRules());
+            VanillaModule.INSTANCE.gameRule.applyDefaultGameRules(Objects.requireNonNull(server.getServer()).getWorld(0).getGameRules());
             sender.sendMessage(new TextComponentString("Applied the default GameRules to the current world."));
         }));
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/content/GroovyBlock.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/content/GroovyBlock.java
@@ -98,8 +98,8 @@ public class GroovyBlock extends Block {
         setHardness(2.0F);
         setResistance(10.0F);
         setSoundType(SoundType.STONE);
-        if (VanillaModule.content.getDefaultTab() != null) {
-            setCreativeTab(VanillaModule.content.getDefaultTab());
+        if (VanillaModule.INSTANCE.content.getDefaultTab() != null) {
+            setCreativeTab(VanillaModule.INSTANCE.content.getDefaultTab());
         }
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/content/GroovyItem.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/content/GroovyItem.java
@@ -36,8 +36,8 @@ public class GroovyItem extends Item {
             GroovyLog.get().errorMC("Items must registered in preInit. Tried to register {} too late!", item.getRegistryName());
             return;
         }
-        if (item.getCreativeTab() == null && VanillaModule.content.getDefaultTab() != null) {
-            item.setCreativeTab(VanillaModule.content.getDefaultTab());
+        if (item.getCreativeTab() == null && VanillaModule.INSTANCE.content.getDefaultTab() != null) {
+            item.setCreativeTab(VanillaModule.INSTANCE.content.getDefaultTab());
         }
         ResourceLocation key = item.getRegistryName();
         if (key == null || ITEMS.containsKey(key.getPath())) {
@@ -77,8 +77,8 @@ public class GroovyItem extends Item {
 
     public GroovyItem(String loc) {
         setRegistryName(GroovyScript.getRunConfig().getPackId(), loc);
-        if (VanillaModule.content.getDefaultTab() != null) {
-            setCreativeTab(VanillaModule.content.getDefaultTab());
+        if (VanillaModule.INSTANCE.content.getDefaultTab() != null) {
+            setCreativeTab(VanillaModule.INSTANCE.content.getDefaultTab());
         }
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/Burning.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/Burning.java
@@ -110,7 +110,7 @@ public class Burning extends StandardListRegistry<Burning.BurningRecipe> {
         public @Nullable Burning.BurningRecipe register() {
             if (!validate()) return null;
             BurningRecipe burningRecipe = new BurningRecipe(this.input.get(0), this.output.get(0), this.ticks, this.startCondition);
-            VanillaModule.inWorldCrafting.burning.add(burningRecipe);
+            VanillaModule.INSTANCE.inWorldCrafting.burning.add(burningRecipe);
             return burningRecipe;
         }
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/Explosion.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/Explosion.java
@@ -133,7 +133,7 @@ public class Explosion extends StandardListRegistry<Explosion.ExplosionRecipe> {
         public @Nullable Explosion.ExplosionRecipe register() {
             if (!validate()) return null;
             ExplosionRecipe explosionRecipe = new ExplosionRecipe(this.input.get(0), this.output.get(0), this.chance, this.startCondition);
-            VanillaModule.inWorldCrafting.explosion.add(explosionRecipe);
+            VanillaModule.INSTANCE.inWorldCrafting.explosion.add(explosionRecipe);
             return explosionRecipe;
         }
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/FluidToBlock.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/FluidToBlock.java
@@ -146,7 +146,7 @@ public class FluidToBlock extends VirtualizedRegistry<FluidToBlock.Recipe> {
                     this.startCondition,
                     this.afterRecipe,
                     this.outputBlock);
-            VanillaModule.inWorldCrafting.fluidToBlock.add(recipe);
+            VanillaModule.INSTANCE.inWorldCrafting.fluidToBlock.add(recipe);
             return recipe;
         }
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/FluidToFluid.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/FluidToFluid.java
@@ -132,7 +132,7 @@ public class FluidToFluid extends VirtualizedRegistry<FluidToFluid.Recipe> {
                     this.startCondition,
                     this.afterRecipe,
                     this.fluidOutput.get(0).getFluid());
-            VanillaModule.inWorldCrafting.fluidToFluid.add(recipe);
+            VanillaModule.INSTANCE.inWorldCrafting.fluidToFluid.add(recipe);
             return recipe;
         }
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/FluidToItem.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/FluidToItem.java
@@ -157,7 +157,7 @@ public class FluidToItem extends VirtualizedRegistry<FluidToItem.Recipe> {
                     this.afterRecipe,
                     this.output.get(0),
                     this.fluidConsumptionChance);
-            VanillaModule.inWorldCrafting.fluidToItem.add(recipe);
+            VanillaModule.INSTANCE.inWorldCrafting.fluidToItem.add(recipe);
             return recipe;
         }
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/PistonPush.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/PistonPush.java
@@ -131,7 +131,7 @@ public class PistonPush extends StandardListRegistry<PistonPush.PistonPushRecipe
         public @Nullable PistonPush.PistonPushRecipe register() {
             if (!validate()) return null;
             PistonPushRecipe pistonPushRecipe = new PistonPushRecipe(this.input.get(0), this.output.get(0), this.maxConversionsPerPush, this.minHarvestLevel, this.startCondition);
-            VanillaModule.inWorldCrafting.pistonPush.add(pistonPushRecipe);
+            VanillaModule.INSTANCE.inWorldCrafting.pistonPush.add(pistonPushRecipe);
             return null;
         }
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/jei/InWorldCraftingJeiPlugin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/inworldcrafting/jei/InWorldCraftingJeiPlugin.java
@@ -38,8 +38,8 @@ public class InWorldCraftingJeiPlugin {
         List<FluidRecipeCategory.RecipeWrapper> recipeWrappers = new ArrayList<>();
         FluidRecipe.forEach(fluidRecipe -> recipeWrappers.add(new FluidRecipeCategory.RecipeWrapper(fluidRecipe)));
         registry.addRecipes(recipeWrappers, FluidRecipeCategory.UID);
-        registry.addRecipes(VanillaModule.inWorldCrafting.explosion.getRecipeWrappers(), ExplosionRecipeCategory.UID);
-        registry.addRecipes(VanillaModule.inWorldCrafting.burning.getRecipeWrappers(), BurningRecipeCategory.UID);
-        registry.addRecipes(VanillaModule.inWorldCrafting.pistonPush.getRecipeWrappers(), PistonPushRecipeCategory.UID);
+        registry.addRecipes(VanillaModule.INSTANCE.inWorldCrafting.explosion.getRecipeWrappers(), ExplosionRecipeCategory.UID);
+        registry.addRecipes(VanillaModule.INSTANCE.inWorldCrafting.burning.getRecipeWrappers(), BurningRecipeCategory.UID);
+        registry.addRecipes(VanillaModule.INSTANCE.inWorldCrafting.pistonPush.getRecipeWrappers(), PistonPushRecipeCategory.UID);
     }
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/loot/LootEntryBuilder.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/loot/LootEntryBuilder.java
@@ -316,9 +316,9 @@ public class LootEntryBuilder {
         if (quality < 0) out.add("quality < 0 may make the loot entry unable to be rolled");
 
         if (validateForRegister) {
-            if (tableName == null || VanillaModule.loot.tables.get(tableName) == null) out.add("No valid LootTable specified").error();
-            else if (poolName == null || poolName.isEmpty() || VanillaModule.loot.tables.get(tableName).getPool(poolName) == null) out.add("No valid LootPool specified").error();
-            else if (VanillaModule.loot.tables.get(tableName).getPool(poolName).getEntry(name) != null) out.add("Attempted to add duplicate entry " + name + " to " + tableName + " - " + poolName);
+            if (tableName == null || VanillaModule.INSTANCE.loot.tables.get(tableName) == null) out.add("No valid LootTable specified").error();
+            else if (poolName == null || poolName.isEmpty() || VanillaModule.INSTANCE.loot.tables.get(tableName).getPool(poolName) == null) out.add("No valid LootPool specified").error();
+            else if (VanillaModule.INSTANCE.loot.tables.get(tableName).getPool(poolName).getEntry(name) != null) out.add("Attempted to add duplicate entry " + name + " to " + tableName + " - " + poolName);
         }
 
         out.postIfNotEmpty();
@@ -332,7 +332,7 @@ public class LootEntryBuilder {
 
     public void register() {
         if (!validate(true)) return;
-        VanillaModule.loot.tables.get(tableName)
+        VanillaModule.INSTANCE.loot.tables.get(tableName)
                 .getPool(poolName)
                 .addEntry(new LootEntryItem(item, weight, quality, functions.toArray(new LootFunction[0]), conditions.toArray(new LootCondition[0]), name));
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/loot/LootPoolBuilder.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/loot/LootPoolBuilder.java
@@ -120,9 +120,9 @@ public class LootPoolBuilder {
     private boolean validate(boolean validateForRegister) {
         if (name == null || name.isEmpty()) out.add("No name provided").error();
         if (validateForRegister) {
-            if (tableName == null || !VanillaModule.loot.tables.containsKey(tableName)) out.add("No valid LootTable specified").error();
+            if (tableName == null || !VanillaModule.INSTANCE.loot.tables.containsKey(tableName)) out.add("No valid LootTable specified").error();
             else if (name == null || name.isEmpty()) out.add("LootPool must have a name specified with .name()").error();
-            else if (VanillaModule.loot.tables.get(tableName).getPool(name) != null) out.add("Attempted to add duplicate pool " + name + " to " + tableName).error();
+            else if (VanillaModule.INSTANCE.loot.tables.get(tableName).getPool(name) != null) out.add("Attempted to add duplicate pool " + name + " to " + tableName).error();
         }
         out.postIfNotEmpty();
         return out.getLevel() != Level.ERROR;
@@ -135,7 +135,7 @@ public class LootPoolBuilder {
 
     public void register() {
         if (!validate(true)) return;
-        VanillaModule.loot.tables.get(tableName)
+        VanillaModule.INSTANCE.loot.tables.get(tableName)
                 .addPool(
                         new LootPool(lootEntries.toArray(new LootEntry[0]), poolConditions.toArray(new LootCondition[0]), rolls, bonusRolls, name)
                 );

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/Ingredient.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/Ingredient.java
@@ -188,7 +188,7 @@ public class Ingredient extends VirtualizedRegistry<Void> {
             return;
         }
         hide(ingredient);
-        VanillaModule.crafting.removeByOutput(ingredient, false);
+        VanillaModule.INSTANCE.crafting.removeByOutput(ingredient, false);
     }
 
     @MethodDescription

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/arcane/ArcaneWorkbench.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/arcane/ArcaneWorkbench.java
@@ -32,7 +32,7 @@ public class ArcaneWorkbench extends NamedRegistry {
 
     @MethodDescription(example = @Example("item('thaumcraft:mechanism_simple')"))
     public void removeByOutput(IIngredient output) {
-        VanillaModule.crafting.removeByOutput(output, true);
+        VanillaModule.INSTANCE.crafting.removeByOutput(output, true);
     }
 
     @RecipeBuilderDescription(example = {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/Furnace.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/Furnace.java
@@ -226,7 +226,7 @@ public class Furnace extends VirtualizedRegistry<Furnace.Recipe> {
             Recipe recipe = null;
             for (ItemStack itemStack : input.get(0).getMatchingStacks()) {
                 recipe = new Recipe(itemStack, output.get(0), exp);
-                VanillaModule.furnace.add(recipe);
+                VanillaModule.INSTANCE.furnace.add(recipe);
             }
             return recipe;
         }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/ItemStackExpansion.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/ItemStackExpansion.java
@@ -8,16 +8,16 @@ import net.minecraft.util.text.TextFormatting;
 public class ItemStackExpansion {
 
     public static ItemStack setRarity(ItemStack self, TextFormatting color) {
-        VanillaModule.rarity.set(color, self);
+        VanillaModule.INSTANCE.rarity.set(color, self);
         return self;
     }
 
     public static void addOreDict(ItemStack self, OreDictIngredient ingredient) {
-        VanillaModule.oreDict.add(ingredient.getOreDict(), self);
+        VanillaModule.INSTANCE.oreDict.add(ingredient.getOreDict(), self);
     }
 
     public static void removeOreDict(ItemStack self, OreDictIngredient ingredient) {
-        VanillaModule.oreDict.remove(ingredient.getOreDict(), self);
+        VanillaModule.INSTANCE.oreDict.remove(ingredient.getOreDict(), self);
     }
 
     public static boolean leftShift(ItemStack self, IIngredient ingredient) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/VanillaModule.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/VanillaModule.java
@@ -45,14 +45,24 @@ public class VanillaModule extends GroovyPropertyContainer {
         globalBindings.add(gameRule);
     }
 
+    /**
+     * Add the given property to the vanilla container.
+     * Useful for mods which add additional support to a vanilla feature,
+     * such as enchanting or brewing.
+     * <p>
+     * In some specific situations the property is important enough
+     * that it should be registered as a global binding.
+     * While this can be done by calling
+     * {@link com.cleanroommc.groovyscript.sandbox.GroovyScriptSandbox#registerBinding(INamed) GroovyScriptSandbox#registerBinding}
+     * directly, for vanilla properties a boolean exists as a shorthand.
+     *
+     * @param property         the property being added to the vanilla container
+     * @param addGlobalBinding if the property will be registered as a global binding. Typically {@code false}.
+     * @see com.cleanroommc.groovyscript.sandbox.GroovyScriptSandbox#registerBinding(INamed) GroovyScriptSandbox#registerBinding
+     */
     public void addProperty(INamed property, boolean addGlobalBinding) {
         addProperty(property);
         if (addGlobalBinding) globalBindings.add(property);
-    }
-
-    @Override
-    public void addProperty(INamed property) {
-        super.addProperty(property);
     }
 
     @Override

--- a/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/VanillaModule.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/VanillaModule.java
@@ -32,17 +32,12 @@ public class VanillaModule extends GroovyPropertyContainer {
     private final List<INamed> globalBindings = new ArrayList<>();
 
     private VanillaModule() {
-        // maybe remove some of these as globals?
         globalBindings.add(crafting);
         globalBindings.add(furnace);
-        globalBindings.add(loot);
         globalBindings.add(oreDict);
         globalBindings.add(player);
         globalBindings.add(content);
-        globalBindings.add(rarity);
         globalBindings.add(inWorldCrafting);
-        globalBindings.add(command);
-        globalBindings.add(gameRule);
     }
 
     /**

--- a/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/VanillaModule.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/VanillaModule.java
@@ -35,7 +35,6 @@ public class VanillaModule extends GroovyPropertyContainer {
         globalBindings.add(crafting);
         globalBindings.add(furnace);
         globalBindings.add(oreDict);
-        globalBindings.add(player);
         globalBindings.add(content);
         globalBindings.add(inWorldCrafting);
     }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/VanillaModule.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/VanillaModule.java
@@ -45,6 +45,16 @@ public class VanillaModule extends GroovyPropertyContainer {
         globalBindings.add(gameRule);
     }
 
+    public void addProperty(INamed property, boolean addGlobalBinding) {
+        addProperty(property);
+        globalBindings.add(property);
+    }
+
+    @Override
+    public void addProperty(INamed property) {
+        super.addProperty(property);
+    }
+
     @Override
     public void initialize(GroovyContainer<?> owner) {
         GroovyScript.getSandbox().registerBinding("Minecraft", this);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/VanillaModule.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/VanillaModule.java
@@ -1,6 +1,7 @@
 package com.cleanroommc.groovyscript.compat.vanilla;
 
 import com.cleanroommc.groovyscript.GroovyScript;
+import com.cleanroommc.groovyscript.api.INamed;
 import com.cleanroommc.groovyscript.compat.content.Content;
 import com.cleanroommc.groovyscript.compat.inworldcrafting.InWorldCrafting;
 import com.cleanroommc.groovyscript.compat.loot.Loot;
@@ -9,6 +10,9 @@ import com.cleanroommc.groovyscript.compat.mods.GroovyPropertyContainer;
 import com.cleanroommc.groovyscript.sandbox.expand.ExpansionHelper;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.item.ItemStack;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class VanillaModule extends GroovyPropertyContainer {
 
@@ -25,23 +29,30 @@ public class VanillaModule extends GroovyPropertyContainer {
     public static final Command command = new Command();
     public static final GameRule gameRule = new GameRule();
 
-    private VanillaModule() {}
+    private final List<INamed> globalBindings = new ArrayList<>();
+
+    private VanillaModule() {
+        // maybe remove some of these as globals?
+        globalBindings.add(crafting);
+        globalBindings.add(furnace);
+        globalBindings.add(loot);
+        globalBindings.add(oreDict);
+        globalBindings.add(player);
+        globalBindings.add(content);
+        globalBindings.add(rarity);
+        globalBindings.add(inWorldCrafting);
+        globalBindings.add(command);
+        globalBindings.add(gameRule);
+    }
 
     @Override
     public void initialize(GroovyContainer<?> owner) {
         GroovyScript.getSandbox().registerBinding("Minecraft", this);
         GroovyScript.getSandbox().registerBinding("Vanilla", this);
-        // maybe remove some of these as globals?
-        GroovyScript.getSandbox().registerBinding(crafting);
-        GroovyScript.getSandbox().registerBinding(furnace);
-        GroovyScript.getSandbox().registerBinding(loot);
-        GroovyScript.getSandbox().registerBinding(oreDict);
-        GroovyScript.getSandbox().registerBinding(player);
-        GroovyScript.getSandbox().registerBinding(content);
-        GroovyScript.getSandbox().registerBinding(rarity);
-        GroovyScript.getSandbox().registerBinding(inWorldCrafting);
-        GroovyScript.getSandbox().registerBinding(command);
-        GroovyScript.getSandbox().registerBinding(gameRule);
+
+        for (INamed registry : globalBindings) {
+            GroovyScript.getSandbox().registerBinding(registry);
+        }
 
         ExpansionHelper.mixinClass(ItemStack.class, ItemStackExpansion.class);
         ExpansionHelper.mixinClass(ICommandSender.class, CommandSenderExpansion.class);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/VanillaModule.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/VanillaModule.java
@@ -47,7 +47,7 @@ public class VanillaModule extends GroovyPropertyContainer {
 
     public void addProperty(INamed property, boolean addGlobalBinding) {
         addProperty(property);
-        globalBindings.add(property);
+        if (addGlobalBinding) globalBindings.add(property);
     }
 
     @Override

--- a/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/VanillaModule.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/VanillaModule.java
@@ -18,16 +18,16 @@ public class VanillaModule extends GroovyPropertyContainer {
 
     public static final VanillaModule INSTANCE = new VanillaModule();
 
-    public static final Crafting crafting = new Crafting();
-    public static final Furnace furnace = new Furnace();
-    public static final Loot loot = new Loot();
-    public static final OreDict oreDict = new OreDict();
-    public static final Player player = new Player();
-    public static final Content content = new Content();
-    public static final Rarity rarity = new Rarity();
-    public static final InWorldCrafting inWorldCrafting = new InWorldCrafting();
-    public static final Command command = new Command();
-    public static final GameRule gameRule = new GameRule();
+    public final Crafting crafting = new Crafting();
+    public final Furnace furnace = new Furnace();
+    public final Loot loot = new Loot();
+    public final OreDict oreDict = new OreDict();
+    public final Player player = new Player();
+    public final Content content = new Content();
+    public final Rarity rarity = new Rarity();
+    public final InWorldCrafting inWorldCrafting = new InWorldCrafting();
+    public final Command command = new Command();
+    public final GameRule gameRule = new GameRule();
 
     private final List<INamed> globalBindings = new ArrayList<>();
 

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/EntityItemMixin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/EntityItemMixin.java
@@ -34,7 +34,7 @@ public abstract class EntityItemMixin extends Entity {
             }
 
             if (((EntityAccessor) thisEntity).getFire() > 0) {
-                VanillaModule.inWorldCrafting.burning.updateRecipeProgress(thisEntity);
+                VanillaModule.INSTANCE.inWorldCrafting.burning.updateRecipeProgress(thisEntity);
                 ci.cancel();
             } else if (Burning.removeBurningItem(thisEntity)) {
                 thisEntity.setEntityInvulnerable(false);

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/ItemMixin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/ItemMixin.java
@@ -15,6 +15,6 @@ public class ItemMixin {
 
     @Inject(method = "getForgeRarity", at = @At("HEAD"), cancellable = true, remap = false)
     private void prioritzeGSRarities(ItemStack stack, CallbackInfoReturnable<IRarity> cir) {
-        cir.setReturnValue(VanillaModule.rarity.check(stack));
+        cir.setReturnValue(VanillaModule.INSTANCE.rarity.check(stack));
     }
 }

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/TileEntityPistonMixin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/TileEntityPistonMixin.java
@@ -61,7 +61,7 @@ public abstract class TileEntityPistonMixin {
         Entity entity = list1.get(index);
         if (entity.getPushReaction() == EnumPushReaction.IGNORE) return;
         if (checkRecipes.get() && index < tryRecipesUntil.get() && entity instanceof EntityItem entityItem) {
-            VanillaModule.inWorldCrafting.pistonPush.findAndRunRecipe(entityItem1 -> {
+            VanillaModule.INSTANCE.inWorldCrafting.pistonPush.findAndRunRecipe(entityItem1 -> {
                 entityItem1.getEntityWorld().spawnEntity(entityItem1);
                 list1.add(entityItem1);
             }, entityItem, pushingAgainst.get());

--- a/src/main/java/com/cleanroommc/groovyscript/core/mixin/loot/LoadTableEventMixin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/core/mixin/loot/LoadTableEventMixin.java
@@ -23,7 +23,7 @@ public abstract class LoadTableEventMixin {
 
     @Inject(method = "reloadLootTables", at = @At("RETURN"))
     private void injection(CallbackInfo ci) {
-        VanillaModule.loot.tables.putAll(this.registeredLootTables.asMap());
+        VanillaModule.INSTANCE.loot.tables.putAll(this.registeredLootTables.asMap());
         MinecraftForge.EVENT_BUS.post(new LootTablesLoadedEvent());
     }
 }

--- a/src/main/java/com/cleanroommc/groovyscript/event/EventHandler.java
+++ b/src/main/java/com/cleanroommc/groovyscript/event/EventHandler.java
@@ -84,7 +84,7 @@ public class EventHandler {
     public static void createSpawnPosition(WorldEvent.CreateSpawnPosition event) {
         // only want to execute this for the overworld
         var target = DimensionManager.getWorld(0);
-        if (event.getWorld() == target) VanillaModule.gameRule.applyDefaultGameRules(event.getWorld().getGameRules());
+        if (event.getWorld() == target) VanillaModule.INSTANCE.gameRule.applyDefaultGameRules(event.getWorld().getGameRules());
     }
 
     @SubscribeEvent
@@ -113,8 +113,8 @@ public class EventHandler {
         if (tag.hasKey(EntityPlayer.PERSISTED_NBT_TAG)) {
             data = tag.getCompoundTag(EntityPlayer.PERSISTED_NBT_TAG);
         }
-        if (VanillaModule.player.isTestingStartingItems() || !data.getBoolean(Player.GIVEN_ITEMS)) {
-            VanillaModule.player.addToInventory(event.player.inventory);
+        if (VanillaModule.INSTANCE.player.isTestingStartingItems() || !data.getBoolean(Player.GIVEN_ITEMS)) {
+            VanillaModule.INSTANCE.player.addToInventory(event.player.inventory);
             data.setBoolean(Player.GIVEN_ITEMS, true);
             tag.setTag(EntityPlayer.PERSISTED_NBT_TAG, data);
         }
@@ -160,7 +160,7 @@ public class EventHandler {
     public static void onExplosion(ExplosionEvent.Detonate event) {
         for (Entity entity : event.getAffectedEntities()) {
             if (entity instanceof EntityItem entityItem) {
-                VanillaModule.inWorldCrafting.explosion.findAndRunRecipe(entityItem);
+                VanillaModule.INSTANCE.inWorldCrafting.explosion.findAndRunRecipe(entityItem);
             }
         }
     }

--- a/src/main/java/com/cleanroommc/groovyscript/event/LootTablesLoadedEvent.java
+++ b/src/main/java/com/cleanroommc/groovyscript/event/LootTablesLoadedEvent.java
@@ -24,7 +24,7 @@ public class LootTablesLoadedEvent extends Event {
         public static final LootTable EMPTY_LOOT_TABLE = new LootTable(new LootPool[0]);
 
         public LootTable getTable(ResourceLocation name) {
-            LootTable lootTable = VanillaModule.loot.tables.get(name);
+            LootTable lootTable = VanillaModule.INSTANCE.loot.tables.get(name);
             if (lootTable == null) GroovyLog.msg("GroovyScript found 0 LootTable(s) named " + name).post();
             return lootTable;
         }
@@ -43,20 +43,20 @@ public class LootTablesLoadedEvent extends Event {
 
         public void printTables() {
             GroovyLog.Msg out = GroovyLog.msg("GroovyScript found the following LootTable(s)");
-            VanillaModule.loot.tables.keySet().forEach(table -> out.add(table.toString()));
+            VanillaModule.INSTANCE.loot.tables.keySet().forEach(table -> out.add(table.toString()));
             if (!out.postIfNotEmpty())
                 GroovyLog.msg("GroovyScript found 0 LootTables :thonk:").error().post();
         }
 
         public void printPools() {
-            if (VanillaModule.loot.tables.values().isEmpty()) {
+            if (VanillaModule.INSTANCE.loot.tables.values().isEmpty()) {
                 GroovyLog.msg("GroovyScript found 0 LootTables :thonk:").error().post();
                 return;
             }
 
             GroovyLog.Msg out = GroovyLog.msg("GroovyScript found the following LootPools(s)");
 
-            VanillaModule.loot.tables.forEach((rl, table) -> {
+            VanillaModule.INSTANCE.loot.tables.forEach((rl, table) -> {
                 if (((LootTableAccessor) table).getPools() == null || ((LootTableAccessor) table).getPools().isEmpty()) {
                     return;
                 }
@@ -78,14 +78,14 @@ public class LootTablesLoadedEvent extends Event {
         }
 
         public void printEntries() {
-            if (VanillaModule.loot.tables.values().isEmpty()) {
+            if (VanillaModule.INSTANCE.loot.tables.values().isEmpty()) {
                 GroovyLog.msg("GroovyScript found 0 LootTables :thonk:").error().post();
                 return;
             }
 
             GroovyLog.Msg out = GroovyLog.msg("GroovyScript found the following LootEntries(s)");
 
-            VanillaModule.loot.tables.forEach((rl, table) -> {
+            VanillaModule.INSTANCE.loot.tables.forEach((rl, table) -> {
                 if (((LootTableAccessor) table).getPools() == null || ((LootTableAccessor) table).getPools().isEmpty()) {
                     return;
                 }

--- a/src/main/java/com/cleanroommc/groovyscript/helper/ingredient/OreDictIngredient.java
+++ b/src/main/java/com/cleanroommc/groovyscript/helper/ingredient/OreDictIngredient.java
@@ -113,7 +113,7 @@ public class OreDictIngredient extends IngredientBase implements Iterable<ItemSt
     }
 
     public void add(ItemStack itemStack) {
-        VanillaModule.oreDict.add(this.oreDict, itemStack);
+        VanillaModule.INSTANCE.oreDict.add(this.oreDict, itemStack);
     }
 
     public void add(ItemStack... itemStacks) {
@@ -133,7 +133,7 @@ public class OreDictIngredient extends IngredientBase implements Iterable<ItemSt
     }
 
     public void remove(ItemStack itemStack) {
-        VanillaModule.oreDict.remove(this.oreDict, itemStack);
+        VanillaModule.INSTANCE.oreDict.remove(this.oreDict, itemStack);
     }
 
     public void remove(ItemStack... itemStacks) {

--- a/src/main/java/com/cleanroommc/groovyscript/registry/AbstractCraftingRecipeBuilder.java
+++ b/src/main/java/com/cleanroommc/groovyscript/registry/AbstractCraftingRecipeBuilder.java
@@ -119,7 +119,7 @@ public abstract class AbstractCraftingRecipeBuilder<R> {
     @GroovyBlacklist
     protected void handleReplace() {
         if (replace == 1) {
-            VanillaModule.crafting.removeByOutput(IngredientHelper.toIIngredient(output), false);
+            VanillaModule.INSTANCE.crafting.removeByOutput(IngredientHelper.toIIngredient(output), false);
         } else if (replace == 2) {
             if (name == null) {
                 GroovyLog.msg("Error replacing Minecraft Crafting recipe")


### PR DESCRIPTION
changes in this PR:
- make the currently `static` property fields of `VanillaModule` non-static.
- convert the properties added as global bindings to a list.
- remove some global bindings - specifically `player`, `loot`, `rarity`, `command`, and `gameRule`. 
- create a way to add additional properties to the `VanillaModule`, include a shorthand way to make it a global binding (relevant for mods that add functionality involving vanilla features).


