### PR TITLE
Fix constant crash when cache always disabled

### DIFF
--- a/src/main/java/com/cleanroommc/groovyscript/sandbox/CustomGroovyScriptEngine.java
+++ b/src/main/java/com/cleanroommc/groovyscript/sandbox/CustomGroovyScriptEngine.java
@@ -171,7 +171,7 @@ public class CustomGroovyScriptEngine implements ResourceConnector {
         this.loadedClasses.clear();
         getClassLoader().clearCache();
         try {
-            FileUtils.cleanDirectory(this.cacheRoot);
+            if (this.cacheRoot.exists()) FileUtils.cleanDirectory(this.cacheRoot);
             return true;
         } catch (IOException e) {
             GroovyScript.LOGGER.throwing(e);


### PR DESCRIPTION
changes in this PR:
- check if cache exists before cleaning. 

if delete cache on run is enabled, it will attempt to delete everything in the cache. if the cache is always disabled, the folder will never be created. if both are true, this will cause an `IllegalArgumentException`.