### PR TITLE
Consistently Capitalize as `blockMaterial`

### DIFF
--- a/examples/postInit/generated/erebus_generated.groovy
+++ b/examples/postInit/generated/erebus_generated.groovy
@@ -9,14 +9,14 @@ log 'mod \'erebus\' detected, running script'
 // any Blocks using the valid Materials to be converted, and the Registry contains any valid ItemStacks. The conversion
 // takes 10 seconds, and is fueled by erebus wall plants.
 
-mods.erebus.composter.removeFromMaterial(blockmaterial('sponge'))
+mods.erebus.composter.removeFromMaterial(blockMaterial('sponge'))
 mods.erebus.composter.removeFromRegistry(item('minecraft:stick'))
 // mods.erebus.composter.removeFromBlacklist(item('erebus:wall_plants', 1))
 // mods.erebus.composter.removeAllFromMaterial()
 // mods.erebus.composter.removeAllFromRegistry()
 // mods.erebus.composter.removeAllFromBlacklist()
 
-mods.erebus.composter.addMaterial(blockmaterial('tnt'))
+mods.erebus.composter.addMaterial(blockMaterial('tnt'))
 mods.erebus.composter.addRegistry(item('minecraft:gold_ingot'))
 mods.erebus.composter.addBlacklist(item('erebus:wall_plants', 7))
 mods.erebus.composter.addBlacklist(item('erebus:wall_plants_cultivated', 7))

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/erebus/Composter.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/erebus/Composter.java
@@ -51,7 +51,7 @@ public class Composter extends NamedRegistry implements IScriptReloadable {
     @Override
     public void afterScriptLoad() {}
 
-    @MethodDescription(type = MethodDescription.Type.ADDITION, example = @Example("blockmaterial('tnt')"))
+    @MethodDescription(type = MethodDescription.Type.ADDITION, example = @Example("blockMaterial('tnt')"))
     public boolean addMaterial(Material material) {
         return getMaterial().add(material) && materialStorage.addScripted(material);
     }
@@ -69,7 +69,7 @@ public class Composter extends NamedRegistry implements IScriptReloadable {
         return getBlacklist().add(stack) && blacklistStorage.addScripted(stack);
     }
 
-    @MethodDescription(example = @Example("blockmaterial('sponge')"))
+    @MethodDescription(example = @Example("blockMaterial('sponge')"))
     public boolean removeFromMaterial(Material material) {
         return getMaterial().removeIf(r -> material == r && materialStorage.addBackup(r));
     }

--- a/src/main/java/com/cleanroommc/groovyscript/mapper/ObjectMapperManager.java
+++ b/src/main/java/com/cleanroommc/groovyscript/mapper/ObjectMapperManager.java
@@ -128,7 +128,7 @@ public class ObjectMapperManager {
                 .toGroovyCode(x -> GroovyScriptCodeConverter.asGroovyCode(x, false))
                 .textureBinder(TextureBinder.of(ItemStack::new, TextureBinder.ofItem()))
                 .register();
-        ObjectMapper.builder("blockmaterial", Material.class)
+        ObjectMapper.builder("blockMaterial", Material.class)
                 .parser(IObjectParser.wrapStringGetter(ObjectParserHelper.materials::get))
                 .completerOfNames(ObjectParserHelper.materials::keySet)
                 .docOfType("block material")


### PR DESCRIPTION
changes in this PR:
- change the object mapper for `Material` from `blockmaterial` to `blockMaterial`.
- apply this change to examples for erebus.
- this capitalization was already the case for vanilla examples and for the Object Mapper Inverter code.

related to #357, #342, and #316