### PR TITLE
Ice & Fire RLCraft support

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -89,7 +89,7 @@ final Map<String, List<String>> mod_dependencies = [
         'libnine-322344:3509087'                              : [debug_lazy_ae2],
         'libvulpes-236541:3801015'                            : [debug_advanced_rocketry],
         'lightningcraft-237422:2872478'                       : [debug_lightningcraft],
-        'llibrary-243298:2504999'                             : [debug_ice_and_fire_old, debug_ice_and_fire_rotn],
+        'llibrary-243298:2504999'                             : [debug_ice_and_fire_old, debug_ice_and_fire_rotn, debug_ice_and_fire_rlcraft],
         'magneticraft-224808:3791484'                         : [debug_magneticraft],
         'mantle-74924:2713386'                                : [debug_inspirations, debug_tinkers_construct],
         'mct-immersive-technology-359407:7752858'             : [debug_immersive_technology],
@@ -220,10 +220,13 @@ dependencies {
     // WARNING: rotn must be placed before normal, otherwise you will not be able to properly detect sources for the LightningForge
     compileOnly rfg.deobf('curse.maven:ice-and-fire-rotn-edition-457668:5738729')
     compileOnly rfg.deobf('curse.maven:iceandfire-264231:2939529')
+    compileOnly rfg.deobf('curse.maven:ice-and-fire-rlcraft-edition-888556:8350620')
     if (debug_ice_and_fire_rotn.toBoolean()) {
         runtimeOnly rfg.deobf('curse.maven:ice-and-fire-rotn-edition-457668:5738729')
     } else if (debug_ice_and_fire_old.toBoolean()) {
         runtimeOnly rfg.deobf('curse.maven:iceandfire-264231:2939529')
+    } else if (debug_ice_and_fire_rlcraft.toBoolean()) {
+        runtimeOnly rfg.deobf('curse.maven:ice-and-fire-rlcraft-edition-888556:8350620')
     }
 
     // WARNING: experimental must be placed before classic, otherwise you will crash when debugging either. Check FluidGenerator compat to confirm

--- a/gradle.properties
+++ b/gradle.properties
@@ -73,6 +73,7 @@ debug_horse_power = false
 
 debug_ice_and_fire_old = false
 debug_ice_and_fire_rotn = false
+debug_ice_and_fire_rlcraft = false
 debug_immersive_engineering = false
 debug_immersive_petroleum = false
 debug_immersive_technology = false

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/iceandfire/DragonForge.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/iceandfire/DragonForge.java
@@ -12,9 +12,11 @@ import java.util.Collection;
 
 public abstract class DragonForge extends StandardListRegistry<DragonForgeRecipe> {
 
+    private final String type;
     private final Collection<DragonForgeRecipe> recipes;
 
-    public DragonForge(Collection<DragonForgeRecipe> recipes) {
+    protected DragonForge(String type, Collection<DragonForgeRecipe> recipes) {
+        this.type = type;
         this.recipes = recipes;
     }
 
@@ -41,7 +43,7 @@ public abstract class DragonForge extends StandardListRegistry<DragonForgeRecipe
 
         @Override
         public String getErrorMsg() {
-            return "Error adding Ice And Fire Fire Forge recipe";
+            return "Error adding Ice And Fire " + DragonForge.this.type + " Forge recipe";
         }
 
         @Override

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/iceandfire/DragonForge.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/iceandfire/DragonForge.java
@@ -1,0 +1,67 @@
+package com.cleanroommc.groovyscript.compat.mods.iceandfire;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.api.documentation.annotations.*;
+import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
+import com.cleanroommc.groovyscript.registry.StandardListRegistry;
+import com.github.alexthe666.iceandfire.recipe.DragonForgeRecipe;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+
+public abstract class DragonForge extends StandardListRegistry<DragonForgeRecipe> {
+
+    private final Collection<DragonForgeRecipe> recipes;
+
+    public DragonForge(Collection<DragonForgeRecipe> recipes) {
+        this.recipes = recipes;
+    }
+
+    @Override
+    public final Collection<DragonForgeRecipe> getRecipes() {
+        return recipes;
+    }
+
+    public RecipeBuilder recipeBuilder() {
+        return new RecipeBuilder();
+    }
+
+    public boolean removeByInput(IIngredient input) {
+        return getRecipes().removeIf(r -> (input.test(r.getInput()) || input.test(r.getBlood())) && doAddBackup(r));
+    }
+
+    public boolean removeByOutput(IIngredient output) {
+        return getRecipes().removeIf(r -> output.test(r.getOutput()) && doAddBackup(r));
+    }
+
+    @Property(property = "input", comp = @Comp(eq = 2))
+    @Property(property = "output", comp = @Comp(eq = 1))
+    public final class RecipeBuilder extends AbstractRecipeBuilder<DragonForgeRecipe> {
+
+        @Override
+        public String getErrorMsg() {
+            return "Error adding Ice And Fire Fire Forge recipe";
+        }
+
+        @Override
+        public void validate(GroovyLog.Msg msg) {
+            validateItems(msg, 2, 2, 1, 1);
+            validateFluids(msg);
+        }
+
+        @Override
+        @RecipeBuilderRegistrationMethod
+        public @Nullable DragonForgeRecipe register() {
+            if (!validate()) return null;
+            DragonForgeRecipe recipe = null;
+            for (var inputStack : input.get(0).getMatchingStacks()) {
+                for (var blood : input.get(1).getMatchingStacks()) {
+                    recipe = new DragonForgeRecipe(inputStack, blood, output.get(0));
+                    DragonForge.this.add(recipe);
+                }
+            }
+            return recipe;
+        }
+    }
+}

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/iceandfire/FireForge.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/iceandfire/FireForge.java
@@ -1,38 +1,27 @@
 package com.cleanroommc.groovyscript.compat.mods.iceandfire;
 
-import com.cleanroommc.groovyscript.api.IIngredient;
 import com.cleanroommc.groovyscript.api.documentation.annotations.*;
 import com.github.alexthe666.iceandfire.recipe.DragonForgeRecipe;
 
 import java.util.Collection;
 
-@RegistryDescription
+@RegistryDescription(
+        override = @MethodOverride(method = {
+                @MethodDescription(method = "removeByOutput", example = @Example(value = "item('iceandfire:dragonsteel_fire_ingot')", commented = true)),
+                @MethodDescription(method = "removeByInput", example = {
+                        @Example("item('minecraft:iron_ingot')"),
+                        @Example(value = "item('iceandfire:fire_dragon_blood')", commented = true)
+                })
+        }, recipeBuilder = {
+                @RecipeBuilderDescription(method = "recipeBuilder", example = {
+                        @Example(".input(item('minecraft:gold_ingot'), item('minecraft:gold_ingot')).output(item('minecraft:clay'))"),
+                        @Example(".input(item('minecraft:diamond'), item('minecraft:clay')).output(item('minecraft:gold_ingot'))")
+                })}
+        )
+)
 public class FireForge extends DragonForge {
 
     public FireForge(Collection<DragonForgeRecipe> recipes) {
         super("Fire", recipes);
-    }
-
-    @RecipeBuilderDescription(example = {
-            @Example(".input(item('minecraft:gold_ingot'), item('minecraft:gold_ingot')).output(item('minecraft:clay'))"),
-            @Example(".input(item('minecraft:diamond'), item('minecraft:clay')).output(item('minecraft:gold_ingot'))")
-    })
-    @Override
-    public RecipeBuilder recipeBuilder() {
-        return super.recipeBuilder();
-    }
-
-    @MethodDescription(example = {
-            @Example("item('minecraft:iron_ingot')"), @Example(value = "item('iceandfire:fire_dragon_blood')", commented = true)
-    })
-    @Override
-    public boolean removeByInput(IIngredient input) {
-        return super.removeByInput(input);
-    }
-
-    @MethodDescription(example = @Example(value = "item('iceandfire:dragonsteel_fire_ingot')", commented = true))
-    @Override
-    public boolean removeByOutput(IIngredient output) {
-        return super.removeByOutput(output);
     }
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/iceandfire/FireForge.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/iceandfire/FireForge.java
@@ -10,7 +10,7 @@ import java.util.Collection;
 public class FireForge extends DragonForge {
 
     public FireForge(Collection<DragonForgeRecipe> recipes) {
-        super(recipes);
+        super("Fire", recipes);
     }
 
     @RecipeBuilderDescription(example = {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/iceandfire/FireForge.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/iceandfire/FireForge.java
@@ -1,72 +1,38 @@
 package com.cleanroommc.groovyscript.compat.mods.iceandfire;
 
-import com.cleanroommc.groovyscript.api.GroovyLog;
 import com.cleanroommc.groovyscript.api.IIngredient;
 import com.cleanroommc.groovyscript.api.documentation.annotations.*;
-import com.cleanroommc.groovyscript.compat.mods.ModSupport;
-import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
-import com.cleanroommc.groovyscript.registry.StandardListRegistry;
 import com.github.alexthe666.iceandfire.recipe.DragonForgeRecipe;
-import com.github.alexthe666.iceandfire.recipe.IafRecipeRegistry;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
 
 @RegistryDescription
-public class FireForge extends StandardListRegistry<DragonForgeRecipe> {
+public class FireForge extends DragonForge {
 
-    @Override
-    public Collection<DragonForgeRecipe> getRecipes() {
-        return IafRecipeRegistry.FIRE_FORGE_RECIPES;
+    public FireForge(Collection<DragonForgeRecipe> recipes) {
+        super(recipes);
     }
 
     @RecipeBuilderDescription(example = {
             @Example(".input(item('minecraft:gold_ingot'), item('minecraft:gold_ingot')).output(item('minecraft:clay'))"),
             @Example(".input(item('minecraft:diamond'), item('minecraft:clay')).output(item('minecraft:gold_ingot'))")
     })
+    @Override
     public RecipeBuilder recipeBuilder() {
-        return new RecipeBuilder();
+        return super.recipeBuilder();
     }
 
     @MethodDescription(example = {
             @Example("item('minecraft:iron_ingot')"), @Example(value = "item('iceandfire:fire_dragon_blood')", commented = true)
     })
+    @Override
     public boolean removeByInput(IIngredient input) {
-        return getRecipes().removeIf(r -> (input.test(r.getInput()) || input.test(r.getBlood())) && doAddBackup(r));
+        return super.removeByInput(input);
     }
 
     @MethodDescription(example = @Example(value = "item('iceandfire:dragonsteel_fire_ingot')", commented = true))
+    @Override
     public boolean removeByOutput(IIngredient output) {
-        return getRecipes().removeIf(r -> output.test(r.getOutput()) && doAddBackup(r));
-    }
-
-    @Property(property = "input", comp = @Comp(eq = 2))
-    @Property(property = "output", comp = @Comp(eq = 1))
-    public static class RecipeBuilder extends AbstractRecipeBuilder<DragonForgeRecipe> {
-
-        @Override
-        public String getErrorMsg() {
-            return "Error adding Ice And Fire Fire Forge recipe";
-        }
-
-        @Override
-        public void validate(GroovyLog.Msg msg) {
-            validateItems(msg, 2, 2, 1, 1);
-            validateFluids(msg);
-        }
-
-        @Override
-        @RecipeBuilderRegistrationMethod
-        public @Nullable DragonForgeRecipe register() {
-            if (!validate()) return null;
-            DragonForgeRecipe recipe = null;
-            for (var inputStack : input.get(0).getMatchingStacks()) {
-                for (var blood : input.get(1).getMatchingStacks()) {
-                    recipe = new DragonForgeRecipe(inputStack, blood, output.get(0));
-                    ModSupport.ICE_AND_FIRE.get().fireForge.add(recipe);
-                }
-            }
-            return recipe;
-        }
+        return super.removeByOutput(output);
     }
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/iceandfire/IceAndFire.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/iceandfire/IceAndFire.java
@@ -1,22 +1,48 @@
 package com.cleanroommc.groovyscript.compat.mods.iceandfire;
 
 import com.cleanroommc.groovyscript.compat.mods.GroovyPropertyContainer;
+import com.github.alexthe666.iceandfire.item.IafDragonForgeRecipeRegistry;
+import com.github.alexthe666.iceandfire.recipe.IafRecipeRegistry;
 import net.minecraftforge.fml.common.Loader;
 
 public class IceAndFire extends GroovyPropertyContainer {
 
-    public final FireForge fireForge = new FireForge();
-    public final IceForge iceForge = new IceForge();
+    public final FireForge fireForge;
+    public final IceForge iceForge;
     public final LightningForge lightningForge;
 
     public IceAndFire() {
-        lightningForge = isRotN() ? new LightningForge() : null;
+        Version version = version();
+        fireForge = new FireForge(version == Version.RLCRAFT ? IafDragonForgeRecipeRegistry.FIRE_FORGE_RECIPES : IafRecipeRegistry.FIRE_FORGE_RECIPES);
+        iceForge = new IceForge(version == Version.RLCRAFT ? IafDragonForgeRecipeRegistry.ICE_FORGE_RECIPES : IafRecipeRegistry.ICE_FORGE_RECIPES);
+        lightningForge = switch (version) {
+            case ORIGINAL -> null;
+            case ROTN -> new LightningForge(IafRecipeRegistry.LIGHTNING_FORGE_RECIPES);
+            case RLCRAFT -> new LightningForge(IafDragonForgeRecipeRegistry.LIGHTNING_FORGE_RECIPES);
+        };
     }
 
+    private static Version version() {
+        var entry = Loader.instance().getIndexedModList().get("iceandfire");
+        if (entry == null) return Version.ORIGINAL;
+        // Name should be "Ice And Fire: RotN Edition"
+        if (entry.getName().contains("RotN")) return Version.ROTN;
+        // Ice And Fire 2.x most likely means RLCraft edition
+        else if (entry.getVersion().startsWith("2")) return Version.RLCRAFT;
+        else return Version.ORIGINAL;
+    }
+
+    @Deprecated
     public static boolean isRotN() {
         var entry = Loader.instance().getIndexedModList().get("iceandfire");
         if (entry == null) return false;
         // Name should be "Ice And Fire: RotN Edition"
         return entry.getName().contains("RotN");
+    }
+
+    enum Version {
+        ORIGINAL,
+        ROTN,
+        RLCRAFT;
     }
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/iceandfire/IceAndFire.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/iceandfire/IceAndFire.java
@@ -29,7 +29,7 @@ public class IceAndFire extends GroovyPropertyContainer {
         if (entry.getName().contains("RotN")) return Version.ROTN;
         // Ice And Fire 2.x most likely means RLCraft edition
         else if (entry.getVersion().startsWith("2")) return Version.RLCRAFT;
-        else return Version.ORIGINAL;
+        return Version.ORIGINAL;
     }
 
     @Deprecated

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/iceandfire/IceForge.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/iceandfire/IceForge.java
@@ -10,7 +10,7 @@ import java.util.Collection;
 public class IceForge extends DragonForge {
 
     public IceForge(Collection<DragonForgeRecipe> recipes) {
-        super(recipes);
+        super("Ice", recipes);
     }
 
     @RecipeBuilderDescription(example = {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/iceandfire/IceForge.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/iceandfire/IceForge.java
@@ -1,72 +1,38 @@
 package com.cleanroommc.groovyscript.compat.mods.iceandfire;
 
-import com.cleanroommc.groovyscript.api.GroovyLog;
 import com.cleanroommc.groovyscript.api.IIngredient;
 import com.cleanroommc.groovyscript.api.documentation.annotations.*;
-import com.cleanroommc.groovyscript.compat.mods.ModSupport;
-import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
-import com.cleanroommc.groovyscript.registry.StandardListRegistry;
 import com.github.alexthe666.iceandfire.recipe.DragonForgeRecipe;
-import com.github.alexthe666.iceandfire.recipe.IafRecipeRegistry;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
 
 @RegistryDescription
-public class IceForge extends StandardListRegistry<DragonForgeRecipe> {
+public class IceForge extends DragonForge {
 
-    @Override
-    public Collection<DragonForgeRecipe> getRecipes() {
-        return IafRecipeRegistry.ICE_FORGE_RECIPES;
+    public IceForge(Collection<DragonForgeRecipe> recipes) {
+        super(recipes);
     }
 
     @RecipeBuilderDescription(example = {
             @Example(".input(item('minecraft:gold_ingot'), item('minecraft:gold_ingot')).output(item('minecraft:clay'))"),
             @Example(".input(item('minecraft:diamond'), item('minecraft:gold_ingot')).output(item('minecraft:clay'))")
     })
+    @Override
     public RecipeBuilder recipeBuilder() {
-        return new RecipeBuilder();
+        return super.recipeBuilder();
     }
 
     @MethodDescription(example = {
             @Example("item('minecraft:iron_ingot')"), @Example(value = "item('iceandfire:ice_dragon_blood')", commented = true)
     })
+    @Override
     public boolean removeByInput(IIngredient input) {
-        return getRecipes().removeIf(r -> (input.test(r.getInput()) || input.test(r.getBlood())) && doAddBackup(r));
+        return super.removeByInput(input);
     }
 
     @MethodDescription(example = @Example(value = "item('iceandfire:dragonsteel_ice_ingot')", commented = true))
+    @Override
     public boolean removeByOutput(IIngredient output) {
-        return getRecipes().removeIf(r -> output.test(r.getOutput()) && doAddBackup(r));
-    }
-
-    @Property(property = "input", comp = @Comp(eq = 2))
-    @Property(property = "output", comp = @Comp(eq = 1))
-    public static class RecipeBuilder extends AbstractRecipeBuilder<DragonForgeRecipe> {
-
-        @Override
-        public String getErrorMsg() {
-            return "Error adding Ice And Fire Ice Forge recipe";
-        }
-
-        @Override
-        public void validate(GroovyLog.Msg msg) {
-            validateItems(msg, 2, 2, 1, 1);
-            validateFluids(msg);
-        }
-
-        @Override
-        @RecipeBuilderRegistrationMethod
-        public @Nullable DragonForgeRecipe register() {
-            if (!validate()) return null;
-            DragonForgeRecipe recipe = null;
-            for (var inputStack : input.get(0).getMatchingStacks()) {
-                for (var blood : input.get(1).getMatchingStacks()) {
-                    recipe = new DragonForgeRecipe(inputStack, blood, output.get(0));
-                    ModSupport.ICE_AND_FIRE.get().iceForge.add(recipe);
-                }
-            }
-            return recipe;
-        }
+        return super.removeByOutput(output);
     }
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/iceandfire/IceForge.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/iceandfire/IceForge.java
@@ -1,38 +1,27 @@
 package com.cleanroommc.groovyscript.compat.mods.iceandfire;
 
-import com.cleanroommc.groovyscript.api.IIngredient;
 import com.cleanroommc.groovyscript.api.documentation.annotations.*;
 import com.github.alexthe666.iceandfire.recipe.DragonForgeRecipe;
 
 import java.util.Collection;
 
-@RegistryDescription
+@RegistryDescription(
+        override = @MethodOverride(method = {
+                @MethodDescription(method = "removeByOutput", example = @Example(value = "item('iceandfire:dragonsteel_ice_ingot')", commented = true)),
+                @MethodDescription(method = "removeByInput", example = {
+                        @Example("item('minecraft:iron_ingot')"),
+                        @Example(value = "item('iceandfire:ice_dragon_blood')", commented = true)
+                })
+        }, recipeBuilder = {
+                @RecipeBuilderDescription(method = "recipeBuilder", example = {
+                        @Example(".input(item('minecraft:gold_ingot'), item('minecraft:gold_ingot')).output(item('minecraft:clay'))"),
+                        @Example(".input(item('minecraft:diamond'), item('minecraft:gold_ingot')).output(item('minecraft:clay'))")
+                })
+        })
+)
 public class IceForge extends DragonForge {
 
     public IceForge(Collection<DragonForgeRecipe> recipes) {
         super("Ice", recipes);
-    }
-
-    @RecipeBuilderDescription(example = {
-            @Example(".input(item('minecraft:gold_ingot'), item('minecraft:gold_ingot')).output(item('minecraft:clay'))"),
-            @Example(".input(item('minecraft:diamond'), item('minecraft:gold_ingot')).output(item('minecraft:clay'))")
-    })
-    @Override
-    public RecipeBuilder recipeBuilder() {
-        return super.recipeBuilder();
-    }
-
-    @MethodDescription(example = {
-            @Example("item('minecraft:iron_ingot')"), @Example(value = "item('iceandfire:ice_dragon_blood')", commented = true)
-    })
-    @Override
-    public boolean removeByInput(IIngredient input) {
-        return super.removeByInput(input);
-    }
-
-    @MethodDescription(example = @Example(value = "item('iceandfire:dragonsteel_ice_ingot')", commented = true))
-    @Override
-    public boolean removeByOutput(IIngredient output) {
-        return super.removeByOutput(output);
     }
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/iceandfire/LightningForge.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/iceandfire/LightningForge.java
@@ -14,60 +14,32 @@ import java.util.Collection;
 
 // want all the examples to be commented
 @RegistryDescription(admonition = @Admonition("groovyscript.wiki.iceandfire.lightning_forge.note"))
-public class LightningForge extends StandardListRegistry<DragonForgeRecipe> {
+public class LightningForge extends DragonForge {
 
-    @Override
-    public Collection<DragonForgeRecipe> getRecipes() {
-        return IafRecipeRegistry.LIGHTNING_FORGE_RECIPES;
+    public LightningForge(Collection<DragonForgeRecipe> recipes) {
+        super(recipes);
     }
 
     @RecipeBuilderDescription(example = {
             @Example(value = ".input(item('minecraft:gold_ingot'), item('minecraft:gold_ingot')).output(item('minecraft:clay'))", commented = true),
             @Example(value = ".input(item('minecraft:diamond'), item('minecraft:gold_ingot')).output(item('minecraft:clay'))", commented = true)
     })
+    @Override
     public RecipeBuilder recipeBuilder() {
-        return new RecipeBuilder();
+        return super.recipeBuilder();
     }
 
     @MethodDescription(example = {
             @Example(value = "item('minecraft:iron_ingot')", commented = true), @Example(value = "item('iceandfire:lightning_dragon_blood')", commented = true)
     })
+    @Override
     public boolean removeByInput(IIngredient input) {
-        return getRecipes().removeIf(r -> (input.test(r.getInput()) || input.test(r.getBlood())) && doAddBackup(r));
+        return super.removeByInput(input);
     }
 
     @MethodDescription(example = @Example(value = "item('iceandfire:dragonsteel_lightning_ingot')", commented = true))
+    @Override
     public boolean removeByOutput(IIngredient output) {
-        return getRecipes().removeIf(r -> output.test(r.getOutput()) && doAddBackup(r));
-    }
-
-    @Property(property = "input", comp = @Comp(eq = 2))
-    @Property(property = "output", comp = @Comp(eq = 1))
-    public static class RecipeBuilder extends AbstractRecipeBuilder<DragonForgeRecipe> {
-
-        @Override
-        public String getErrorMsg() {
-            return "Error adding Ice And Fire Lightning Forge recipe";
-        }
-
-        @Override
-        public void validate(GroovyLog.Msg msg) {
-            validateItems(msg, 2, 2, 1, 1);
-            validateFluids(msg);
-        }
-
-        @Override
-        @RecipeBuilderRegistrationMethod
-        public @Nullable DragonForgeRecipe register() {
-            if (!validate()) return null;
-            DragonForgeRecipe recipe = null;
-            for (var inputStack : input.get(0).getMatchingStacks()) {
-                for (var blood : input.get(1).getMatchingStacks()) {
-                    recipe = new DragonForgeRecipe(inputStack, blood, output.get(0));
-                    ModSupport.ICE_AND_FIRE.get().lightningForge.add(recipe);
-                }
-            }
-            return recipe;
-        }
+        return super.removeByOutput(output);
     }
 }

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/iceandfire/LightningForge.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/iceandfire/LightningForge.java
@@ -17,7 +17,7 @@ import java.util.Collection;
 public class LightningForge extends DragonForge {
 
     public LightningForge(Collection<DragonForgeRecipe> recipes) {
-        super(recipes);
+        super("Lightning", recipes);
     }
 
     @RecipeBuilderDescription(example = {

--- a/src/main/java/com/cleanroommc/groovyscript/compat/mods/iceandfire/LightningForge.java
+++ b/src/main/java/com/cleanroommc/groovyscript/compat/mods/iceandfire/LightningForge.java
@@ -1,43 +1,47 @@
 package com.cleanroommc.groovyscript.compat.mods.iceandfire;
 
-import com.cleanroommc.groovyscript.api.GroovyLog;
 import com.cleanroommc.groovyscript.api.IIngredient;
 import com.cleanroommc.groovyscript.api.documentation.annotations.*;
-import com.cleanroommc.groovyscript.compat.mods.ModSupport;
-import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
-import com.cleanroommc.groovyscript.registry.StandardListRegistry;
 import com.github.alexthe666.iceandfire.recipe.DragonForgeRecipe;
-import com.github.alexthe666.iceandfire.recipe.IafRecipeRegistry;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
 
 // want all the examples to be commented
-@RegistryDescription(admonition = @Admonition("groovyscript.wiki.iceandfire.lightning_forge.note"))
+@RegistryDescription(
+        admonition = @Admonition("groovyscript.wiki.iceandfire.lightning_forge.note"),
+        override = @MethodOverride(method = {
+                @MethodDescription(method = "removeByOutput", example = @Example(value = "item('iceandfire:dragonsteel_lightning_ingot')", commented = true)),
+                @MethodDescription(method = "removeByInput", example = {
+                        @Example(value = "item('minecraft:iron_ingot')", commented = true),
+                        @Example(value = "item('iceandfire:lightning_dragon_blood')", commented = true)
+                })
+        }, recipeBuilder = {
+                @RecipeBuilderDescription(method = "recipeBuilder", example = {
+                        @Example(value = ".input(item('minecraft:gold_ingot'), item('minecraft:gold_ingot')).output(item('minecraft:clay'))", commented = true),
+                        @Example(value = ".input(item('minecraft:diamond'), item('minecraft:gold_ingot')).output(item('minecraft:clay'))", commented = true)
+                })
+        })
+)
 public class LightningForge extends DragonForge {
 
     public LightningForge(Collection<DragonForgeRecipe> recipes) {
         super("Lightning", recipes);
     }
 
-    @RecipeBuilderDescription(example = {
-            @Example(value = ".input(item('minecraft:gold_ingot'), item('minecraft:gold_ingot')).output(item('minecraft:clay'))", commented = true),
-            @Example(value = ".input(item('minecraft:diamond'), item('minecraft:gold_ingot')).output(item('minecraft:clay'))", commented = true)
-    })
     @Override
     public RecipeBuilder recipeBuilder() {
         return super.recipeBuilder();
     }
 
     @MethodDescription(example = {
-            @Example(value = "item('minecraft:iron_ingot')", commented = true), @Example(value = "item('iceandfire:lightning_dragon_blood')", commented = true)
+
     })
     @Override
     public boolean removeByInput(IIngredient input) {
         return super.removeByInput(input);
     }
 
-    @MethodDescription(example = @Example(value = "item('iceandfire:dragonsteel_lightning_ingot')", commented = true))
+    @MethodDescription()
     @Override
     public boolean removeByOutput(IIngredient output) {
         return super.removeByOutput(output);


### PR DESCRIPTION
Rlcraft edition moves recipe lists to a different class which makes it incompatible with GroovyScript. This PR fixes it adding list parameter to constructor and getting the right field via checking for the version in mods container.