### PR TITLE
Refactor JEI description, add support for fluids

### DIFF
--- a/examples/postInit/generated/jei_generated.groovy
+++ b/examples/postInit/generated/jei_generated.groovy
@@ -37,9 +37,9 @@ mods.jei.category.hideCategory('minecraft.fuel')
 // mods.jei.description.remove(fluid('water'))
 // mods.jei.description.remove(item('thaumcraft:triple_meat_treat'))
 
-mods.jei.description.add(fluid('water'), 'groovyscript.recipe.fluid_recipe')
-mods.jei.description.add(item('minecraft:gold_ingot'), 'groovyscript.recipe.fluid_recipe')
-mods.jei.description.add(fluid('lava'), ['very', 'hot', 'fluid'])
+mods.jei.description.add(fluid('water') * 1000, 'groovyscript.recipe.fluid_recipe')
+mods.jei.description.add(item('minecraft:gold_ingot') | item('minecraft:iron_block'), 'groovyscript.recipe.fluid_recipe')
+mods.jei.description.add(fluid('lava') * 500, ['very', 'hot', 'fluid'])
 mods.jei.description.add(item('minecraft:clay'), ['wow', 'this', 'is', 'neat'])
 
 // Ingredient Sidebar:

--- a/examples/postInit/generated/jei_generated.groovy
+++ b/examples/postInit/generated/jei_generated.groovy
@@ -34,9 +34,12 @@ mods.jei.category.hideCategory('minecraft.fuel')
 // Description Category:
 // Modify the description of the input items, where the description is a unique JEI tab containing text.
 
+// mods.jei.description.remove(fluid('water'))
 // mods.jei.description.remove(item('thaumcraft:triple_meat_treat'))
 
+mods.jei.description.add(fluid('water'), 'groovyscript.recipe.fluid_recipe')
 mods.jei.description.add(item('minecraft:gold_ingot'), 'groovyscript.recipe.fluid_recipe')
+mods.jei.description.add(fluid('lava'), ['very', 'hot', 'fluid'])
 mods.jei.description.add(item('minecraft:clay'), ['wow', 'this', 'is', 'neat'])
 
 // Ingredient Sidebar:

--- a/examples/postInit/generated/jei_generated.groovy
+++ b/examples/postInit/generated/jei_generated.groovy
@@ -34,12 +34,11 @@ mods.jei.category.hideCategory('minecraft.fuel')
 // Description Category:
 // Modify the description of the input items, where the description is a unique JEI tab containing text.
 
-// mods.jei.description.remove(fluid('water'))
 // mods.jei.description.remove(item('thaumcraft:triple_meat_treat'))
 
-mods.jei.description.add(fluid('water') * 1000, 'groovyscript.recipe.fluid_recipe')
-mods.jei.description.add(item('minecraft:gold_ingot') | item('minecraft:iron_block'), 'groovyscript.recipe.fluid_recipe')
-mods.jei.description.add(fluid('lava') * 500, ['very', 'hot', 'fluid'])
+mods.jei.description.add(fluid('lava') * 500, 'some moderately cold fluid')
+mods.jei.description.add(item('minecraft:gold_ingot'), 'groovyscript.recipe.fluid_recipe')
+mods.jei.description.add([item('minecraft:diamond'), item('minecraft:emerald')], 'groovyscript.recipe.fluid_recipe')
 mods.jei.description.add(item('minecraft:clay'), ['wow', 'this', 'is', 'neat'])
 
 // Ingredient Sidebar:

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/Description.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/Description.java
@@ -2,7 +2,6 @@ package com.cleanroommc.groovyscript.compat.mods.jei;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -16,69 +15,72 @@ import com.cleanroommc.groovyscript.api.documentation.annotations.Example;
 import com.cleanroommc.groovyscript.api.documentation.annotations.MethodDescription;
 import com.cleanroommc.groovyscript.api.documentation.annotations.RegistryDescription;
 import com.cleanroommc.groovyscript.core.mixin.jei.IngredientInfoRecipeAccessor;
-import com.cleanroommc.groovyscript.helper.ingredient.ItemsIngredient;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
 
 import mezz.jei.api.IModRegistry;
 import mezz.jei.api.IRecipeRegistry;
-import mezz.jei.api.ingredients.VanillaTypes;
+import mezz.jei.api.ingredients.IIngredientHelper;
+import mezz.jei.api.ingredients.IIngredientRegistry;
 import mezz.jei.api.recipe.IIngredientType;
 import mezz.jei.api.recipe.VanillaRecipeCategoryUid;
 import mezz.jei.plugins.jei.info.IngredientInfoRecipeCategory;
-import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
 @RegistryDescription(category = RegistryDescription.Category.ENTRIES)
-public class Description extends VirtualizedRegistry<Description.DescriptionEntry<?>> {
+public class Description extends VirtualizedRegistry<Description.DescriptionEntry> {
 
-    static class DescriptionEntry<T> {
-        T representative;
-        List<T> ingredients;
-        IIngredientType<T> ingredientType;
+    public static class DescriptionEntry {
+        List<Object> ingredients;
         String[] descriptionKeys;
 
-        DescriptionEntry(@Nonnull List<T> ingredients, @Nonnull IIngredientType<T> ingredientType, @Nullable List<String> descriptionKeys) {
+        @SuppressWarnings("unchecked")
+        DescriptionEntry(@Nonnull List<?> ingredients, @Nullable List<String> descriptionKeys) {
             if (ingredients.isEmpty()) {
                 throw new IllegalArgumentException("JEI Description Entries must not have an empty list of ingredients, got " + ingredients);
             }
-            Objects.requireNonNull(ingredientType);
 
-            this.ingredients = ingredients;
-            this.ingredientType = ingredientType;
-            this.representative = this.ingredients.get(0);
-            Objects.requireNonNull(representative);
+            // This cast is not exactly correct, but Java/JVM allows it due to type erasure
+            this.ingredients = (List<Object>) ingredients;
 
             this.descriptionKeys = descriptionKeys == null ? new String[0] : descriptionKeys.toArray(new String[0]);
         }
+
+        @Nullable
+        IIngredientType<Object> validateIngredientType(IModRegistry modRegistry) {
+            Object first = ingredients.get(0);
+            IIngredientType<Object> ingredientType = modRegistry.getIngredientRegistry().getIngredientType(first);
+            if (ingredientType == null) {
+                return null;
+            }
+            for (Object o : ingredients) {
+                if (!ingredientType.equals(modRegistry.getIngredientRegistry().getIngredientType(o))) {
+                    return null;
+                }
+            }
+            return ingredientType;
+        }
+    }
+
+    private <T> void addIngredientInfo(IModRegistry modRegistry, List<T> ingredients, IIngredientType<T> ingredientType, String[] description) {
+        // Force Java to pick the correct overload we use
+        // This is needed because the method has overloads in a way T = Object cannot be substituted
+        modRegistry.addIngredientInfo(ingredients, ingredientType, description);
     }
 
     /**
      * Called by {@link JeiPlugin#register}
      */
-    @SuppressWarnings("unchecked")
     @GroovyBlacklist
     public void applyAdditions(IModRegistry modRegistry) {
-        for (DescriptionEntry<?> entry : this.getScriptedRecipes()) {
-            if (entry.representative instanceof ItemStack) {
-                modRegistry.addIngredientInfo((List<ItemStack>) entry.ingredients, (IIngredientType<ItemStack>) entry.ingredientType, entry.descriptionKeys);
-            } else if (entry.representative instanceof FluidStack) {
-                modRegistry.addIngredientInfo((List<FluidStack>) entry.ingredients, (IIngredientType<FluidStack>) entry.ingredientType, entry.descriptionKeys);
+        for (DescriptionEntry entry : this.getScriptedRecipes()) {
+            IIngredientType<Object> ingredientType = entry.validateIngredientType(modRegistry);
+            if (ingredientType != null) {
+                addIngredientInfo(modRegistry, entry.ingredients, ingredientType, entry.descriptionKeys);
             } else {
-                GroovyLog.msg("Got a Description Entry of an invalid type, this is probably a bug in Groovyscript").error().post();
+                GroovyLog.msg("Unable to obtain an ingredient type for items {}", entry.ingredients.toArray())
+                    .error()
+                    .post();
             }
-        }
-    }
-
-    private boolean compareObjects(Object inEntry, Object inRegistry) {
-        if (inEntry instanceof ItemStack ieStack) {
-            return inRegistry instanceof ItemStack irStack && new ItemsIngredient(ieStack).test(irStack);
-        } else if (inEntry instanceof FluidStack ieStack) {
-            return inRegistry instanceof FluidStack irStack && ieStack.getFluid().equals(irStack.getFluid());
-        } else {
-            GroovyLog.msg("Got a Description Entry of type {} which is not supported, this is probably a bug in Groovyscript", inEntry.getClass().getName())
-                .error()
-                .post();
-            return false;
         }
     }
 
@@ -87,17 +89,20 @@ public class Description extends VirtualizedRegistry<Description.DescriptionEntr
      */
     @SuppressWarnings("unchecked")
     @GroovyBlacklist
-    public void applyRemovals(IRecipeRegistry recipeRegistry) {
+    public void applyRemovals(IModRegistry modRegistry, IRecipeRegistry recipeRegistry) {
+        IIngredientRegistry ingredientRegistry = modRegistry.getIngredientRegistry();
         IngredientInfoRecipeCategory category = (IngredientInfoRecipeCategory) recipeRegistry.getRecipeCategory(VanillaRecipeCategoryUid.INFORMATION);
         if (category != null) {
             recipeRegistry.getRecipeWrappers(category).forEach(wrapper -> {
                 IngredientInfoRecipeAccessor<?> accessor = (IngredientInfoRecipeAccessor<?>) wrapper;
 
-                for (DescriptionEntry<?> entry : this.getBackupRecipes()) {
-                    if (!entry.ingredientType.equals(accessor.getIngredientType())) continue;
+                for (DescriptionEntry entry : this.getBackupRecipes()) {
+                    IIngredientType<Object> ingredientType = entry.validateIngredientType(modRegistry);
+                    IIngredientHelper<Object> helper = ingredientRegistry.getIngredientHelper(ingredientType);
+                    if (ingredientType == null || !ingredientType.equals(accessor.getIngredientType())) continue;
                     if (entry.ingredients
                             .stream()
-                            .anyMatch(x -> accessor.getIngredients().stream().anyMatch(a -> compareObjects(x, a)))) {
+                            .anyMatch(x -> accessor.getIngredients().stream().anyMatch(a -> helper.getUniqueId(a).equals(helper.getUniqueId(x))))) {
                         // the API seems to be broken hence the cast
                         entry.descriptionKeys = ((List<String>)wrapper.getDescription()).toArray(new String[0]);
                         recipeRegistry.hideRecipe(wrapper, VanillaRecipeCategoryUid.INFORMATION);
@@ -115,9 +120,8 @@ public class Description extends VirtualizedRegistry<Description.DescriptionEntr
 
     @MethodDescription(type = MethodDescription.Type.ADDITION)
     public void add(IIngredient[] target, String... description) {
-        addScripted(new DescriptionEntry<>(
+        addScripted(new DescriptionEntry(
             Stream.of(target).flatMap(x -> Stream.of(x.getMatchingStacks())).collect(Collectors.toList()),
-            VanillaTypes.ITEM,
             Arrays.asList(description)));
     }
 
@@ -131,16 +135,39 @@ public class Description extends VirtualizedRegistry<Description.DescriptionEntr
         add(new IIngredient[]{target}, description);
     }
 
-    @MethodDescription(type = MethodDescription.Type.ADDITION, example = @Example("item('minecraft:gold_ingot'), 'groovyscript.recipe.fluid_recipe'"))
+    @MethodDescription(type = MethodDescription.Type.ADDITION, example = @Example("item('minecraft:gold_ingot') | item('minecraft:iron_block'), 'groovyscript.recipe.fluid_recipe'"))
     public void add(IIngredient target, String... description) {
         add(new IIngredient[]{target}, description);
     }
 
     @MethodDescription(type = MethodDescription.Type.ADDITION)
-    public void add(FluidStack[] target, String... description) {
-        addScripted(new DescriptionEntry<>(
+    public void add(Object[] target, String... description) {
+        addScripted(new DescriptionEntry(
             Arrays.asList(target),
-            VanillaTypes.FLUID,
+            Arrays.asList(description)));
+    }
+
+    @MethodDescription(type = MethodDescription.Type.ADDITION)
+    public void add(Object[] target, List<String> description) {
+        add(target, description.toArray(new String[0]));
+    }
+
+    @MethodDescription(type = MethodDescription.Type.ADDITION)
+    public void add(Object target, List<String> description) {
+        add(new Object[]{target}, description);
+    }
+
+    @MethodDescription(type = MethodDescription.Type.ADDITION)
+    public void add(Object target, String... description) {
+        add(new Object[]{target}, description);
+    }
+
+    // This overload set is the same as Object one. It exists because FluidStack implements IIngredient, but does not have any matching stacks,
+    // which causes a JEI startup crash when trying to add that description
+    @MethodDescription(type = MethodDescription.Type.ADDITION)
+    public void add(FluidStack[] target, String... description) {
+        addScripted(new DescriptionEntry(
+            Arrays.asList(target),
             Arrays.asList(description)));
     }
 
@@ -161,11 +188,11 @@ public class Description extends VirtualizedRegistry<Description.DescriptionEntr
 
     @MethodDescription(example = @Example(value = "item('thaumcraft:triple_meat_treat')", commented = true))
     public void remove(IIngredient target) {
-        addBackup(new DescriptionEntry<>(Arrays.asList(target.getMatchingStacks()), VanillaTypes.ITEM, null));
+        addBackup(new DescriptionEntry(Arrays.asList(target.getMatchingStacks()), null));
     }
 
     @MethodDescription(example = @Example(value = "fluid('water')", commented = true))
-    public void remove(FluidStack target) {
-        addBackup(new DescriptionEntry<>(Arrays.asList(target), VanillaTypes.FLUID, null));
+    public void remove(Object target) {
+        addBackup(new DescriptionEntry(Arrays.asList(target), null));
     }
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/Description.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/Description.java
@@ -1,5 +1,6 @@
 package com.cleanroommc.groovyscript.compat.mods.jei;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -118,81 +119,51 @@ public class Description extends VirtualizedRegistry<Description.DescriptionEntr
         removeScripted();
     }
 
-    @MethodDescription(type = MethodDescription.Type.ADDITION)
-    public void add(IIngredient[] target, String... description) {
-        addScripted(new DescriptionEntry(
-            Stream.of(target).flatMap(x -> Stream.of(x.getMatchingStacks())).collect(Collectors.toList()),
-            Arrays.asList(description)));
+    private @Nullable List<Object> toStacks(List<Object> target) {
+        if (target == null || target.isEmpty()) {
+            GroovyLog.msg("The ingredient list cannot be empty")
+                .error()
+                .post();
+            return null;
+        }
+
+        return target.stream()
+            .<Object> flatMap(x ->
+                x instanceof IIngredient && !(x instanceof FluidStack)
+                ? Stream.of(((IIngredient)x).getMatchingStacks()) : Stream.of(x))
+            .collect(Collectors.toList());
     }
 
     @MethodDescription(type = MethodDescription.Type.ADDITION)
-    public void add(IIngredient[] target, List<String> description) {
+    public void add(List<Object> target, String... description) {
+        target = toStacks(target);
+        if (target != null) {
+            addScripted(new DescriptionEntry(target, Arrays.asList(description)));
+        }
+    }
+
+    @MethodDescription(type = MethodDescription.Type.ADDITION)
+    public void add(List<Object> target, List<String> description) {
         add(target, description.toArray(new String[0]));
     }
 
     @MethodDescription(type = MethodDescription.Type.ADDITION, example = @Example("item('minecraft:clay'), ['wow', 'this', 'is', 'neat']"))
-    public void add(IIngredient target, List<String> description) {
-        add(new IIngredient[]{target}, description);
+    public void add(Object target, List<String> description) {
+        List<Object> objects = new ArrayList<>();
+        objects.add(target);
+        add(objects, description);
     }
 
     @MethodDescription(type = MethodDescription.Type.ADDITION, example = @Example("item('minecraft:gold_ingot') | item('minecraft:iron_block'), 'groovyscript.recipe.fluid_recipe'"))
-    public void add(IIngredient target, String... description) {
-        add(new IIngredient[]{target}, description);
-    }
-
-    @MethodDescription(type = MethodDescription.Type.ADDITION)
-    public void add(Object[] target, String... description) {
-        addScripted(new DescriptionEntry(
-            Arrays.asList(target),
-            Arrays.asList(description)));
-    }
-
-    @MethodDescription(type = MethodDescription.Type.ADDITION)
-    public void add(Object[] target, List<String> description) {
-        add(target, description.toArray(new String[0]));
-    }
-
-    @MethodDescription(type = MethodDescription.Type.ADDITION)
-    public void add(Object target, List<String> description) {
-        add(new Object[]{target}, description);
-    }
-
-    @MethodDescription(type = MethodDescription.Type.ADDITION)
     public void add(Object target, String... description) {
-        add(new Object[]{target}, description);
-    }
-
-    // This overload set is the same as Object one. It exists because FluidStack implements IIngredient, but does not have any matching stacks,
-    // which causes a JEI startup crash when trying to add that description
-    @MethodDescription(type = MethodDescription.Type.ADDITION)
-    public void add(FluidStack[] target, String... description) {
-        addScripted(new DescriptionEntry(
-            Arrays.asList(target),
-            Arrays.asList(description)));
-    }
-
-    @MethodDescription(type = MethodDescription.Type.ADDITION)
-    public void add(FluidStack[] target, List<String> description) {
-        add(target, description.toArray(new String[0]));
-    }
-
-    @MethodDescription(type = MethodDescription.Type.ADDITION, example = @Example("fluid('lava') * 500, ['very', 'hot', 'fluid']"))
-    public void add(FluidStack target, List<String> description) {
-        add(new FluidStack[]{target}, description);
-    }
-
-    @MethodDescription(type = MethodDescription.Type.ADDITION, example = @Example("fluid('water') * 1000, 'groovyscript.recipe.fluid_recipe'"))
-    public void add(FluidStack target, String... description) {
-        add(new FluidStack[]{target}, description);
+        List<Object> objects = new ArrayList<>();
+        objects.add(target);
+        add(objects, description);
     }
 
     @MethodDescription(example = @Example(value = "item('thaumcraft:triple_meat_treat')", commented = true))
-    public void remove(IIngredient target) {
-        addBackup(new DescriptionEntry(Arrays.asList(target.getMatchingStacks()), null));
-    }
-
-    @MethodDescription(example = @Example(value = "fluid('water')", commented = true))
     public void remove(Object target) {
-        addBackup(new DescriptionEntry(Arrays.asList(target), null));
+        List<Object> targets = toStacks(Arrays.asList(target));
+        addBackup(new DescriptionEntry(targets, null));
     }
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/Description.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/Description.java
@@ -59,7 +59,6 @@ public class Description extends VirtualizedRegistry<Description.DescriptionEntr
     @GroovyBlacklist
     public void applyAdditions(IModRegistry modRegistry) {
         for (DescriptionEntry<?> entry : this.getScriptedRecipes()) {
-            System.out.println("adding entry: " + entry);
             if (entry.representative instanceof ItemStack) {
                 modRegistry.addIngredientInfo((List<ItemStack>) entry.ingredients, (IIngredientType<ItemStack>) entry.ingredientType, entry.descriptionKeys);
             } else if (entry.representative instanceof FluidStack) {
@@ -95,7 +94,6 @@ public class Description extends VirtualizedRegistry<Description.DescriptionEntr
                 IngredientInfoRecipeAccessor<?> accessor = (IngredientInfoRecipeAccessor<?>) wrapper;
 
                 for (DescriptionEntry<?> entry : this.getBackupRecipes()) {
-                    System.out.println("removing entry: " + entry);
                     if (!entry.ingredientType.equals(accessor.getIngredientType())) continue;
                     if (entry.ingredients
                             .stream()

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/Description.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/Description.java
@@ -44,17 +44,22 @@ public class Description extends VirtualizedRegistry<Description.DescriptionEntr
 
         @Nullable
         IIngredientType<Object> validateIngredientType(IModRegistry modRegistry) {
-            Object first = ingredients.get(0);
-            IIngredientType<Object> ingredientType = modRegistry.getIngredientRegistry().getIngredientType(first);
-            if (ingredientType == null) {
-                return null;
-            }
-            for (Object o : ingredients) {
-                if (!ingredientType.equals(modRegistry.getIngredientRegistry().getIngredientType(o))) {
+            try {
+                Object first = ingredients.get(0);
+                IIngredientType<Object> ingredientType = modRegistry.getIngredientRegistry().getIngredientType(first);
+                if (ingredientType == null) {
                     return null;
                 }
+                for (Object o : ingredients) {
+                    if (!ingredientType.equals(modRegistry.getIngredientRegistry().getIngredientType(o))) {
+                        return null;
+                    }
+                }
+                return ingredientType;
+            } catch (IllegalArgumentException e) {
+                // unchecked exception thrown when there's an unknown ingredient class
+                return null;
             }
-            return ingredientType;
         }
     }
 
@@ -74,7 +79,7 @@ public class Description extends VirtualizedRegistry<Description.DescriptionEntr
             if (ingredientType != null) {
                 addIngredientInfo(modRegistry, entry.ingredients, ingredientType, entry.descriptionKeys);
             } else {
-                GroovyLog.msg("Unable to obtain an ingredient type for items {}", entry.ingredients.toArray())
+                GroovyLog.msg("Unable to obtain an ingredient type for the ingredients [{}]", entry.ingredients.toArray())
                     .error()
                     .post();
             }
@@ -115,7 +120,7 @@ public class Description extends VirtualizedRegistry<Description.DescriptionEntr
         removeScripted();
     }
 
-    @MethodDescription(type = MethodDescription.Type.ADDITION)
+    @MethodDescription(type = MethodDescription.Type.ADDITION, example = @Example("[item('minecraft:diamond'), item('minecraft:emerald')], 'groovyscript.recipe.fluid_recipe'"))
     public void add(List<Object> target, String... description) {
         if (target != null) {
             addScripted(new DescriptionEntry(target, Arrays.asList(description)));
@@ -134,7 +139,7 @@ public class Description extends VirtualizedRegistry<Description.DescriptionEntr
         add(objects, description);
     }
 
-    @MethodDescription(type = MethodDescription.Type.ADDITION, example = @Example("item('minecraft:gold_ingot') | item('minecraft:iron_block'), 'groovyscript.recipe.fluid_recipe'"))
+    @MethodDescription(type = MethodDescription.Type.ADDITION, example = {@Example("item('minecraft:gold_ingot'), 'groovyscript.recipe.fluid_recipe'"), @Example("fluid('lava') * 500, 'some moderately cold fluid'")})
     public void add(Object target, String... description) {
         List<Object> objects = new ArrayList<>();
         objects.add(target);

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/Description.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/Description.java
@@ -1,46 +1,92 @@
 package com.cleanroommc.groovyscript.compat.mods.jei;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import com.cleanroommc.groovyscript.api.GroovyBlacklist;
+import com.cleanroommc.groovyscript.api.GroovyLog;
 import com.cleanroommc.groovyscript.api.IIngredient;
 import com.cleanroommc.groovyscript.api.documentation.annotations.Example;
 import com.cleanroommc.groovyscript.api.documentation.annotations.MethodDescription;
 import com.cleanroommc.groovyscript.api.documentation.annotations.RegistryDescription;
 import com.cleanroommc.groovyscript.core.mixin.jei.IngredientInfoRecipeAccessor;
+import com.cleanroommc.groovyscript.helper.ingredient.ItemsIngredient;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+
 import mezz.jei.api.IModRegistry;
 import mezz.jei.api.IRecipeRegistry;
 import mezz.jei.api.ingredients.VanillaTypes;
+import mezz.jei.api.recipe.IIngredientType;
 import mezz.jei.api.recipe.VanillaRecipeCategoryUid;
 import mezz.jei.plugins.jei.info.IngredientInfoRecipeCategory;
 import net.minecraft.item.ItemStack;
-import org.apache.commons.lang3.tuple.Pair;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import net.minecraftforge.fluids.FluidStack;
 
 @RegistryDescription(category = RegistryDescription.Category.ENTRIES)
-public class Description extends VirtualizedRegistry<Pair<List<IIngredient>, List<String>>> {
+public class Description extends VirtualizedRegistry<Description.DescriptionEntry<?>> {
+
+    static class DescriptionEntry<T> {
+        T representative;
+        List<T> ingredients;
+        IIngredientType<T> ingredientType;
+        String[] descriptionKeys;
+
+        DescriptionEntry(@Nonnull List<T> ingredients, @Nonnull IIngredientType<T> ingredientType, @Nullable List<String> descriptionKeys) {
+            if (ingredients.isEmpty()) {
+                throw new IllegalArgumentException("JEI Description Entries must not have an empty list of ingredients, got " + ingredients);
+            }
+            Objects.requireNonNull(ingredientType);
+
+            this.ingredients = ingredients;
+            this.ingredientType = ingredientType;
+            this.representative = this.ingredients.get(0);
+            Objects.requireNonNull(representative);
+
+            this.descriptionKeys = descriptionKeys == null ? new String[0] : descriptionKeys.toArray(new String[0]);
+        }
+    }
 
     /**
      * Called by {@link JeiPlugin#register}
      */
+    @SuppressWarnings("unchecked")
     @GroovyBlacklist
     public void applyAdditions(IModRegistry modRegistry) {
-        for (Pair<List<IIngredient>, List<String>> entry : this.getScriptedRecipes()) {
-            modRegistry.addIngredientInfo(
-                    entry.getLeft().stream().flatMap(x -> Stream.of(x.getMatchingStacks())).collect(Collectors.toList()),
-                    // Currently, it is only possible to add VanillaTypes.ITEM. It may be desirable to add the ability to do other types.
-                    VanillaTypes.ITEM,
-                    entry.getRight().toArray(new String[0]));
+        for (DescriptionEntry<?> entry : this.getScriptedRecipes()) {
+            System.out.println("adding entry: " + entry);
+            if (entry.representative instanceof ItemStack) {
+                modRegistry.addIngredientInfo((List<ItemStack>) entry.ingredients, (IIngredientType<ItemStack>) entry.ingredientType, entry.descriptionKeys);
+            } else if (entry.representative instanceof FluidStack) {
+                modRegistry.addIngredientInfo((List<FluidStack>) entry.ingredients, (IIngredientType<FluidStack>) entry.ingredientType, entry.descriptionKeys);
+            } else {
+                GroovyLog.msg("Got a Description Entry of an invalid type, this is probably a bug in Groovyscript").error().post();
+            }
+        }
+    }
+
+    private boolean compareObjects(Object inEntry, Object inRegistry) {
+        if (inEntry instanceof ItemStack ieStack) {
+            return inRegistry instanceof ItemStack irStack && new ItemsIngredient(ieStack).test(irStack);
+        } else if (inEntry instanceof FluidStack ieStack) {
+            return inRegistry instanceof FluidStack irStack && ieStack.getFluid().equals(irStack.getFluid());
+        } else {
+            GroovyLog.msg("Got a Description Entry of type {} which is not supported, this is probably a bug in Groovyscript", inEntry.getClass().getName())
+                .error()
+                .post();
+            return false;
         }
     }
 
     /**
      * Called by {@link JeiPlugin#afterRuntimeAvailable()}
      */
+    @SuppressWarnings("unchecked")
     @GroovyBlacklist
     public void applyRemovals(IRecipeRegistry recipeRegistry) {
         IngredientInfoRecipeCategory category = (IngredientInfoRecipeCategory) recipeRegistry.getRecipeCategory(VanillaRecipeCategoryUid.INFORMATION);
@@ -48,13 +94,14 @@ public class Description extends VirtualizedRegistry<Pair<List<IIngredient>, Lis
             recipeRegistry.getRecipeWrappers(category).forEach(wrapper -> {
                 IngredientInfoRecipeAccessor<?> accessor = (IngredientInfoRecipeAccessor<?>) wrapper;
 
-                // Currently, it is only possible to remove VanillaTypes.ITEM. It may be desirable to add the ability to do other types.
-                if (!VanillaTypes.ITEM.equals(accessor.getIngredientType())) return;
-
-                for (Pair<List<IIngredient>, List<String>> entry : this.getBackupRecipes()) {
-                    if (entry.getKey()
+                for (DescriptionEntry<?> entry : this.getBackupRecipes()) {
+                    System.out.println("removing entry: " + entry);
+                    if (!entry.ingredientType.equals(accessor.getIngredientType())) continue;
+                    if (entry.ingredients
                             .stream()
-                            .anyMatch(x -> accessor.getIngredients().stream().anyMatch(a -> a instanceof ItemStack itemStack && x.test(itemStack)))) {
+                            .anyMatch(x -> accessor.getIngredients().stream().anyMatch(a -> compareObjects(x, a)))) {
+                        // the API seems to be broken hence the cast
+                        entry.descriptionKeys = ((List<String>)wrapper.getDescription()).toArray(new String[0]);
                         recipeRegistry.hideRecipe(wrapper, VanillaRecipeCategoryUid.INFORMATION);
                     }
                 }
@@ -69,32 +116,58 @@ public class Description extends VirtualizedRegistry<Pair<List<IIngredient>, Lis
     }
 
     @MethodDescription(type = MethodDescription.Type.ADDITION)
-    public void add(List<IIngredient> target, List<String> description) {
-        addScripted(Pair.of(target, description));
+    public void add(IIngredient[] target, String... description) {
+        addScripted(new DescriptionEntry<>(
+            Stream.of(target).flatMap(x -> Stream.of(x.getMatchingStacks())).collect(Collectors.toList()),
+            VanillaTypes.ITEM,
+            Arrays.asList(description)));
     }
 
     @MethodDescription(type = MethodDescription.Type.ADDITION)
-    public void add(List<IIngredient> target, String... description) {
-        addScripted(Pair.of(target, Arrays.asList(description)));
+    public void add(IIngredient[] target, List<String> description) {
+        add(target, description.toArray(new String[0]));
     }
 
     @MethodDescription(type = MethodDescription.Type.ADDITION, example = @Example("item('minecraft:clay'), ['wow', 'this', 'is', 'neat']"))
     public void add(IIngredient target, List<String> description) {
-        addScripted(Pair.of(Collections.singletonList(target), description));
+        add(new IIngredient[]{target}, description);
     }
 
     @MethodDescription(type = MethodDescription.Type.ADDITION, example = @Example("item('minecraft:gold_ingot'), 'groovyscript.recipe.fluid_recipe'"))
     public void add(IIngredient target, String... description) {
-        addScripted(Pair.of(Collections.singletonList(target), Arrays.asList(description)));
+        add(new IIngredient[]{target}, description);
+    }
+
+    @MethodDescription(type = MethodDescription.Type.ADDITION)
+    public void add(FluidStack[] target, String... description) {
+        addScripted(new DescriptionEntry<>(
+            Arrays.asList(target),
+            VanillaTypes.FLUID,
+            Arrays.asList(description)));
+    }
+
+    @MethodDescription(type = MethodDescription.Type.ADDITION)
+    public void add(FluidStack[] target, List<String> description) {
+        add(target, description.toArray(new String[0]));
+    }
+
+    @MethodDescription(type = MethodDescription.Type.ADDITION, example = @Example("fluid('lava') * 500, ['very', 'hot', 'fluid']"))
+    public void add(FluidStack target, List<String> description) {
+        add(new FluidStack[]{target}, description);
+    }
+
+    @MethodDescription(type = MethodDescription.Type.ADDITION, example = @Example("fluid('water') * 1000, 'groovyscript.recipe.fluid_recipe'"))
+    public void add(FluidStack target, String... description) {
+        add(new FluidStack[]{target}, description);
     }
 
     @MethodDescription(example = @Example(value = "item('thaumcraft:triple_meat_treat')", commented = true))
-    public void remove(List<IIngredient> target) {
-        addBackup(Pair.of(target, null));
+    public void remove(IIngredient target) {
+        addBackup(new DescriptionEntry<>(Arrays.asList(target.getMatchingStacks()), VanillaTypes.ITEM, null));
     }
 
-    @MethodDescription
-    public void remove(IIngredient... target) {
-        addBackup(Pair.of(Arrays.asList(target), null));
+    @MethodDescription(example = @Example(value = "fluid('water')", commented = true))
+    public void remove(FluidStack target) {
+        addBackup(new DescriptionEntry<>(Arrays.asList(target), VanillaTypes.FLUID, null));
     }
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/Description.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/Description.java
@@ -3,15 +3,12 @@ package com.cleanroommc.groovyscript.compat.mods.jei;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import com.cleanroommc.groovyscript.api.GroovyBlacklist;
 import com.cleanroommc.groovyscript.api.GroovyLog;
-import com.cleanroommc.groovyscript.api.IIngredient;
 import com.cleanroommc.groovyscript.api.documentation.annotations.Example;
 import com.cleanroommc.groovyscript.api.documentation.annotations.MethodDescription;
 import com.cleanroommc.groovyscript.api.documentation.annotations.RegistryDescription;
@@ -25,7 +22,6 @@ import mezz.jei.api.ingredients.IIngredientRegistry;
 import mezz.jei.api.recipe.IIngredientType;
 import mezz.jei.api.recipe.VanillaRecipeCategoryUid;
 import mezz.jei.plugins.jei.info.IngredientInfoRecipeCategory;
-import net.minecraftforge.fluids.FluidStack;
 
 @RegistryDescription(category = RegistryDescription.Category.ENTRIES)
 public class Description extends VirtualizedRegistry<Description.DescriptionEntry> {
@@ -119,24 +115,8 @@ public class Description extends VirtualizedRegistry<Description.DescriptionEntr
         removeScripted();
     }
 
-    private @Nullable List<Object> toStacks(List<Object> target) {
-        if (target == null || target.isEmpty()) {
-            GroovyLog.msg("The ingredient list cannot be empty")
-                .error()
-                .post();
-            return null;
-        }
-
-        return target.stream()
-            .<Object> flatMap(x ->
-                x instanceof IIngredient && !(x instanceof FluidStack)
-                ? Stream.of(((IIngredient)x).getMatchingStacks()) : Stream.of(x))
-            .collect(Collectors.toList());
-    }
-
     @MethodDescription(type = MethodDescription.Type.ADDITION)
     public void add(List<Object> target, String... description) {
-        target = toStacks(target);
         if (target != null) {
             addScripted(new DescriptionEntry(target, Arrays.asList(description)));
         }
@@ -163,7 +143,6 @@ public class Description extends VirtualizedRegistry<Description.DescriptionEntr
 
     @MethodDescription(example = @Example(value = "item('thaumcraft:triple_meat_treat')", commented = true))
     public void remove(Object target) {
-        List<Object> targets = toStacks(Arrays.asList(target));
-        addBackup(new DescriptionEntry(targets, null));
+        addBackup(new DescriptionEntry(Arrays.asList(target), null));
     }
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/JeiPlugin.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/jei/JeiPlugin.java
@@ -1,5 +1,9 @@
 package com.cleanroommc.groovyscript.compat.mods.jei;
 
+import java.util.Comparator;
+
+import org.jetbrains.annotations.NotNull;
+
 import com.cleanroommc.groovyscript.api.GroovyBlacklist;
 import com.cleanroommc.groovyscript.api.GroovyLog;
 import com.cleanroommc.groovyscript.command.GSCommand;
@@ -8,8 +12,14 @@ import com.cleanroommc.groovyscript.compat.inworldcrafting.jei.InWorldCraftingJe
 import com.cleanroommc.groovyscript.compat.mods.ModSupport;
 import com.cleanroommc.groovyscript.compat.vanilla.ShapedCraftingRecipe;
 import com.cleanroommc.groovyscript.compat.vanilla.ShapelessCraftingRecipe;
+
 import mezz.jei.Internal;
-import mezz.jei.api.*;
+import mezz.jei.api.IJeiHelpers;
+import mezz.jei.api.IJeiRuntime;
+import mezz.jei.api.IModPlugin;
+import mezz.jei.api.IModRegistry;
+import mezz.jei.api.IRecipeRegistry;
+import mezz.jei.api.JEIPlugin;
 import mezz.jei.api.ingredients.IIngredientHelper;
 import mezz.jei.api.ingredients.IIngredientRegistry;
 import mezz.jei.api.ingredients.IIngredientRenderer;
@@ -22,9 +32,6 @@ import mezz.jei.plugins.vanilla.crafting.ShapelessRecipeWrapper;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.text.TextComponentString;
 import net.minecraftforge.fluids.FluidStack;
-import org.jetbrains.annotations.NotNull;
-
-import java.util.Comparator;
 
 @SuppressWarnings("AssignmentToStaticFieldFromInstanceMethod")
 @GroovyBlacklist
@@ -47,7 +54,7 @@ public class JeiPlugin implements IModPlugin {
     public static void afterRuntimeAvailable() {
         ModSupport.JEI.get().ingredient.applyChanges(modRegistry.getIngredientRegistry());
         ModSupport.JEI.get().category.applyChanges(jeiRuntime.getRecipeRegistry());
-        ModSupport.JEI.get().description.applyRemovals(jeiRuntime.getRecipeRegistry());
+        ModSupport.JEI.get().description.applyRemovals(modRegistry, jeiRuntime.getRecipeRegistry());
     }
 
     /**


### PR DESCRIPTION
Allows using `fluid(...)` in `mods.jei.description`, which also fixes a startup crash when the code does that

This should support adding more types fairly easily

lmk if this is a bad approach, I was kinda very focused on keeping it a VirtualizedRegistry, and its probably not the cleanest way