### PR TITLE
Disable Furnace Logging

### DIFF
--- a/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/Furnace.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/Furnace.java
@@ -6,7 +6,6 @@ import com.cleanroommc.groovyscript.api.IIngredient;
 import com.cleanroommc.groovyscript.api.documentation.annotations.*;
 import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
 import com.cleanroommc.groovyscript.helper.ingredient.GroovyScriptCodeConverter;
-import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
 import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
 import com.cleanroommc.groovyscript.registry.AbstractReloadableStorage;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
@@ -65,12 +64,6 @@ public class Furnace extends VirtualizedRegistry<Furnace.Recipe> {
 
     @MethodDescription(example = @Example("item('minecraft:clay:*')"))
     public boolean removeByInput(IIngredient input) {
-        if (GroovyLog.msg("Error adding Minecraft Furnace recipe")
-                .add(IngredientHelper.isEmpty(input), () -> "Input must not be empty")
-                .error()
-                .postIfNotEmpty()) {
-            return false;
-        }
         if (FurnaceRecipes.instance().getSmeltingList().entrySet().removeIf(entry -> {
             if (input.test(entry.getKey())) {
                 addBackup(Recipe.of(entry.getKey(), entry.getValue()));
@@ -96,26 +89,13 @@ public class Furnace extends VirtualizedRegistry<Furnace.Recipe> {
 
     @MethodDescription(example = @Example("item('minecraft:brick')"))
     public boolean removeByOutput(IIngredient output) {
-        if (GroovyLog.msg("Error adding Minecraft Furnace recipe")
-                .add(IngredientHelper.isEmpty(output), () -> "Output must not be empty")
-                .error()
-                .postIfNotEmpty()) {
-            return false;
-        }
-        if (FurnaceRecipes.instance().getSmeltingList().entrySet().removeIf(entry -> {
+        return FurnaceRecipes.instance().getSmeltingList().entrySet().removeIf(entry -> {
             if (output.test(entry.getValue())) {
                 addBackup(Recipe.of(entry.getKey(), entry.getValue()));
                 return true;
             }
             return false;
-        })) {
-            return true;
-        }
-        GroovyLog.msg("Error removing Minecraft Furnace recipe")
-                .add("Can't find recipe for output " + output)
-                .error()
-                .post();
-        return false;
+        });
     }
 
     @MethodDescription(type = MethodDescription.Type.QUERY)


### PR DESCRIPTION
changes in this PR:
- remove the logging messages for empty or missed recipes from the Vanilla Furnace.
- make the wildcard suggestion only log on the debug channel, and give suggestion for it.


resolve #360