### PR TITLE
Filter Completions from Object Mappers

### DIFF
--- a/src/main/java/net/prominic/groovyls/providers/CompletionProvider.java
+++ b/src/main/java/net/prominic/groovyls/providers/CompletionProvider.java
@@ -47,6 +47,7 @@ import org.jetbrains.annotations.NotNull;
 import java.net.URI;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 
 public class CompletionProvider extends DocProvider {
 
@@ -197,7 +198,13 @@ public class CompletionProvider extends DocProvider {
                             break;
                         }
                     }
-                    mapper.provideCompletion(index, params, items);
+
+                    // Provide int max completions, then filter
+                    var temp = new Completions(Integer.MAX_VALUE);
+                    mapper.provideCompletion(index, params, temp);
+
+                    temp.removeIf(item -> !item.getLabel().toLowerCase(Locale.ENGLISH).contains(node.getText().toLowerCase(Locale.ENGLISH)));
+                    items.addAll(temp, Function.identity());
                 }
             }
             return false; // don't complete keyword in strings


### PR DESCRIPTION
This PR filters the completions coming from object mappers, so only the ones relevant are sent over lsp.

No APIs have been changed, so no incompatibilities should have been created.

This allows, for example, completion of `item(` mapper for items from mods with a modid lower in the alphabet in large modpacks.