### PR TITLE
Fix Biome Parser

### DIFF
--- a/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/command/infoparser/InfoParserBiome.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/command/infoparser/InfoParserBiome.java
@@ -26,7 +26,8 @@ public class InfoParserBiome extends GenericInfoParser<Biome> {
 
     @Override
     public void parse(InfoParserPackage info) {
-        if (info.getPos() == null || info.getEntity() == null) return;
-        instance.add(info.getMessages(), info.getEntity().getEntityWorld().getBiome(info.getPos()), info.isPrettyNbt());
+        var position = info.getEntity() == null ? info.getPos() : info.getEntity().getPosition();
+        if (position == null) return;
+        instance.add(info.getMessages(), info.getPlayer().getEntityWorld().getBiome(position), info.isPrettyNbt());
     }
 }


### PR DESCRIPTION
changes in this PR:
- make the biome parser actually work - previously, it required both `pos` and `entity` to be nonnull, and those are mutally exclusive. now it prefers the entity position and falls back to `pos` when `entity` is null.