### PR TITLE
Fix ItemStack Matcher

### DIFF
--- a/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/ItemStackMixinExpansion.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/ItemStackMixinExpansion.java
@@ -66,7 +66,7 @@ public interface ItemStackMixinExpansion extends IIngredient, INbtIngredient {
 
     @Override
     default boolean test(ItemStack stack) {
-        if (!OreDictionary.itemMatches(grs$getItemStack(), stack, false) && (grs$getMatcher() == null || !grs$getMatcher().test(stack))) {
+        if (!OreDictionary.itemMatches(grs$getItemStack(), stack, false) || (grs$getMatcher() != null && !grs$getMatcher().test(stack))) {
             return false;
         }
         if (grs$getNbtMatcher() != null) {


### PR DESCRIPTION
This PR fixes the logic behind ingredient matching of an ItemStack that contains a `matcher`: e.g. one that had either `whenNoNbt` or `whenAnyNbt` called on it.

The previous logic led to some serious downfalls. As an example, consider the recipe
```groovy
crafting.shapedBuilder()
    .output(item('minecraft:stick') * 4)
    .matrix('B', 'B')
    .key('B', item('minecraft:enchanted_book').whenNoNbt())
    .register()
```

The previous logic causes success *as long as* the stack matches item/meta, thus the no nbt condition is ignored. Furthermore, if we place one item in, the recipe instantly triggers, ignoring the requirement of the second book, for if the matcher is set, as long as the matcher returns valid (which only checks tag), then the logic causes success.

This PR fixes this, making sure both item stack item/meta and matcher are checked. The changes were checked with a matcher set (e.g. above recipe) and ingredients in recipes without matchers set.