### PR TITLE
Document Steam Dynamo fallback calculation

### DIFF
--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Steam.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/dynamo/Steam.java
@@ -3,6 +3,7 @@ package com.cleanroommc.groovyscript.compat.mods.thermalexpansion.dynamo;
 import cofh.core.inventory.ComparableItemStack;
 import com.cleanroommc.groovyscript.api.GroovyBlacklist;
 import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.Admonition;
 import com.cleanroommc.groovyscript.api.documentation.annotations.Example;
 import com.cleanroommc.groovyscript.api.documentation.annotations.MethodDescription;
 import com.cleanroommc.groovyscript.api.documentation.annotations.RegistryDescription;
@@ -14,7 +15,7 @@ import org.jetbrains.annotations.ApiStatus;
 
 import java.util.Objects;
 
-@RegistryDescription
+@RegistryDescription(admonition = @Admonition(value = "groovyscript.wiki.thermalexpansion.steam.note0", type = Admonition.Type.INFO))
 public class Steam extends VirtualizedRegistry<Steam.SteamRecipe> {
 
     @Override

--- a/src/main/resources/assets/groovyscript/lang/en_us.lang
+++ b/src/main/resources/assets/groovyscript/lang/en_us.lang
@@ -2965,6 +2965,7 @@ groovyscript.wiki.thermalexpansion.smelter.chance.value=Sets the chance the seco
 
 groovyscript.wiki.thermalexpansion.steam.title=Steam Dynamo
 groovyscript.wiki.thermalexpansion.steam.description=Converts an input itemstack into power, taking time based on the power.
+groovyscript.wiki.thermalexpansion.steam.note0=If no energy is provided from an itemstack, the furnace fuel burn time will be checked, with the time in ticks being multiplied by 10 to calculate the energy output and if the energy is over 3000 the itemstack will be a valid fuel.
 groovyscript.wiki.thermalexpansion.steam.add=Adds recipes in the format `itemStack`, `energy`
 groovyscript.wiki.thermalexpansion.steam.removeByInput=Removes all recipes with given IIngredient
 


### PR DESCRIPTION
changes in this PR:
- thermal expansion steam dynamo uses the furnace as a fallback - note this for the wiki

related to #336