### PR TITLE
Remove unneeded SimpleObjectStream copying

### DIFF
--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/starlightaltar/StarlightAltar.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/astralsorcery/starlightaltar/StarlightAltar.java
@@ -94,7 +94,7 @@ public class StarlightAltar extends VirtualizedRegistry<AbstractAltarRecipe> {
 
     @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<AbstractAltarRecipe> streamRecipes() {
-        return new SimpleObjectStream<>(AltarRecipeRegistry.recipes.entrySet().stream().flatMap(r -> r.getValue().stream()).collect(Collectors.toList()))
+        return new SimpleObjectStream<>(AltarRecipeRegistry.recipes.entrySet().stream().flatMap(r -> r.getValue().stream()).collect(Collectors.toList()), false)
                 .setRemover(this::remove);
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/AlloySmelter.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/AlloySmelter.java
@@ -152,7 +152,7 @@ public class AlloySmelter extends VirtualizedRegistry<IManyToOneRecipe> {
                 .filter(r -> r instanceof IManyToOneRecipe)
                 .map(r -> (IManyToOneRecipe) r)
                 .collect(Collectors.toList());
-        return new SimpleObjectStream<>(list)
+        return new SimpleObjectStream<>(list, false)
                 .setRemover(this::remove);
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/Tank.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/Tank.java
@@ -189,7 +189,7 @@ public class Tank extends VirtualizedRegistry<TankMachineRecipe> {
         List<TankMachineRecipe> list = new ArrayList<>();
         list.addAll((Collection<? extends TankMachineRecipe>) MachineRecipeRegistry.instance.getRecipesForMachine(MachineRecipeRegistry.TANK_FILLING).values());
         list.addAll((Collection<? extends TankMachineRecipe>) MachineRecipeRegistry.instance.getRecipesForMachine(MachineRecipeRegistry.TANK_EMPTYING).values());
-        return new SimpleObjectStream<>(list).setRemover(this::remove);
+        return new SimpleObjectStream<>(list, false).setRemover(this::remove);
     }
 
     @MethodDescription(priority = 2000, example = @Example(commented = true))

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/Vat.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/enderio/Vat.java
@@ -77,7 +77,7 @@ public class Vat extends VirtualizedRegistry<VatRecipe> {
 
     @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<VatRecipe> streamRecipes() {
-        return new SimpleObjectStream<>(VatRecipeManager.getInstance().getRecipes().stream().map(r -> (VatRecipe) r).collect(Collectors.toList()))
+        return new SimpleObjectStream<>(VatRecipeManager.getInstance().getRecipes().stream().map(r -> (VatRecipe) r).collect(Collectors.toList()), false)
                 .setRemover(this::remove);
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/extrautils2/Crusher.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/extrautils2/Crusher.java
@@ -61,7 +61,7 @@ public class Crusher extends VirtualizedRegistry<IMachineRecipe> {
         for (IMachineRecipe recipe : XUMachineCrusher.INSTANCE.recipes_registry) {
             list.add(recipe);
         }
-        return new SimpleObjectStream<>(list).setRemover(this::remove);
+        return new SimpleObjectStream<>(list, false).setRemover(this::remove);
     }
 
     @MethodDescription(priority = 2000, example = @Example(commented = true))

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/extrautils2/Enchanter.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/extrautils2/Enchanter.java
@@ -60,7 +60,7 @@ public class Enchanter extends VirtualizedRegistry<IMachineRecipe> {
         for (IMachineRecipe recipe : XUMachineEnchanter.INSTANCE.recipes_registry) {
             list.add(recipe);
         }
-        return new SimpleObjectStream<>(list).setRemover(this::remove);
+        return new SimpleObjectStream<>(list, false).setRemover(this::remove);
     }
 
     @MethodDescription(priority = 2000, example = @Example(commented = true))

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/extrautils2/Furnace.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/extrautils2/Furnace.java
@@ -66,7 +66,7 @@ public class Furnace extends VirtualizedRegistry<IMachineRecipe> {
         for (IMachineRecipe recipe : XUMachineFurnace.INSTANCE.recipes_registry) {
             list.add(recipe);
         }
-        return new SimpleObjectStream<>(list).setRemover(this::remove);
+        return new SimpleObjectStream<>(list, false).setRemover(this::remove);
     }
 
     @MethodDescription(priority = 2000, example = @Example(commented = true))

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/extrautils2/Generator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/extrautils2/Generator.java
@@ -152,7 +152,7 @@ public class Generator extends VirtualizedRegistry<Pair<Machine, IMachineRecipe>
                 list.add(Pair.of(generator, recipe));
             }
         }
-        return new SimpleObjectStream<>(list).setRemover(x -> x.getKey().recipes_registry.removeRecipe(x.getValue()));
+        return new SimpleObjectStream<>(list, false).setRemover(x -> x.getKey().recipes_registry.removeRecipe(x.getValue()));
     }
 
     @MethodDescription(description = "groovyscript.wiki.extrautils2.generator.removeByGenerator")

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/Centrifuge.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/Centrifuge.java
@@ -102,7 +102,7 @@ public class Centrifuge extends VirtualizedRegistry<MachineRecipe<IRecipeInput, 
     }
 
     public SimpleObjectStream<MachineRecipe<IRecipeInput, Collection<ItemStack>>> streamRecipes() {
-        return new SimpleObjectStream<>(asList()).setRemover(this::remove);
+        return new SimpleObjectStream<>(asList(), false).setRemover(this::remove);
     }
 
     private boolean remove(MachineRecipe<IRecipeInput, Collection<ItemStack>> recipe, boolean backup) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/MetalFormer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/MetalFormer.java
@@ -39,11 +39,11 @@ public class MetalFormer extends VirtualizedRegistry<MetalFormer.MetalFormerReci
     }
 
     public SimpleObjectStream<MachineRecipe<IRecipeInput, Collection<ItemStack>>> streamRecipes() {
-        return new SimpleObjectStream<>(asList()).setRemover(this::remove);
+        return new SimpleObjectStream<>(asList(), false).setRemover(this::remove);
     }
 
     public SimpleObjectStream<MachineRecipe<IRecipeInput, Collection<ItemStack>>> streamRecipes(int type) {
-        return new SimpleObjectStream<>(asList(type)).setRemover(r -> this.remove(type, r));
+        return new SimpleObjectStream<>(asList(type), false).setRemover(r -> this.remove(type, r));
     }
 
     public boolean remove(int type, MachineRecipe<IRecipeInput, Collection<ItemStack>> recipe) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/OreWasher.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/OreWasher.java
@@ -46,7 +46,7 @@ public class OreWasher extends VirtualizedRegistry<MachineRecipe<IRecipeInput, C
     }
 
     public SimpleObjectStream<MachineRecipe<IRecipeInput, Collection<ItemStack>>> streamRecipes() {
-        return new SimpleObjectStream<>(asList()).setRemover(this::remove);
+        return new SimpleObjectStream<>(asList(), false).setRemover(this::remove);
     }
 
     public boolean remove(MachineRecipe<IRecipeInput, Collection<ItemStack>> recipe) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/exp/BlastFurnace.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/exp/BlastFurnace.java
@@ -57,7 +57,7 @@ public class BlastFurnace extends VirtualizedRegistry<MachineRecipe<IRecipeInput
     }
 
     public SimpleObjectStream<MachineRecipe<IRecipeInput, Collection<ItemStack>>> streamRecipes() {
-        return new SimpleObjectStream<>(asList()).setRemover(this::remove);
+        return new SimpleObjectStream<>(asList(), false).setRemover(this::remove);
     }
 
     public boolean remove(MachineRecipe<IRecipeInput, Collection<ItemStack>> recipe) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/exp/BlockCutter.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/exp/BlockCutter.java
@@ -44,7 +44,7 @@ public class BlockCutter extends VirtualizedRegistry<MachineRecipe<IRecipeInput,
     }
 
     public SimpleObjectStream<MachineRecipe<IRecipeInput, Collection<ItemStack>>> streamRecipes() {
-        return new SimpleObjectStream<>(asList()).setRemover(this::remove);
+        return new SimpleObjectStream<>(asList(), false).setRemover(this::remove);
     }
 
     public boolean remove(MachineRecipe<IRecipeInput, Collection<ItemStack>> recipe) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/exp/Compressor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/exp/Compressor.java
@@ -53,7 +53,7 @@ public class Compressor extends VirtualizedRegistry<MachineRecipe<IRecipeInput, 
     }
 
     public SimpleObjectStream<MachineRecipe<IRecipeInput, Collection<ItemStack>>> streamRecipes() {
-        return new SimpleObjectStream<>(asList()).setRemover(this::remove);
+        return new SimpleObjectStream<>(asList(), false).setRemover(this::remove);
     }
 
     public boolean remove(MachineRecipe<IRecipeInput, Collection<ItemStack>> recipe) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/exp/Extractor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/exp/Extractor.java
@@ -53,7 +53,7 @@ public class Extractor extends VirtualizedRegistry<MachineRecipe<IRecipeInput, C
     }
 
     public SimpleObjectStream<MachineRecipe<IRecipeInput, Collection<ItemStack>>> streamRecipes() {
-        return new SimpleObjectStream<>(asList()).setRemover(this::remove);
+        return new SimpleObjectStream<>(asList(), false).setRemover(this::remove);
     }
 
     public boolean remove(MachineRecipe<IRecipeInput, Collection<ItemStack>> recipe) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/exp/FluidCanner.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/exp/FluidCanner.java
@@ -58,7 +58,7 @@ public class FluidCanner extends VirtualizedRegistry<MachineRecipe<ICannerEnrich
     }
 
     public SimpleObjectStream<MachineRecipe<ICannerEnrichRecipeManager.Input, FluidStack>> streamRecipes() {
-        return new SimpleObjectStream<>(asList()).setRemover(this::remove);
+        return new SimpleObjectStream<>(asList(), false).setRemover(this::remove);
     }
 
     public boolean remove(MachineRecipe<ICannerEnrichRecipeManager.Input, FluidStack> recipe) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/exp/Macerator.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/exp/Macerator.java
@@ -53,7 +53,7 @@ public class Macerator extends VirtualizedRegistry<MachineRecipe<IRecipeInput, C
     }
 
     public SimpleObjectStream<MachineRecipe<IRecipeInput, Collection<ItemStack>>> streamRecipes() {
-        return new SimpleObjectStream<>(asList()).setRemover(this::remove);
+        return new SimpleObjectStream<>(asList(), false).setRemover(this::remove);
     }
 
     public boolean remove(MachineRecipe<IRecipeInput, Collection<ItemStack>> recipe) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/exp/SolidCanner.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/ic2/exp/SolidCanner.java
@@ -57,7 +57,7 @@ public class SolidCanner extends VirtualizedRegistry<MachineRecipe<ICannerBottle
     }
 
     public SimpleObjectStream<MachineRecipe<ICannerBottleRecipeManager.Input, ItemStack>> streamRecipes() {
-        return new SimpleObjectStream<>(asList()).setRemover(this::remove);
+        return new SimpleObjectStream<>(asList(), false).setRemover(this::remove);
     }
 
     public boolean remove(MachineRecipe<ICannerBottleRecipeManager.Input, ItemStack> recipe) {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/MetalPress.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/immersiveengineering/MetalPress.java
@@ -177,7 +177,7 @@ public class MetalPress extends VirtualizedRegistry<MetalPressRecipe> {
     @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<MetalPressRecipe> streamRecipes() {
         List<MetalPressRecipe> recipes = new ArrayList<>(MetalPressRecipe.recipeList.values());
-        return new SimpleObjectStream<>(recipes).setRemover(this::remove);
+        return new SimpleObjectStream<>(recipes, false).setRemover(this::remove);
     }
 
     @Property(property = "input", comp = @Comp(eq = 1))

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/pneumaticcraft/Amadron.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/pneumaticcraft/Amadron.java
@@ -133,7 +133,7 @@ public class Amadron extends VirtualizedRegistry<AmadronOffer> {
         List<AmadronOffer> list = new ArrayList<>();
         list.addAll(AmadronOfferManager.getInstance().getStaticOffers());
         list.addAll(AmadronOfferManager.getInstance().getPeriodicOffers());
-        return new SimpleObjectStream<>(list).setRemover(this::removeStatic);
+        return new SimpleObjectStream<>(list, false).setRemover(this::removeStatic);
     }
 
     @Property(property = "input", comp = @Comp(gte = 0, lte = 1))

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/pneumaticcraft/AssemblyController.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/pneumaticcraft/AssemblyController.java
@@ -126,7 +126,7 @@ public class AssemblyController extends VirtualizedRegistry<AssemblyRecipe> {
 
     @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<AssemblyRecipe> streamRecipes() {
-        return new SimpleObjectStream<>(Arrays.stream(AssemblyType.values()).map(this::map).flatMap(Collection::stream).collect(Collectors.toList()))
+        return new SimpleObjectStream<>(Arrays.stream(AssemblyType.values()).map(this::map).flatMap(Collection::stream).collect(Collectors.toList()), false)
                 .setRemover(this::remove);
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/prodigytech/PrimordialisReactor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/prodigytech/PrimordialisReactor.java
@@ -85,6 +85,6 @@ public class PrimordialisReactor extends VirtualizedRegistry<IIngredient> {
                 .stream()
                 .map(OreDictIngredient::new);
         List<IIngredient> items = Stream.concat(normalRecipes, oreDictRecipes).collect(Collectors.toList());
-        return new SimpleObjectStream<>(items).setRemover(this::remove);
+        return new SimpleObjectStream<>(items, false).setRemover(this::remove);
     }
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/Crucible.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/Crucible.java
@@ -107,7 +107,7 @@ public class Crucible extends VirtualizedRegistry<CrucibleRecipe> {
     @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<Map.Entry<ResourceLocation, IThaumcraftRecipe>> streamRecipes() {
         List<Map.Entry<ResourceLocation, IThaumcraftRecipe>> recipes = ThaumcraftApi.getCraftingRecipes().entrySet().stream().filter(x -> x.getValue() instanceof CrucibleRecipe).collect(Collectors.toList());
-        return new SimpleObjectStream<>(recipes)
+        return new SimpleObjectStream<>(recipes, false)
                 .setRemover(x -> remove((CrucibleRecipe) x));
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/InfusionCrafting.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thaumcraft/InfusionCrafting.java
@@ -113,7 +113,7 @@ public class InfusionCrafting extends VirtualizedRegistry<Pair<ResourceLocation,
     @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<Map.Entry<ResourceLocation, IThaumcraftRecipe>> streamRecipes() {
         List<Map.Entry<ResourceLocation, IThaumcraftRecipe>> recipes = ThaumcraftApi.getCraftingRecipes().entrySet().stream().filter(x -> x.getValue() instanceof InfusionRecipe).collect(Collectors.toList());
-        return new SimpleObjectStream<>(recipes)
+        return new SimpleObjectStream<>(recipes, false)
                 .setRemover(x -> remove((InfusionRecipe) x.getValue()));
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/Diffuser.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/Diffuser.java
@@ -76,7 +76,7 @@ public class Diffuser extends VirtualizedRegistry<Diffuser.DiffuserRecipe> {
                 .filter(DiffuserManagerAccessor.getReagentDurMap()::containsKey)
                 .map(DiffuserRecipe::new)
                 .collect(Collectors.toList());
-        return new SimpleObjectStream<>(list).setRemover(this::remove);
+        return new SimpleObjectStream<>(list, false).setRemover(this::remove);
     }
 
     @MethodDescription(priority = 2000, example = @Example(commented = true))

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/Factorizer.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/Factorizer.java
@@ -121,7 +121,7 @@ public class Factorizer extends VirtualizedRegistry<Pair<Boolean, FactorizerMana
 
     @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<FactorizerManager.FactorizerRecipe> streamRecipes() {
-        return new SimpleObjectStream<>(Booleans.asList(true, false).stream().map(this::map).map(Map::values).flatMap(Collection::stream).collect(Collectors.toList()))
+        return new SimpleObjectStream<>(Booleans.asList(true, false).stream().map(this::map).map(Map::values).flatMap(Collection::stream).collect(Collectors.toList()), false)
                 .setRemover(this::remove);
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/Tapper.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/device/Tapper.java
@@ -125,13 +125,13 @@ public class Tapper extends VirtualizedRegistry<Tapper.TapperItemRecipe> {
 
     @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<TapperItemRecipe> streamRecipes() {
-        return new SimpleObjectStream<>(TapperManagerAccessor.getItemMap().entrySet().stream().map(x -> new TapperItemRecipe(x.getKey(), x.getValue())).collect(Collectors.toList()))
+        return new SimpleObjectStream<>(TapperManagerAccessor.getItemMap().entrySet().stream().map(x -> new TapperItemRecipe(x.getKey(), x.getValue())).collect(Collectors.toList()), false)
                 .setRemover(this::removeItem);
     }
 
     @MethodDescription(description = "groovyscript.wiki.streamRecipes", type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<TapperBlockRecipe> streamBlockRecipes() {
-        return new SimpleObjectStream<>(TapperManagerAccessor.getBlockMap().entrySet().stream().map(x -> new TapperBlockRecipe(x.getKey(), x.getValue())).collect(Collectors.toList()))
+        return new SimpleObjectStream<>(TapperManagerAccessor.getBlockMap().entrySet().stream().map(x -> new TapperBlockRecipe(x.getKey(), x.getValue())).collect(Collectors.toList()), false)
                 .setRemover(this::removeBlock);
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/machine/Compactor.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/machine/Compactor.java
@@ -129,7 +129,7 @@ public class Compactor extends VirtualizedRegistry<Pair<CompactorManager.Mode, C
 
     @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<CompactorRecipe> streamRecipes() {
-        return new SimpleObjectStream<>(Arrays.stream(CompactorManager.Mode.values()).map(this::map).map(Map::values).flatMap(Collection::stream).collect(Collectors.toList()))
+        return new SimpleObjectStream<>(Arrays.stream(CompactorManager.Mode.values()).map(this::map).map(Map::values).flatMap(Collection::stream).collect(Collectors.toList()), false)
                 .setRemover(this::remove);
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/machine/Extruder.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/thermalexpansion/machine/Extruder.java
@@ -137,7 +137,7 @@ public class Extruder extends VirtualizedRegistry<Pair<Boolean, ExtruderRecipe>>
 
     @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<ExtruderRecipe> streamRecipes() {
-        return new SimpleObjectStream<>(Booleans.asList(true, false).stream().map(this::map).map(Map::values).flatMap(Collection::stream).collect(Collectors.toList()))
+        return new SimpleObjectStream<>(Booleans.asList(true, false).stream().map(this::map).map(Map::values).flatMap(Collection::stream).collect(Collectors.toList()), false)
                 .setRemover(this::remove);
     }
 

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/tinkersconstruct/EntityMelting.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/tinkersconstruct/EntityMelting.java
@@ -95,7 +95,7 @@ public class EntityMelting extends VirtualizedRegistry<EntityMeltingRecipe> {
 
     @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<EntityMeltingRecipe> streamRecipes() {
-        return new SimpleObjectStream<>(getAllRecipes()).setRemover(this::remove);
+        return new SimpleObjectStream<>(getAllRecipes(), false).setRemover(this::remove);
     }
 
     public class RecipeBuilder implements IRecipeBuilder<EntityMeltingRecipe> {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/tinkersconstruct/SmelteryFuel.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/tinkersconstruct/SmelteryFuel.java
@@ -85,6 +85,6 @@ public class SmelteryFuel extends VirtualizedRegistry<SmelteryFuelRecipe> {
 
     @MethodDescription(type = MethodDescription.Type.QUERY)
     public SimpleObjectStream<SmelteryFuelRecipe> streamRecipes() {
-        return new SimpleObjectStream<>(getAllRecipes()).setRemover(this::remove);
+        return new SimpleObjectStream<>(getAllRecipes(), false).setRemover(this::remove);
     }
 }


### PR DESCRIPTION
changes in this PR:
- if we just created a list, we dont need to copy it for the SOS. prior to this PR, not copying the list was used in only two places - now its used in 33.