### PR TITLE
Fix Player Inventory Priority

### DIFF
--- a/src/main/java/com/cleanroommc/groovyscript/event/EventHandler.java
+++ b/src/main/java/com/cleanroommc/groovyscript/event/EventHandler.java
@@ -106,7 +106,10 @@ public class EventHandler {
                 NetworkHandler.sendToPlayer(new SReloadScripts(null, true, true), (EntityPlayerMP) event.player);
             }
         }
+    }
 
+    @SubscribeEvent(priority = EventPriority.LOWEST)
+    public static void playerLoginStarterItems(PlayerEvent.PlayerLoggedInEvent event) {
         // give starter items to player
         NBTTagCompound tag = event.player.getEntityData();
         NBTTagCompound data = new NBTTagCompound();


### PR DESCRIPTION
changes in this PR:
- split login event to have inventory logic be on `EventPriority.LOWEST` to allow clearing the inventory to work correctly